### PR TITLE
Add package job for downloadable JARs; update CUDA classifier to 13; …

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -201,9 +201,36 @@ jobs:
         run: mvn --no-transfer-progress test
 
 
+  package:
+    name: Package JARs
+    needs: [ test-linux,test-macos,test-windows,build-linux-cuda ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*-libraries"
+          merge-multiple: true
+          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-libraries-cuda
+          path: ${{ github.workspace }}/src/main/resources_linux_cuda/de/kherud/llama/
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - name: Build JARs
+        run: mvn --batch-mode --no-transfer-progress -P release -Dmaven.test.skip=true -Dgpg.skip=true package
+      - name: Upload JARs
+        uses: actions/upload-artifact@v4
+        with:
+          name: llama-jars
+          path: target/*.jar
+
   publish:
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.build_only == 'no' }}
-    needs: [ test-linux,test-macos,test-windows,build-linux-cuda ]
+    needs: [ package ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -219,7 +219,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '8'
       - name: Build JARs
         run: mvn --batch-mode --no-transfer-progress -P release -Dmaven.test.skip=true -Dgpg.skip=true package
       - name: Upload JARs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,36 @@ Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, p
 
 Current llama.cpp pinned version: **b8579**
 
+## Upgrading CUDA Version
+
+Current CUDA version: **13.2**
+
+To change the CUDA version, update the following **three** places:
+
+1. **`.github/build_cuda_linux.sh`** — Line 10: `sudo dnf install -y cuda-toolkit-13-2`
+2. **`.github/build_cuda_linux.sh`** — Line 12: `-DCMAKE_CUDA_COMPILER=/usr/local/cuda-13.2/bin/nvcc`
+3. **`pom.xml`** — The `<classifier>` tag in the `cuda` jar execution: `cuda13-linux-x86-64`
+
+Also update the header comment in `build_cuda_linux.sh` and the job name in `.github/workflows/release.yaml` for clarity.
+
+Available CUDA versions for RHEL8/Manylinux_2_28 can be browsed at:
+```
+https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/
+```
+
+**Note:** Each CUDA version supports only certain GCC versions. If the dockcross container uses a newer GCC than CUDA supports, the build will fail with `unsupported GNU version`. Check NVIDIA's compatibility table before downgrading CUDA.
+
+Example: To upgrade from 13.2 to a hypothetical 13.3:
+```bash
+# Edit .github/build_cuda_linux.sh:
+#   line 10: cuda-toolkit-13-2 -> cuda-toolkit-13-3
+#   line 12: /usr/local/cuda-13.2/bin/nvcc -> /usr/local/cuda-13.3/bin/nvcc
+# Edit pom.xml classifier: cuda13-linux-x86-64 (major version only, no need to change for minor bumps)
+# Edit CLAUDE.md line: Current CUDA version: **13.2** -> **13.3**
+git add .github/build_cuda_linux.sh pom.xml CLAUDE.md
+git commit -m "Upgrade CUDA from 13.2 to 13.3"
+```
+
 ## Upgrading/Downgrading llama.cpp Version
 
 To change the llama.cpp version, update the following **three** files:

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
 									<goal>jar</goal>
 								</goals>
 								<configuration>
-									<classifier>cuda12-linux-x86-64</classifier>
+									<classifier>cuda13-linux-x86-64</classifier>
 									<classesDirectory>
 										${project.build.outputDirectory}_cuda</classesDirectory>
 								</configuration>


### PR DESCRIPTION
…document CUDA upgrade

- Add 'package' job to release.yaml: builds all JARs (main + sources + javadoc + CUDA) with -P release -Dgpg.skip=true and uploads them as 'llama-jars' GitHub Actions artifact, downloadable from any workflow run
- Simplify publish job's needs to [package] since package already waits on all test and build jobs
- Update pom.xml CUDA JAR classifier from cuda12-linux-x86-64 to cuda13-linux-x86-64 to match the CUDA 13.2 upgrade
- Add CUDA upgrade section to CLAUDE.md documenting all three locations to update, the version browsing URL, GCC compatibility note, and an example upgrade command

https://claude.ai/code/session_01QMTDzAa9aMe19LiCjzJVhq