### PR TITLE
Fix YAML structure: restore test-macos as a separate job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -161,6 +161,8 @@ jobs:
       - name: Memory after tests
         if: always()
         run: free -h
+
+  test-macos:
     name: Test Mac
     needs: build-macos-native
     runs-on: macos-14


### PR DESCRIPTION
The previous commit accidentally merged test-macos job keys into the test-linux steps block due to a missing blank line + job key.

https://claude.ai/code/session_01QMTDzAa9aMe19LiCjzJVhq