### PR TITLE
Fix Java 8 JNI compilation error and suppress Maven download progress

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,7 +156,7 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
       - name: Run tests
-        run: mvn test
+        run: mvn --no-transfer-progress test
 
   test-macos:
     name: Test Mac
@@ -175,7 +175,7 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
       - name: Run tests
-        run: mvn test
+        run: mvn --no-transfer-progress test
 
 
   test-windows:
@@ -195,7 +195,7 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
       - name: Run tests
-        run: mvn test
+        run: mvn --no-transfer-progress test
 
 
   publish:

--- a/src/main/java/de/kherud/llama/LlamaModel.java
+++ b/src/main/java/de/kherud/llama/LlamaModel.java
@@ -1,8 +1,6 @@
 package de.kherud.llama;
 
 import de.kherud.llama.args.LogFormat;
-import org.jetbrains.annotations.Nullable;
-
 import java.lang.annotation.Native;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -113,7 +111,7 @@ public class LlamaModel implements AutoCloseable {
 	 * @param format the log format to use
 	 * @param callback a method to call for log messages
 	 */
-	public static native void setLogger(LogFormat format, @Nullable BiConsumer<LogLevel, String> callback);
+	public static native void setLogger(LogFormat format, BiConsumer<LogLevel, String> callback);
 
 	@Override
 	public void close() {


### PR DESCRIPTION
- Remove @Nullable from native setLogger() parameter: Java 8's JNIWriter cannot handle type annotations on parameterized types (BiConsumer<K,V>), causing SignatureException during compilation
- Remove now-unused org.jetbrains.annotations.Nullable import
- Add --no-transfer-progress to all mvn test invocations to suppress verbose download output in CI logs

https://claude.ai/code/session_01QMTDzAa9aMe19LiCjzJVhq