### PR TITLE
Upload JAR artifact from test-linux job in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,8 +154,13 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-      - name: Run tests
-        run: mvn test
+      - name: Run tests and package
+        run: mvn package
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: llama-jar
+          path: target/llama-*.jar
 
 #  test-macos:
 #    name: Test Mac


### PR DESCRIPTION
Adds an upload-artifact step so the built llama-*.jar is available as a downloadable artifact from each release workflow run.

https://claude.ai/code/session_01S4XaPKHDnjPnk2PcRfqNNp