### PR TITLE
Add memory reporting before and after tests on all platforms

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,10 +154,13 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
+      - name: Memory before tests
+        run: free -h
       - name: Run tests
         run: mvn --no-transfer-progress test
-
-  test-macos:
+      - name: Memory after tests
+        if: always()
+        run: free -h
     name: Test Mac
     needs: build-macos-native
     runs-on: macos-14
@@ -175,8 +178,13 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
+      - name: Memory before tests
+        run: vm_stat && sysctl hw.memsize hw.physmem
       - name: Run tests
         run: mvn --no-transfer-progress -Dde.kherud.llama.test.ngl=0 test
+      - name: Memory after tests
+        if: always()
+        run: vm_stat && sysctl hw.memsize hw.physmem
 
 
   test-windows:
@@ -197,8 +205,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
+      - name: Memory before tests
+        run: Get-CimInstance Win32_OperatingSystem | Select-Object FreePhysicalMemory,TotalVisibleMemorySize | Format-List
+        shell: pwsh
       - name: Run tests
         run: mvn --no-transfer-progress test
+      - name: Memory after tests
+        if: always()
+        run: Get-CimInstance Win32_OperatingSystem | Select-Object FreePhysicalMemory,TotalVisibleMemorySize | Format-List
+        shell: pwsh
 
 
   package:


### PR DESCRIPTION
Helps diagnose potential OOM crashes during large model tensor loading.
- Linux: free -h
- macOS: vm_stat + sysctl hw.memsize/hw.physmem
- Windows: Get-CimInstance Win32_OperatingSystem (FreePhysicalMemory, TotalVisibleMemorySize) Steps run with if: always() so memory is reported even after a crash.

https://claude.ai/code/session_01QMTDzAa9aMe19LiCjzJVhq