### PR TITLE
Add vocab-only mode for lightweight tokenization without model weights

### DIFF
--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -793,13 +793,11 @@ JNIEXPORT jbyteArray JNICALL Java_de_kherud_llama_LlamaModel_decodeBytes(JNIEnv 
     std::vector<llama_token> tokens(elements, elements + length);
 
     std::string text;
-    if (ctx_server->ctx != nullptr) {
+    if (!ctx_server->is_vocab_only()) {
         text = tokens_to_str(ctx_server->ctx, tokens.cbegin(), tokens.cend());
     } else {
         // vocab-only mode: detokenize using vocabulary directly
-        for (const auto &tok : tokens) {
-            text += common_token_to_piece(ctx_server->vocab, tok);
-        }
+        text = tokens_to_str(ctx_server->vocab, tokens.cbegin(), tokens.cend());
     }
 
     env->ReleaseIntArrayElements(java_tokens, elements, 0);
@@ -810,7 +808,7 @@ JNIEXPORT jbyteArray JNICALL Java_de_kherud_llama_LlamaModel_decodeBytes(JNIEnv 
 JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_delete(JNIEnv *env, jobject obj) {
     jlong server_handle = env->GetLongField(obj, f_model_pointer);
     auto *ctx_server = reinterpret_cast<server_context *>(server_handle); // NOLINT(*-no-int-to-ptr)
-    if (ctx_server->ctx != nullptr) {
+    if (!ctx_server->is_vocab_only()) {
         // Full model mode: stop the background task processing loop
         ctx_server->queue_tasks.terminate();
     }

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -384,15 +384,7 @@ JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_loadModel(JNIEnv *env, jo
 
     // Strip --vocab-only before common_params_parse (not a common_params flag).
     bool vocab_only = false;
-    std::vector<char *> filtered_argv;
-    for (jsize i = 0; i < argc; i++) {
-        if (strcmp(argv[i], "--vocab-only") == 0) {
-            vocab_only = true;
-        } else {
-            filtered_argv.push_back(argv[i]);
-        }
-    }
-
+    std::vector<char *> filtered_argv = strip_flag_from_argv(argv, static_cast<int>(argc), "--vocab-only", &vocab_only);
     int filtered_argc = static_cast<int>(filtered_argv.size());
     const auto parsed_params = common_params_parse(filtered_argc, filtered_argv.data(), params, LLAMA_EXAMPLE_SERVER);
     free_string_array(argv, argc);

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -382,18 +382,42 @@ JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_loadModel(JNIEnv *env, jo
         return;
     }
 
-    const auto parsed_params = common_params_parse(argc, argv, params, LLAMA_EXAMPLE_SERVER);
+    // Strip --vocab-only before common_params_parse (not a common_params flag).
+    bool vocab_only = false;
+    std::vector<char *> filtered_argv;
+    for (jsize i = 0; i < argc; i++) {
+        if (strcmp(argv[i], "--vocab-only") == 0) {
+            vocab_only = true;
+        } else {
+            filtered_argv.push_back(argv[i]);
+        }
+    }
+
+    int filtered_argc = static_cast<int>(filtered_argv.size());
+    const auto parsed_params = common_params_parse(filtered_argc, filtered_argv.data(), params, LLAMA_EXAMPLE_SERVER);
     free_string_array(argv, argc);
     if (!parsed_params) {
         return;
     }
 
-    SRV_INF("loading model '%s'\n", params.model.path.c_str());
-
     common_init();
 
-    // struct that contains llama context and inference
     auto *ctx_server = new server_context();
+
+    // Vocab-only mode: load just the tokenizer, skip inference setup.
+    if (vocab_only) {
+        SRV_INF("loading tokenizer from '%s'\n", params.model.path.c_str());
+        if (!ctx_server->load_tokenizer(params)) {
+            delete ctx_server;
+            llama_backend_free();
+            env->ThrowNew(c_llama_error, "could not load tokenizer from given file path");
+            return;
+        }
+        env->SetLongField(obj, f_model_pointer, reinterpret_cast<jlong>(ctx_server));
+        return;
+    }
+
+    SRV_INF("loading model '%s'\n", params.model.path.c_str());
 
     llama_numa_init(params.numa);
 
@@ -417,6 +441,7 @@ JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_loadModel(JNIEnv *env, jo
 
     // load the model
     if (!ctx_server->load_model(params)) {
+        delete ctx_server;
         llama_backend_free();
         env->ThrowNew(c_llama_error, "could not load model from given file path");
         return;
@@ -774,7 +799,16 @@ JNIEXPORT jbyteArray JNICALL Java_de_kherud_llama_LlamaModel_decodeBytes(JNIEnv 
     jsize length = env->GetArrayLength(java_tokens);
     jint *elements = env->GetIntArrayElements(java_tokens, nullptr);
     std::vector<llama_token> tokens(elements, elements + length);
-    std::string text = tokens_to_str(ctx_server->ctx, tokens.cbegin(), tokens.cend());
+
+    std::string text;
+    if (ctx_server->ctx != nullptr) {
+        text = tokens_to_str(ctx_server->ctx, tokens.cbegin(), tokens.cend());
+    } else {
+        // vocab-only mode: detokenize using vocabulary directly
+        for (const auto &tok : tokens) {
+            text += common_token_to_piece(ctx_server->vocab, tok);
+        }
+    }
 
     env->ReleaseIntArrayElements(java_tokens, elements, 0);
 
@@ -784,7 +818,10 @@ JNIEXPORT jbyteArray JNICALL Java_de_kherud_llama_LlamaModel_decodeBytes(JNIEnv 
 JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_delete(JNIEnv *env, jobject obj) {
     jlong server_handle = env->GetLongField(obj, f_model_pointer);
     auto *ctx_server = reinterpret_cast<server_context *>(server_handle); // NOLINT(*-no-int-to-ptr)
-    ctx_server->queue_tasks.terminate();
+    if (ctx_server->ctx != nullptr) {
+        // Full model mode: stop the background task processing loop
+        ctx_server->queue_tasks.terminate();
+    }
     // delete ctx_server;
 }
 

--- a/src/main/cpp/server.hpp
+++ b/src/main/cpp/server.hpp
@@ -1861,6 +1861,10 @@ struct server_context {
     common_chat_templates_ptr chat_templates;
     oaicompat_parser_options oai_parser_opt;
 
+    // Returns true when the model was loaded in vocab-only mode:
+    // the vocabulary is available but no inference context was created.
+    bool is_vocab_only() const { return model != nullptr && ctx == nullptr; }
+
     ~server_context() {
         mtmd_free(mctx);
 

--- a/src/main/cpp/server.hpp
+++ b/src/main/cpp/server.hpp
@@ -1836,6 +1836,7 @@ struct server_context {
     const llama_vocab *vocab = nullptr;
 
     llama_model_ptr model_dft;
+    llama_model_ptr model_vocab_only; // owns model when loaded in vocab-only mode
 
     llama_batch batch{};
 
@@ -1875,6 +1876,32 @@ struct server_context {
         }
 
         llama_batch_free(batch);
+    }
+
+    // Only load vocabulary for tokenization (no weights, no context).
+    // After calling this, only encode/decode operations are available.
+    bool load_tokenizer(const common_params &params) {
+        SRV_INF("loading tokenizer from '%s'\n", params.model.path.c_str());
+
+        params_base = params;
+
+        llama_model_params model_params = llama_model_default_params();
+        model_params.vocab_only = true;
+
+        llama_model * m = llama_model_load_from_file(params.model.path.c_str(), model_params);
+        if (m == nullptr) {
+            SRV_ERR("failed to load tokenizer, '%s'\n", params.model.path.c_str());
+            return false;
+        }
+
+        model_vocab_only.reset(m);
+        model = m;
+        vocab  = llama_model_get_vocab(model);
+
+        add_bos_token = llama_vocab_get_add_bos(vocab);
+        has_eos_token = llama_vocab_eos(vocab) != LLAMA_TOKEN_NULL;
+
+        return true;
     }
 
     bool load_model(const common_params &params) {

--- a/src/main/cpp/utils.hpp
+++ b/src/main/cpp/utils.hpp
@@ -502,6 +502,16 @@ template <class Iter> static std::string tokens_to_str(llama_context *ctx, Iter 
     return ret;
 }
 
+// Vocab-only variant: detokenize without an inference context.
+template <class Iter> static std::string tokens_to_str(const llama_vocab *vocab, Iter begin, Iter end) {
+    std::string ret;
+    for (; begin != end; ++begin) {
+        ret += common_token_to_piece(vocab, *begin);
+    }
+
+    return ret;
+}
+
 // format incomplete utf-8 multibyte character for output
 static std::string tokens_to_output_formatted_string(const llama_context *ctx, const llama_token token) {
     std::string out = token == LLAMA_TOKEN_NULL ? "" : common_token_to_piece(ctx, token);

--- a/src/main/cpp/utils.hpp
+++ b/src/main/cpp/utils.hpp
@@ -471,6 +471,23 @@ static std::string gen_chatcmplid() { return "chatcmpl-" + random_string(); }
 
 static std::string gen_tool_call_id() { return random_string(); }
 
+// Strip an exact-match flag (no value) from an argv array.
+// Returns a new vector of pointers (non-owning) with every occurrence removed.
+// Sets *found = true if the flag was present at least once.
+static std::vector<char *> strip_flag_from_argv(char **argv, int argc, const char *flag, bool *found) {
+    *found = false;
+    std::vector<char *> out;
+    out.reserve(argc);
+    for (int i = 0; i < argc; i++) {
+        if (strcmp(argv[i], flag) == 0) {
+            *found = true;
+        } else {
+            out.push_back(argv[i]);
+        }
+    }
+    return out;
+}
+
 //
 // other common utils
 //

--- a/src/main/java/de/kherud/llama/ModelParameters.java
+++ b/src/main/java/de/kherud/llama/ModelParameters.java
@@ -959,6 +959,16 @@ public final class ModelParameters extends CliParameters {
         return this;
     }
 
+    /**
+     * Only load the vocabulary for tokenization, no weights (default: false).
+     * A model loaded with this option can only be used for {@link LlamaModel#encode(String)}
+     * and {@link LlamaModel#decode(int[])}. Inference, embedding, and reranking will not work.
+     */
+    public ModelParameters setVocabOnly() {
+        parameters.put("--vocab-only", null);
+        return this;
+    }
+
     public boolean isDefault(String key) {
         return !parameters.containsKey("--" + key);
     }

--- a/src/test/cpp/test_server.cpp
+++ b/src/test/cpp/test_server.cpp
@@ -600,3 +600,51 @@ TEST(ServerTaskResultApplyLora, ToJson_SuccessTrue) {
     ASSERT_TRUE(j.contains("success"));
     EXPECT_TRUE(j.at("success").get<bool>());
 }
+
+// ============================================================
+// server_context::is_vocab_only
+//   Pure predicate on two pointer fields — testable without a
+//   model by directly manipulating the struct members.
+//
+//   Semantics:
+//     false  — default-constructed (both null): no model at all
+//     true   — model set, ctx null: vocab-only load via load_tokenizer
+//     false  — model and ctx both set: full model loaded via load_model
+// ============================================================
+
+TEST(IsVocabOnly, DefaultConstructed_False) {
+    // Neither model nor ctx is set; we have no model at all.
+    server_context sc;
+    EXPECT_FALSE(sc.is_vocab_only());
+}
+
+TEST(IsVocabOnly, ModelSetCtxNull_True) {
+    // Simulate the state after load_tokenizer():
+    // model_vocab_only owns the real pointer; model is a raw alias.
+    // Use a non-null sentinel without calling llama.cpp.
+    server_context sc;
+    sc.model = reinterpret_cast<llama_model *>(static_cast<uintptr_t>(1));
+    sc.ctx   = nullptr;
+    EXPECT_TRUE(sc.is_vocab_only());
+    sc.model = nullptr; // prevent destructor confusion
+}
+
+TEST(IsVocabOnly, ModelAndCtxSet_False) {
+    // Simulate the state after load_model():
+    // both model and ctx are live pointers.
+    server_context sc;
+    sc.model = reinterpret_cast<llama_model   *>(static_cast<uintptr_t>(1));
+    sc.ctx   = reinterpret_cast<llama_context *>(static_cast<uintptr_t>(2));
+    EXPECT_FALSE(sc.is_vocab_only());
+    sc.model = nullptr; // prevent destructor confusion
+    sc.ctx   = nullptr;
+}
+
+TEST(IsVocabOnly, OnlyCtxSet_False) {
+    // Degenerate: ctx set but model null — not vocab-only either
+    // (model == nullptr fails the first condition).
+    server_context sc;
+    sc.ctx = reinterpret_cast<llama_context *>(static_cast<uintptr_t>(1));
+    EXPECT_FALSE(sc.is_vocab_only());
+    sc.ctx = nullptr;
+}

--- a/src/test/cpp/test_utils.cpp
+++ b/src/test/cpp/test_utils.cpp
@@ -1203,3 +1203,118 @@ TEST(ParseLoraRequest, DoesNotModifyOriginalBase) {
     // original must be unchanged
     EXPECT_FLOAT_EQ(base[0].scale, 0.8f);
 }
+
+// ============================================================
+// StripFlagFromArgv
+//   Helper used by loadModel to remove --vocab-only from argv
+//   before passing to common_params_parse, which does not know
+//   about this flag.
+// ============================================================
+
+// Build a mutable char* array from string literals for use as argv.
+// Lifetime is tied to the vector of strings passed in.
+static std::vector<char *> make_argv(std::vector<std::string> &strings) {
+    std::vector<char *> ptrs;
+    ptrs.reserve(strings.size());
+    for (auto &s : strings) {
+        ptrs.push_back(s.data());
+    }
+    return ptrs;
+}
+
+TEST(StripFlagFromArgv, FlagAbsent_NothingRemoved) {
+    std::vector<std::string> s = {"prog", "--model", "foo.gguf"};
+    auto argv = make_argv(s);
+    bool found = true; // pre-set to true so we verify it gets cleared
+    auto out = strip_flag_from_argv(argv.data(), static_cast<int>(argv.size()), "--vocab-only", &found);
+    EXPECT_FALSE(found);
+    ASSERT_EQ(out.size(), 3u);
+    EXPECT_STREQ(out[0], "prog");
+    EXPECT_STREQ(out[1], "--model");
+    EXPECT_STREQ(out[2], "foo.gguf");
+}
+
+TEST(StripFlagFromArgv, FlagAtStart_Removed) {
+    std::vector<std::string> s = {"--vocab-only", "--model", "foo.gguf"};
+    auto argv = make_argv(s);
+    bool found = false;
+    auto out = strip_flag_from_argv(argv.data(), static_cast<int>(argv.size()), "--vocab-only", &found);
+    EXPECT_TRUE(found);
+    ASSERT_EQ(out.size(), 2u);
+    EXPECT_STREQ(out[0], "--model");
+    EXPECT_STREQ(out[1], "foo.gguf");
+}
+
+TEST(StripFlagFromArgv, FlagAtEnd_Removed) {
+    std::vector<std::string> s = {"prog", "--model", "foo.gguf", "--vocab-only"};
+    auto argv = make_argv(s);
+    bool found = false;
+    auto out = strip_flag_from_argv(argv.data(), static_cast<int>(argv.size()), "--vocab-only", &found);
+    EXPECT_TRUE(found);
+    ASSERT_EQ(out.size(), 3u);
+    EXPECT_STREQ(out[2], "foo.gguf");
+}
+
+TEST(StripFlagFromArgv, FlagInMiddle_OrderPreserved) {
+    std::vector<std::string> s = {"prog", "--ctx-size", "128", "--vocab-only", "--model", "m.gguf"};
+    auto argv = make_argv(s);
+    bool found = false;
+    auto out = strip_flag_from_argv(argv.data(), static_cast<int>(argv.size()), "--vocab-only", &found);
+    EXPECT_TRUE(found);
+    ASSERT_EQ(out.size(), 5u);
+    EXPECT_STREQ(out[0], "prog");
+    EXPECT_STREQ(out[1], "--ctx-size");
+    EXPECT_STREQ(out[2], "128");
+    EXPECT_STREQ(out[3], "--model");
+    EXPECT_STREQ(out[4], "m.gguf");
+}
+
+TEST(StripFlagFromArgv, FlagAppearsMultipleTimes_AllRemoved) {
+    std::vector<std::string> s = {"--vocab-only", "--model", "m.gguf", "--vocab-only"};
+    auto argv = make_argv(s);
+    bool found = false;
+    auto out = strip_flag_from_argv(argv.data(), static_cast<int>(argv.size()), "--vocab-only", &found);
+    EXPECT_TRUE(found);
+    ASSERT_EQ(out.size(), 2u);
+    EXPECT_STREQ(out[0], "--model");
+    EXPECT_STREQ(out[1], "m.gguf");
+}
+
+TEST(StripFlagFromArgv, FlagOnly_ResultEmpty) {
+    std::vector<std::string> s = {"--vocab-only"};
+    auto argv = make_argv(s);
+    bool found = false;
+    auto out = strip_flag_from_argv(argv.data(), static_cast<int>(argv.size()), "--vocab-only", &found);
+    EXPECT_TRUE(found);
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(StripFlagFromArgv, EmptyArgv_NoCrash) {
+    bool found = true;
+    auto out = strip_flag_from_argv(nullptr, 0, "--vocab-only", &found);
+    EXPECT_FALSE(found);
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(StripFlagFromArgv, PartialMatchNotStripped) {
+    // "--vocab-onlyX" must not be treated as "--vocab-only"
+    std::vector<std::string> s = {"prog", "--vocab-onlyX"};
+    auto argv = make_argv(s);
+    bool found = false;
+    auto out = strip_flag_from_argv(argv.data(), static_cast<int>(argv.size()), "--vocab-only", &found);
+    EXPECT_FALSE(found);
+    ASSERT_EQ(out.size(), 2u);
+    EXPECT_STREQ(out[1], "--vocab-onlyX");
+}
+
+TEST(StripFlagFromArgv, OtherFlagsUnchanged) {
+    std::vector<std::string> s = {"prog", "--embedding", "--vocab-only", "--jinja"};
+    auto argv = make_argv(s);
+    bool found = false;
+    auto out = strip_flag_from_argv(argv.data(), static_cast<int>(argv.size()), "--vocab-only", &found);
+    EXPECT_TRUE(found);
+    ASSERT_EQ(out.size(), 3u);
+    EXPECT_STREQ(out[0], "prog");
+    EXPECT_STREQ(out[1], "--embedding");
+    EXPECT_STREQ(out[2], "--jinja");
+}

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -246,6 +246,66 @@ public class LlamaModelTest {
 		}
 	}
 
+	@Test
+	public void testVocabOnlyDecodeEmptyArray() {
+		try (LlamaModel vocabModel = new LlamaModel(
+				new ModelParameters()
+						.setModel(TestConstants.MODEL_PATH)
+						.setVocabOnly()
+		)) {
+			String decoded = vocabModel.decode(new int[0]);
+			Assert.assertEquals("Decoding empty token array should give empty string", "", decoded);
+		}
+	}
+
+	@Test
+	public void testVocabOnlyUnicodeRoundTrip() {
+		try (LlamaModel vocabModel = new LlamaModel(
+				new ModelParameters()
+						.setModel(TestConstants.MODEL_PATH)
+						.setVocabOnly()
+		)) {
+			// Multi-byte characters: accents, CJK ideograph, emoji
+			String prompt = "naïve café résumé";
+			int[] tokens = vocabModel.encode(prompt);
+			Assert.assertTrue("Unicode string should tokenise to at least one token", tokens.length > 0);
+			String decoded = vocabModel.decode(tokens);
+			// Leading space is normal (llama tokenizer behaviour); compare content
+			Assert.assertTrue("Decoded text should contain original characters",
+					decoded.contains("na") && decoded.contains("caf") && decoded.contains("sum"));
+		}
+	}
+
+	@Test
+	public void testVocabOnlyTwoInstancesCoexist() {
+		// Two independent vocab-only models open simultaneously must not interfere.
+		try (LlamaModel a = new LlamaModel(
+				new ModelParameters().setModel(TestConstants.MODEL_PATH).setVocabOnly());
+			 LlamaModel b = new LlamaModel(
+				new ModelParameters().setModel(TestConstants.MODEL_PATH).setVocabOnly())
+		) {
+			String prompt = "hello";
+			int[] tokensA = a.encode(prompt);
+			int[] tokensB = b.encode(prompt);
+			Assert.assertArrayEquals("Two concurrent vocab-only instances must produce equal tokens",
+					tokensA, tokensB);
+		}
+	}
+
+	@Test
+	public void testVocabOnlyCoexistsWithFullModel() {
+		// A vocab-only instance must work correctly while the class-level full model is loaded.
+		try (LlamaModel vocabModel = new LlamaModel(
+				new ModelParameters().setModel(TestConstants.MODEL_PATH).setVocabOnly()
+		)) {
+			String prompt = "int main()";
+			int[] vocabTokens = vocabModel.encode(prompt);
+			int[] fullTokens  = model.encode(prompt);
+			Assert.assertArrayEquals("Vocab-only instance must match full-model tokenization",
+					fullTokens, vocabTokens);
+		}
+	}
+
 	@Ignore
 	public void testLogText() {
 		List<LogMessage> messages = new ArrayList<>();

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -217,6 +217,35 @@ public class LlamaModelTest {
 		Assert.assertEquals(" " +prompt, decoded);
 	}
 
+	@Test
+	public void testVocabOnly() {
+		try (LlamaModel vocabModel = new LlamaModel(
+				new ModelParameters()
+						.setModel(TestConstants.MODEL_PATH)
+						.setVocabOnly()
+		)) {
+			String prompt = "Hello, world!";
+			int[] encoded = vocabModel.encode(prompt);
+			Assert.assertTrue("Should produce at least one token", encoded.length > 0);
+			String decoded = vocabModel.decode(encoded);
+			Assert.assertEquals(" " + prompt, decoded);
+		}
+	}
+
+	@Test
+	public void testVocabOnlyMatchesFullModel() {
+		try (LlamaModel vocabModel = new LlamaModel(
+				new ModelParameters()
+						.setModel(TestConstants.MODEL_PATH)
+						.setVocabOnly()
+		)) {
+			String prompt = "def remove_non_ascii(s: str) -> str:";
+			int[] vocabTokens = vocabModel.encode(prompt);
+			int[] fullTokens = model.encode(prompt);
+			Assert.assertArrayEquals("Vocab-only tokenization should match full model", fullTokens, vocabTokens);
+		}
+	}
+
 	@Ignore
 	public void testLogText() {
 		List<LogMessage> messages = new ArrayList<>();


### PR DESCRIPTION
Adds ModelParameters.setVocabOnly() which loads only the vocabulary from a GGUF file, skipping weight loading and context creation. This allows fast, memory-efficient tokenization (encode/decode) without the cost of loading the full model.

Implementation:
- ModelParameters.java: new setVocabOnly() builder method
- server.hpp: new load_tokenizer() using llama_model_load_from_file with vocab_only=true, storing model via llama_model_ptr for RAII cleanup
- jllama.cpp: strips --vocab-only from argv before common_params_parse (not a common_params flag), branches to tokenizer-only load path
- jllama.cpp: decodeBytes() falls back to common_token_to_piece(vocab,...) when ctx is null (vocab-only mode)
- jllama.cpp: delete() skips queue_tasks.terminate() in vocab-only mode since no background thread was started

Tests: testVocabOnly (encode/decode round-trip) and testVocabOnlyMatchesFullModel (tokenization parity with full model).

https://claude.ai/code/session_01XY6m5KyUM379a83KhGtqfU