### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: "11"
@@ -25,14 +25,14 @@ jobs:
           .github/build.sh -DLLAMA_VERBOSE=ON
       - name: Download text generation model
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
-      - name: Download reranking model 
+      - name: Download reranking model
         run: curl -L ${RERANKING_MODEL_URL} --create-dirs -o models/${RERANKING_MODEL_NAME}
       - name: List files in models directory
         run: ls -l models/
       - name: Run tests
         run: mvn test
       - if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: error-log-linux
           path: ${{ github.workspace }}/hs_err_pid*.log
@@ -55,8 +55,8 @@ jobs:
             name: macos-15-metal
             cmake: -DLLAMA_METAL_EMBED_LIBRARY=ON -DLLAMA_VERBOSE=ON -DGGML_NATIVE=OFF
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: "11"
@@ -64,16 +64,16 @@ jobs:
         run: |
           mvn compile
           .github/build.sh ${{ matrix.target.cmake }}
-      - name: Download text generaton model model
+      - name: Download text generation model
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
-      - name: Download reranking model 
+      - name: Download reranking model
         run: curl -L ${RERANKING_MODEL_URL} --create-dirs -o models/${RERANKING_MODEL_NAME}
       - name: List files in models directory
         run: ls -l models/
       - name: Run tests
         run: mvn test
       - if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: error-log-${{ matrix.target.name }}
           path: ${{ github.workspace }}/hs_err_pid*.log
@@ -83,8 +83,8 @@ jobs:
     name: windows-2022
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -94,14 +94,14 @@ jobs:
           .github\build.bat -DLLAMA_VERBOSE=ON
       - name: Download model
         run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
-      - name: Download reranking model 
+      - name: Download reranking model
         run: curl -L $env:RERANKING_MODEL_URL --create-dirs -o models/$env:RERANKING_MODEL_NAME
       - name: List files in models directory
         run: ls -l models/
       - name: Run tests
         run: mvn test
       - if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-output
           path: |


### PR DESCRIPTION
Upgrade deprecated Node.js 20 actions before the June 2, 2026 deadline:
- actions/checkout: v4 -> v5
- actions/setup-java: v4 -> v5
- actions/upload-artifact: v4 -> v6

Also fix minor typos in step names ("Download reranking model" trailing space, "Download text generaton model model" duplicate/typo).

https://claude.ai/code/session_01NB7tQaDY9WrbNzQ8HdbFpR