### PR TITLE
Disable doclint in maven-javadoc-plugin to fix package job failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,9 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.5.0</version>
+						<configuration>
+							<doclint>none</doclint>
+						</configuration>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>


### PR DESCRIPTION
Java 8 javadoc fails with exit code 1 on 100+ missing @param/@return tags in InferenceParameters.java and ModelParameters.java. Adding <doclint>none</doclint> suppresses these checks while still producing the javadoc JAR.

https://claude.ai/code/session_01QMTDzAa9aMe19LiCjzJVhq