### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           distribution: zulu
@@ -55,7 +55,7 @@ jobs:
             name: macos-15-metal
             cmake: -DLLAMA_METAL_EMBED_LIBRARY=ON -DLLAMA_VERBOSE=ON -DGGML_NATIVE=OFF
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           distribution: zulu
@@ -83,7 +83,7 @@ jobs:
     name: windows-2022
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'


### PR DESCRIPTION
- Upgrade actions/checkout from v5 to v6
- actions/setup-java remains at v5 (latest stable)
- actions/upload-artifact remains at v6

https://claude.ai/code/session_01Kebe535iCUtxr1HULJGbGi