### PR TITLE
Upgrade llama.cpp from b8268 to b8495 with compatibility fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8268**
+Current llama.cpp pinned version: **b8495**
 
 ## Upgrading/Downgrading llama.cpp Version
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8533**
+Current llama.cpp pinned version: **b8576**
 
 ## Upgrading/Downgrading llama.cpp Version
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8495**
+Current llama.cpp pinned version: **b8533**
 
 ## Upgrading/Downgrading llama.cpp Version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(LLAMA_BUILD_COMMON ON)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8533
+	GIT_TAG        b8576
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(LLAMA_BUILD_COMMON ON)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8268
+	GIT_TAG        b8495
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(LLAMA_BUILD_COMMON ON)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8495
+	GIT_TAG        b8533
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)
-[![llama.cpp b8533](https://img.shields.io/badge/llama.cpp-%23b8533-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8533)
+[![llama.cpp b8576](https://img.shields.io/badge/llama.cpp-%23b8576-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8576)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)
-[![llama.cpp b8495](https://img.shields.io/badge/llama.cpp-%23b8495-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8495)
+[![llama.cpp b8533](https://img.shields.io/badge/llama.cpp-%23b8533-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8533)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)
-[![llama.cpp b8268](https://img.shields.io/badge/llama.cpp-%23b8268-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8268)
+[![llama.cpp b8495](https://img.shields.io/badge/llama.cpp-%23b8495-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8495)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 

--- a/src/main/cpp/server.hpp
+++ b/src/main/cpp/server.hpp
@@ -186,14 +186,14 @@ struct slot_params {
             {"logit_bias", format_logit_bias(sampling.logit_bias)},
             {"n_probs", sampling.n_probs},
             {"min_keep", sampling.min_keep},
-            {"grammar", sampling.grammar},
+            {"grammar", common_grammar_value(sampling.grammar)},
             {"grammar_lazy", sampling.grammar_lazy},
             {"grammar_triggers", grammar_triggers},
             {"preserved_tokens", sampling.preserved_tokens},
             {"chat_format", common_chat_format_name(oaicompat_chat_syntax.format)},
             {"reasoning_format", common_reasoning_format_name(oaicompat_chat_syntax.reasoning_format)},
             {"reasoning_in_content", oaicompat_chat_syntax.reasoning_in_content},
-            {"thinking_forced_open", oaicompat_chat_syntax.thinking_forced_open},
+            {"generation_prompt", oaicompat_chat_syntax.generation_prompt},
             {"samplers", samplers},
             {"speculative.n_max", speculative.n_max},
             {"speculative.n_min", speculative.n_min},
@@ -359,14 +359,21 @@ struct server_task {
             try {
                 auto schema = json_value(data, "json_schema", json::object());
                 SRV_DBG("JSON schema: %s\n", schema.dump(2).c_str());
-                params.sampling.grammar = json_schema_to_grammar(schema);
-                SRV_DBG("Converted grammar: %s\n", params.sampling.grammar.c_str());
+                params.sampling.grammar = {COMMON_GRAMMAR_TYPE_OUTPUT_FORMAT, json_schema_to_grammar(schema)};
+                SRV_DBG("Converted grammar: %s\n", common_grammar_value(params.sampling.grammar).c_str());
             } catch (const std::exception &e) {
                 throw std::runtime_error(std::string("\"json_schema\": ") + e.what());
             }
         } else {
-            params.sampling.grammar = json_value(data, "grammar", defaults.sampling.grammar);
-            SRV_DBG("Grammar: %s\n", params.sampling.grammar.c_str());
+            {
+                const std::string grammar_str = json_value(data, "grammar", common_grammar_value(defaults.sampling.grammar));
+                if (!grammar_str.empty()) {
+                    params.sampling.grammar = {COMMON_GRAMMAR_TYPE_USER, grammar_str};
+                } else {
+                    params.sampling.grammar = {};
+                }
+            }
+            SRV_DBG("Grammar: %s\n", common_grammar_value(params.sampling.grammar).c_str());
             params.sampling.grammar_lazy = json_value(data, "grammar_lazy", defaults.sampling.grammar_lazy);
             SRV_DBG("Grammar lazy: %s\n", params.sampling.grammar_lazy ? "true" : "false");
         }
@@ -382,7 +389,7 @@ struct server_task {
             params.oaicompat_chat_syntax.reasoning_format = params_base.reasoning_format;
             params.oaicompat_chat_syntax.reasoning_in_content =
                 params.stream && (params_base.reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY);
-            params.oaicompat_chat_syntax.thinking_forced_open = json_value(data, "thinking_forced_open", false);
+            params.oaicompat_chat_syntax.generation_prompt = json_value(data, "generation_prompt", std::string());
             params.oaicompat_chat_syntax.parse_tool_calls = json_value(data, "parse_tool_calls", false);
         }
 

--- a/src/main/cpp/utils.hpp
+++ b/src/main/cpp/utils.hpp
@@ -771,7 +771,7 @@ static json oaicompat_chat_params_parse(json &body, /* openai api json semantics
     }
     llama_params["grammar_triggers"] = grammar_triggers;
     llama_params["preserved_tokens"] = chat_params.preserved_tokens;
-    llama_params["thinking_forced_open"] = chat_params.thinking_forced_open;
+    llama_params["generation_prompt"] = chat_params.generation_prompt;
     for (const auto &stop : chat_params.additional_stops) {
         llama_params["stop"].push_back(stop);
     }


### PR DESCRIPTION
- Update GIT_TAG to b8495 in CMakeLists.txt
- Update version badge/link in README.md and CLAUDE.md
- Fix server.hpp/utils.hpp for breaking API changes in b8495:
  * common_params_sampling::grammar changed from std::string to common_grammar struct; update all usages to use common_grammar_value() and construct with {COMMON_GRAMMAR_TYPE_USER/OUTPUT_FORMAT, str}
  * common_chat_parser_params::thinking_forced_open removed; replaced with generation_prompt (string) throughout server.hpp and utils.hpp
  * common_chat_params::thinking_forced_open removed; replaced with generation_prompt field in the JSON serialization path

https://claude.ai/code/session_01DRvuiQX2qH13zHua4F4Kwq