### PR TITLE
fix(build): set LLAMA_INSTALL_VERSION fallback for mtmd standalone build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,13 @@ FetchContent_MakeAvailable(llama.cpp)
 # LLAMA_BUILD_TOOLS defaults to LLAMA_STANDALONE, which is OFF when llama.cpp
 # is consumed via FetchContent.  Build mtmd explicitly so the target exists.
 if(NOT TARGET mtmd)
+    # LLAMA_INSTALL_VERSION is set inside llama.cpp's directory scope and is not
+    # visible here.  tools/mtmd/CMakeLists.txt uses it in set_target_properties()
+    # as a VERSION value; if the variable is empty the token list after PROPERTIES
+    # becomes odd-length and CMake aborts with "incorrect number of arguments".
+    if(NOT DEFINED LLAMA_INSTALL_VERSION)
+        set(LLAMA_INSTALL_VERSION "0")
+    endif()
     add_subdirectory(${llama.cpp_SOURCE_DIR}/tools/mtmd ${llama.cpp_BINARY_DIR}/tools/mtmd)
 endif()
 


### PR DESCRIPTION
LLAMA_INSTALL_VERSION is set inside llama.cpp's directory scope and is not propagated to the top-level scope. When add_subdirectory(mtmd) is called, tools/mtmd/CMakeLists.txt tries to use it in set_target_properties(), but an undefined variable causes an odd-length token list after PROPERTIES, which CMake rejects with 'incorrect number of arguments'.

Set a fallback value of '0' only if LLAMA_INSTALL_VERSION is not already defined, guarding the check so the variable is never overwritten when the normal llama.cpp build defines it first.

https://claude.ai/code/session_012FX1VBYAQBCCPo58XvxcWy