### PR TITLE
Configure Maven compiler to target Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
 				<executions>
 					<!-- We have to perform a separate build pass for cuda
 					classifier -->


### PR DESCRIPTION
Added explicit <source> and <target> configuration to maven-compiler-plugin to target Java 1.8, making the Java version requirement explicit. JetBrains annotations 24.1.0 supports Java 1.8 as the minimum version, and no Java 11+ language features are used in the codebase.

https://claude.ai/code/session_017jVi5rubS8dhrxJc36p8jQ