### PR TITLE
fix(android): use CACHE BOOL FORCE to disable server tools on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,10 @@ set(BUILD_SHARED_LIBS OFF)
 # does not implement the posix_spawn_* functions; subprocess.h (pulled in by
 # server-tools.cpp) uses them and fails to compile.  The server tools are not
 # needed by the jllama JNI library, so skip them on Android.
-if(NOT ANDROID_ABI)
-    set(LLAMA_BUILD_TOOLS ON)
-    set(LLAMA_BUILD_SERVER ON)
+# Must use CACHE BOOL FORCE to override llama.cpp's own option() defaults.
+if(ANDROID_ABI)
+    set(LLAMA_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
+    set(LLAMA_BUILD_SERVER OFF CACHE BOOL "" FORCE)
 endif()
 set(LLAMA_CURL OFF)
 


### PR DESCRIPTION
Plain set() is invisible to llama.cpp's option() which reads from the CMake cache; the option() default (ON) won dominates regardless. Use CACHE BOOL FORCE so LLAMA_BUILD_TOOLS and LLAMA_BUILD_SERVER are forced OFF before FetchContent_MakeAvailable processes llama.cpp's own CMakeLists, preventing the subprocess.h posix_spawn_* build error.

https://claude.ai/code/session_01SczKihybnwHE6BGipTBS1G