### PR TITLE
Add reranking model download to macOS and Windows test jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,8 +168,10 @@ jobs:
         with:
           name: macos-14-libraries
           path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
-      - name: Download model
+      - name: Download text generation model
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
+      - name: Download reranking model
+        run: curl -L ${RERANKING_MODEL_URL} --create-dirs -o models/${RERANKING_MODEL_NAME}
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
@@ -188,8 +190,10 @@ jobs:
         with:
           name: Windows-x86_64-libraries
           path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
-      - name: Download model
+      - name: Download text generation model
         run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
+      - name: Download reranking model
+        run: curl -L $env:RERANKING_MODEL_URL --create-dirs -o models/$env:RERANKING_MODEL_NAME
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'


### PR DESCRIPTION
Both test-macos and test-windows were missing the reranking model download step, causing RerankingModelTest to fail with "could not load model from given file path". On macOS this also triggered a JVM crash (abort trap 6) due to the native library crashing on a missing path.

https://claude.ai/code/session_01QMTDzAa9aMe19LiCjzJVhq