### PR TITLE
Document API compatibility files and known breaking changes for llama.cpp upgrades

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,71 @@ For individual file content at a specific build:
 https://raw.githubusercontent.com/ggerganov/llama.cpp/b<VERSION>/common/chat.h
 ```
 
+### Files to check for API compatibility
+
+The three project C++ files (`jllama.cpp`, `server.hpp`, `utils.hpp`) pull in the following
+llama.cpp headers. Any of these can introduce breaking changes on upgrade.
+
+**Include dependency graph:**
+```
+jllama.cpp / server.hpp / utils.hpp
+│
+├── arg.h ──────────────────────────► common.h ─┐
+├── common.h ──────────────────────────────────►├── ggml-opt.h ──► ggml.h
+├── chat.h ─────────────► common.h, peg-parser.h └── ggml-backend.h ──► ggml-alloc.h
+├── speculative.h ──────► llama.h, common.h
+├── sampling.h ─────────► llama.h, common.h
+├── download.h ─────────► (stdlib only, no deps)
+├── log.h ──────────────► ggml.h
+├── llama.h ────────────────────────────────────► ggml.h, ggml-cpu.h, ggml-backend.h, ggml-opt.h
+│                                                  └── llama-cpp.h ──► llama.h
+├── json-schema-to-grammar.h
+├── base64.hpp
+├── mtmd.h
+└── mtmd-helper.h
+```
+
+**Priority-ordered review list** (highest break risk first):
+
+| File | What to watch for |
+|------|-------------------|
+| `include/llama.h` | Core llama_ function signatures, token types, `llama_model_ptr`, renamed structs |
+| `include/llama-cpp.h` | C++ smart pointer types: `llama_model_ptr`, `common_init_result_ptr`; access pattern changes (`.get()` vs `->method()`) |
+| `common/common.h` | `common_params` / `common_params_speculative` struct fields, `model_alias` type, `common_init_result` shape |
+| `common/common.cpp` | Implementation of any inline API used directly |
+| `common/speculative.h` | `common_speculative_init`, `common_speculative_draft`, `common_speculative_accept` signatures |
+| `common/speculative.cpp` | Speculative decoding implementation details |
+| `common/chat.h` | `common_chat_parser_params` (was `common_chat_syntax`), `to_json_oaicompat`, `common_chat_msg_diff_to_json_oaicompat`, `set_tool_call_ids` |
+| `common/chat.cpp` | Chat parsing implementation |
+| `common/arg.h` | Parameter parsing; check what moved to `download.h` across versions |
+| `common/download.h` | `common_remote_params` struct, `headers` field format (string vs key-value pair) |
+| `common/sampling.h` | Sampler API, `common_sampler_*` functions |
+| `common/log.h` | Log macro signatures |
+| `common/mtmd.h` | Multimodal API, `mtmd_init_params` fields |
+| `common/mtmd-helper.h` | Multimodal helper functions |
+| `common/json-schema-to-grammar.h` | Grammar API |
+| `ggml/include/ggml.h` | `ggml_type` enum values (e.g. `GGML_TYPE_F16`), tensor primitives |
+| `ggml/include/ggml-backend.h` | Backend/device abstraction types |
+| `ggml/include/ggml-opt.h` | Optimizer params pulled in via `common.h` |
+
+**Safe to skip** (stable leaf headers, not used directly by project code):
+`ggml-alloc.h`, `ggml-cpu.h`, `peg-parser.h`, `base64.hpp`
+
+**Known breaking changes by version range** (b5022 → b8190):
+
+| Version | File | Change |
+|---------|------|--------|
+| ~b7217–b7433 | `common/common.h`, `include/llama-cpp.h` | `common_init_result` became `common_init_result_ptr`; access changed to `->model()` / `->context()` / `->free_context()` |
+| ~b7433 | `common/arg.h` | `n_parallel` default changed to sentinel `-1` (auto); Java bindings must resolve to `1` before model load |
+| ~b7217–b7783 | `common/arg.h` → `common/download.h` | `common_remote_get_content` and `common_remote_params` split into new `download.h`; `headers` changed from `vector<string>` to `vector<pair>` |
+| ~b7783 | `common/common.h` | `build_info` string moved into `common.h`; local definition must be removed |
+| ~b7783–b7858 | `common/chat.h` | `common_chat_syntax` renamed to `common_chat_parser_params`; `to_json_oaicompat<json>()` template removed (no template arg); `ensure_tool_call_ids_set()` → `set_tool_call_ids()` |
+| ~b7858–b7864 | `common/speculative.h` | Full redesign: `common_speculative_init(ctx_tgt, ctx_dft)` → `common_speculative_init(params_speculative, ctx)`; `common_speculative_gen_draft` → `common_speculative_draft`; new `common_speculative_accept()`; `common_speculative_params` struct replaced by `common_params_speculative`; draft model loaded via `llama_model_load_from_file` into `llama_model_ptr` |
+| ~b7858–b7864 | `common/common.h` | `params_speculative`: `.model.path`/`.hf_repo` replaced by `.has_dft()`/`.mparams_dft`; new `.model_dft` and `.cparams_dft` fields; `speculative.type` enum added (`COMMON_SPECULATIVE_TYPE_NONE`) |
+| ~b7858–b7864 | `server.hpp` (internal) | `slot_action.slot_id` → `slot_action.id_slot`; `llama_init_dft` removed from `server_context`; `model_dft` changed from `llama_model*` to `llama_model_ptr`; `slot.ctx_tgt`/`ctx_dft` removed |
+| ~b7864 | `common/mtmd.h` | `mtmd_init_params.verbosity` field removed |
+| ~b7904–b8190 | `common/common.h` | `params_base.model_alias` changed from `std::string` to a container; use `*model_alias.begin()` instead of direct string cast |
+
 ## Build Commands
 
 ### Java (Maven)


### PR DESCRIPTION
Adds a structured reference section to the upgrade guide covering:
- Full include dependency graph for the three C++ project files
- Priority-ordered table of all llama.cpp headers to review per upgrade
- Known breaking changes between b5022 and b8190 with version ranges, affected files, and exact API differences (type renames, signature changes, struct field changes, file splits)

https://claude.ai/code/session_01F5jpj6htsiAGfubfwuiLY8