### PR TITLE
Fix GPU hang crash on macOS 14 Metal CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,15 @@ jobs:
           - runner: macos-15
             name: macos-15-no-metal
             cmake: -DLLAMA_METAL=OFF -DLLAMA_VERBOSE=ON -DGGML_NATIVE=OFF
+            mvn_test_args: ""
           - runner: macos-14
             name: macos-14-metal
             cmake: -DLLAMA_METAL_EMBED_LIBRARY=ON -DLLAMA_VERBOSE=ON
+            mvn_test_args: "-Dde.kherud.llama.test.ngl=0"
           - runner: macos-15
             name: macos-15-metal
             cmake: -DLLAMA_METAL_EMBED_LIBRARY=ON -DLLAMA_VERBOSE=ON -DGGML_NATIVE=OFF
+            mvn_test_args: ""
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -71,7 +74,7 @@ jobs:
       - name: List files in models directory
         run: ls -l models/
       - name: Run tests
-        run: mvn test
+        run: mvn test ${{ matrix.target.mvn_test_args }}
       - if: failure()
         uses: actions/upload-artifact@v6
         with:

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -41,7 +41,7 @@ public class LlamaModelTest {
 	@BeforeClass
 	public static void setup() {
 //		LlamaModel.setLogger(LogFormat.TEXT, (level, msg) -> System.out.println(level + ": " + msg));
-		int gpuLayers = Integer.getInteger("de.kherud.llama.test.ngl", 43);
+		int gpuLayers = Integer.getInteger(TestConstants.PROP_TEST_NGL, TestConstants.DEFAULT_TEST_NGL);
 		model = new LlamaModel(
 				new ModelParameters()
 						.setCtxSize(128)

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -41,12 +41,13 @@ public class LlamaModelTest {
 	@BeforeClass
 	public static void setup() {
 //		LlamaModel.setLogger(LogFormat.TEXT, (level, msg) -> System.out.println(level + ": " + msg));
+		int gpuLayers = Integer.getInteger("de.kherud.llama.test.ngl", 43);
 		model = new LlamaModel(
 				new ModelParameters()
 						.setCtxSize(128)
 						.setModel("models/codellama-7b.Q2_K.gguf")
 						//.setModelUrl("https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q2_K.gguf")
-						.setGpuLayers(43)
+						.setGpuLayers(gpuLayers)
 						.enableEmbedding().enableLogTimestamps().enableLogPrefix()
 		);
 	}

--- a/src/test/java/de/kherud/llama/RerankingModelTest.java
+++ b/src/test/java/de/kherud/llama/RerankingModelTest.java
@@ -21,7 +21,7 @@ public class RerankingModelTest {
 
 	@BeforeClass
 	public static void setup() {
-		int gpuLayers = Integer.getInteger("de.kherud.llama.test.ngl", 43);
+		int gpuLayers = Integer.getInteger(TestConstants.PROP_TEST_NGL, TestConstants.DEFAULT_TEST_NGL);
 		model = new LlamaModel(
 				new ModelParameters().setCtxSize(128).setModel("models/jina-reranker-v1-tiny-en-Q4_0.gguf")
 						.setGpuLayers(gpuLayers).enableReranking().enableLogTimestamps().enableLogPrefix());

--- a/src/test/java/de/kherud/llama/RerankingModelTest.java
+++ b/src/test/java/de/kherud/llama/RerankingModelTest.java
@@ -21,9 +21,10 @@ public class RerankingModelTest {
 
 	@BeforeClass
 	public static void setup() {
+		int gpuLayers = Integer.getInteger("de.kherud.llama.test.ngl", 43);
 		model = new LlamaModel(
 				new ModelParameters().setCtxSize(128).setModel("models/jina-reranker-v1-tiny-en-Q4_0.gguf")
-						.setGpuLayers(43).enableReranking().enableLogTimestamps().enableLogPrefix());
+						.setGpuLayers(gpuLayers).enableReranking().enableLogTimestamps().enableLogPrefix());
 	}
 
 	@AfterClass

--- a/src/test/java/de/kherud/llama/TestConstants.java
+++ b/src/test/java/de/kherud/llama/TestConstants.java
@@ -1,0 +1,10 @@
+package de.kherud.llama;
+
+class TestConstants {
+
+	/** System property to override GPU layers used in tests. Follows the de.kherud.llama.* property naming convention. */
+	static final String PROP_TEST_NGL = "de.kherud.llama.test.ngl";
+
+	static final int DEFAULT_TEST_NGL = 43;
+
+}


### PR DESCRIPTION
### Problem

The `macos-14-metal` CI job was crashing with a fatal GPU hang during test execution:
```
ggml_metal_synchronize: error: command buffer 0 failed with status 5
error: Caused GPU Hang Error (00000003:kIOGPUCommandBufferCallbackErrorHang)
```

The `macos-14` GitHub Actions runner uses an **Apple Paravirtual GPU**, a virtualized GPU
that lacks simdgroup support (`simdgroup reduction = false`, `simdgroup matrix mul. = false`).
Both `LlamaModelTest` and `RerankingModelTest` had `.setGpuLayers(43)` hardcoded, which
offloads all layers to Metal — overloading the virtual GPU and causing a hard hang during
the model warmup phase, killing the JVM with exit code 137.

### Solution

- Add a `TestConstants` class with `PROP_TEST_NGL` (`"de.kherud.llama.test.ngl"`) and
  `DEFAULT_TEST_NGL` (`43`), following the existing `de.kherud.llama.*` system property
  naming convention used in `LlamaLoader` and `OSInfo`.
- Both test classes now resolve GPU layers via
  `Integer.getInteger(TestConstants.PROP_TEST_NGL, TestConstants.DEFAULT_TEST_NGL)`
  instead of a hardcoded literal.
- The `macos-14-metal` CI matrix entry passes `-Dde.kherud.llama.test.ngl=0`, keeping
  inference on CPU. The Metal-enabled library is still built and loaded — only GPU
  offloading is disabled for this runner.
- `macos-15-metal` and `macos-15-no-metal` are unaffected and continue to use the
  default of 43 layers.
