### PR TITLE
Skip warmup in RerankingModelTest to fix native crash on Windows/macOS

### DIFF
--- a/src/test/java/de/kherud/llama/RerankingModelTest.java
+++ b/src/test/java/de/kherud/llama/RerankingModelTest.java
@@ -24,7 +24,8 @@ public class RerankingModelTest {
 		int gpuLayers = Integer.getInteger(TestConstants.PROP_TEST_NGL, TestConstants.DEFAULT_TEST_NGL);
 		model = new LlamaModel(
 				new ModelParameters().setCtxSize(128).setModel("models/jina-reranker-v1-tiny-en-Q4_0.gguf")
-						.setGpuLayers(gpuLayers).enableReranking().enableLogTimestamps().enableLogPrefix());
+						.setGpuLayers(gpuLayers).enableReranking().enableLogTimestamps().enableLogPrefix()
+						.skipWarmup());
 	}
 
 	@AfterClass


### PR DESCRIPTION
The jina-bert-v2 reranker model hits a native crash during the warmup run on both Windows (exit code 1) and macOS Metal (GGML_ASSERT(buf_dst) in ggml-metal-context.m). Adding skipWarmup() (--no-warmup) avoids the buggy code path without affecting reranking correctness.

https://claude.ai/code/session_01QMTDzAa9aMe19LiCjzJVhq