### PR TITLE
fix(build): explicitly build mtmd when consumed via FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,13 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(llama.cpp)
 
+# mtmd lives in tools/mtmd, which is only built when LLAMA_BUILD_TOOLS=ON.
+# LLAMA_BUILD_TOOLS defaults to LLAMA_STANDALONE, which is OFF when llama.cpp
+# is consumed via FetchContent.  Build mtmd explicitly so the target exists.
+if(NOT TARGET mtmd)
+    add_subdirectory(${llama.cpp_SOURCE_DIR}/tools/mtmd ${llama.cpp_BINARY_DIR}/tools/mtmd)
+endif()
+
 # Workaround: server-common.h (included transitively by llama-cli) includes
 # mtmd.h, but the mtmd include path is not propagated to llama-cli consumers.
 if(TARGET llama-cli)


### PR DESCRIPTION
LLAMA_BUILD_TOOLS defaults to LLAMA_STANDALONE, which is OFF when llama.cpp is pulled in via FetchContent (not the top-level project). This means tools/mtmd is never added as a subdirectory, so the mtmd CMake target does not exist. CMake silently falls back to passing -lmtmd to the linker, which fails with "library 'mtmd' not found".

Fix by unconditionally adding tools/mtmd as a subdirectory after FetchContent_MakeAvailable if the target is not already defined.

https://claude.ai/code/session_01RboHwarWGMzjnG1DWjquHv