### PR TITLE
Upgrade CUDA from 12.1 to 13.2

### DIFF
--- a/.github/build_cuda_linux.sh
+++ b/.github/build_cuda_linux.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
-# A Cuda 12.1 install script for RHEL8/Rocky8/Manylinux_2.28
+# A Cuda 13.2 install script for RHEL8/Rocky8/Manylinux_2.28
+# Available versions can be found at:
+# https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/
 
 sudo dnf install -y kernel-devel kernel-headers
 sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
 
-# We prefer CUDA 12.1 as it's compatible with 12.2+
-sudo dnf install -y cuda-toolkit-12-1
+sudo dnf install -y cuda-toolkit-13-2
 
-exec .github/build.sh $@ -DGGML_CUDA=1 -DCMAKE_CUDA_COMPILER=/usr/local/cuda-12.1/bin/nvcc
+exec .github/build.sh $@ -DGGML_CUDA=1 -DCMAKE_CUDA_COMPILER=/usr/local/cuda-13.2/bin/nvcc

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
 
   build-linux-cuda:
-    name: Build Linux x86-64 CUDA12
+    name: Build Linux x86-64 CUDA13
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update build_cuda_linux.sh to install cuda-toolkit-13-2 and use the corresponding nvcc path. Update job name in release.yaml accordingly. Available versions found at:
https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/

https://claude.ai/code/session_01QMTDzAa9aMe19LiCjzJVhq