### PR TITLE
Fix README badge href for llama.cpp version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)
-![llama.cpp b4916](https://img.shields.io/badge/llama.cpp-%23b4916-informational)
+[![llama.cpp b4916](https://img.shields.io/badge/llama.cpp-%23b4916-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b4916)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 


### PR DESCRIPTION
Update the llama.cpp version badge to link to the correct GitHub release tag (b4916) instead of being a plain image.

https://claude.ai/code/session_012CXHD9TxFbX55Vcs6zrvCT