### PR TITLE
Add @param/@return Javadoc tags and remove doclint suppression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,9 +161,6 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.5.0</version>
-						<configuration>
-							<doclint>none</doclint>
-						</configuration>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>

--- a/src/main/java/de/kherud/llama/InferenceParameters.java
+++ b/src/main/java/de/kherud/llama/InferenceParameters.java
@@ -59,6 +59,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the prompt to start generation with (default: empty)
+	 *
+	 * @param prompt the prompt to start generation with
+	 * @return this builder
 	 */
 	public InferenceParameters setPrompt(String prompt) {
 		parameters.put(PARAM_PROMPT, toJsonString(prompt));
@@ -67,6 +70,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set a prefix for infilling (default: empty)
+	 *
+	 * @param inputPrefix the prefix for infilling
+	 * @return this builder
 	 */
 	public InferenceParameters setInputPrefix(String inputPrefix) {
 		parameters.put(PARAM_INPUT_PREFIX, toJsonString(inputPrefix));
@@ -75,6 +81,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set a suffix for infilling (default: empty)
+	 *
+	 * @param inputSuffix the suffix for infilling
+	 * @return this builder
 	 */
 	public InferenceParameters setInputSuffix(String inputSuffix) {
 		parameters.put(PARAM_INPUT_SUFFIX, toJsonString(inputSuffix));
@@ -83,6 +92,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Whether to remember the prompt to avoid reprocessing it
+	 *
+	 * @param cachePrompt whether to cache the prompt
+	 * @return this builder
 	 */
 	public InferenceParameters setCachePrompt(boolean cachePrompt) {
 		parameters.put(PARAM_CACHE_PROMPT, String.valueOf(cachePrompt));
@@ -91,6 +103,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the number of tokens to predict (default: -1, -1 = infinity, -2 = until context filled)
+	 *
+	 * @param nPredict number of tokens to predict (-1 = infinity, -2 = until context filled)
+	 * @return this builder
 	 */
 	public InferenceParameters setNPredict(int nPredict) {
 		parameters.put(PARAM_N_PREDICT, String.valueOf(nPredict));
@@ -99,6 +114,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set top-k sampling (default: 40, 0 = disabled)
+	 *
+	 * @param topK the top-k value (0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setTopK(int topK) {
 		parameters.put(PARAM_TOP_K, String.valueOf(topK));
@@ -107,6 +125,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set top-p sampling (default: 0.9, 1.0 = disabled)
+	 *
+	 * @param topP the top-p value (1.0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setTopP(float topP) {
 		parameters.put(PARAM_TOP_P, String.valueOf(topP));
@@ -115,6 +136,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set min-p sampling (default: 0.1, 0.0 = disabled)
+	 *
+	 * @param minP the min-p value (0.0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setMinP(float minP) {
 		parameters.put(PARAM_MIN_P, String.valueOf(minP));
@@ -123,6 +147,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set tail free sampling, parameter z (default: 1.0, 1.0 = disabled)
+	 *
+	 * @param tfsZ tail free sampling parameter z (1.0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setTfsZ(float tfsZ) {
 		parameters.put(PARAM_TFS_Z, String.valueOf(tfsZ));
@@ -131,6 +158,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set locally typical sampling, parameter p (default: 1.0, 1.0 = disabled)
+	 *
+	 * @param typicalP the locally typical sampling parameter p (1.0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setTypicalP(float typicalP) {
 		parameters.put(PARAM_TYPICAL_P, String.valueOf(typicalP));
@@ -139,6 +169,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the temperature (default: 0.8)
+	 *
+	 * @param temperature the sampling temperature
+	 * @return this builder
 	 */
 	public InferenceParameters setTemperature(float temperature) {
 		parameters.put(PARAM_TEMPERATURE, String.valueOf(temperature));
@@ -147,6 +180,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the dynamic temperature range (default: 0.0, 0.0 = disabled)
+	 *
+	 * @param dynatempRange the dynamic temperature range (0.0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setDynamicTemperatureRange(float dynatempRange) {
 		parameters.put(PARAM_DYNATEMP_RANGE, String.valueOf(dynatempRange));
@@ -155,6 +191,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the dynamic temperature exponent (default: 1.0)
+	 *
+	 * @param dynatempExponent the dynamic temperature exponent
+	 * @return this builder
 	 */
 	public InferenceParameters setDynamicTemperatureExponent(float dynatempExponent) {
 		parameters.put(PARAM_DYNATEMP_EXPONENT, String.valueOf(dynatempExponent));
@@ -163,6 +202,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the last n tokens to consider for penalties (default: 64, 0 = disabled, -1 = ctx_size)
+	 *
+	 * @param repeatLastN the number of last tokens to consider for penalties (0 = disabled, -1 = ctx_size)
+	 * @return this builder
 	 */
 	public InferenceParameters setRepeatLastN(int repeatLastN) {
 		parameters.put(PARAM_REPEAT_LAST_N, String.valueOf(repeatLastN));
@@ -171,6 +213,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the penalty of repeated sequences of tokens (default: 1.0, 1.0 = disabled)
+	 *
+	 * @param repeatPenalty the repeat penalty (1.0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setRepeatPenalty(float repeatPenalty) {
 		parameters.put(PARAM_REPEAT_PENALTY, String.valueOf(repeatPenalty));
@@ -179,6 +224,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the repetition alpha frequency penalty (default: 0.0, 0.0 = disabled)
+	 *
+	 * @param frequencyPenalty the repetition alpha frequency penalty (0.0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setFrequencyPenalty(float frequencyPenalty) {
 		parameters.put(PARAM_FREQUENCY_PENALTY, String.valueOf(frequencyPenalty));
@@ -187,6 +235,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the repetition alpha presence penalty (default: 0.0, 0.0 = disabled)
+	 *
+	 * @param presencePenalty the repetition alpha presence penalty (0.0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setPresencePenalty(float presencePenalty) {
 		parameters.put(PARAM_PRESENCE_PENALTY, String.valueOf(presencePenalty));
@@ -195,6 +246,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set MiroStat sampling strategies.
+	 *
+	 * @param mirostat the MiroStat sampling strategy
+	 * @return this builder
 	 */
 	public InferenceParameters setMiroStat(MiroStat mirostat) {
 		parameters.put(PARAM_MIROSTAT, String.valueOf(mirostat.ordinal()));
@@ -203,6 +257,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the MiroStat target entropy, parameter tau (default: 5.0)
+	 *
+	 * @param mirostatTau the MiroStat target entropy parameter tau
+	 * @return this builder
 	 */
 	public InferenceParameters setMiroStatTau(float mirostatTau) {
 		parameters.put(PARAM_MIROSTAT_TAU, String.valueOf(mirostatTau));
@@ -211,6 +268,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the MiroStat learning rate, parameter eta (default: 0.1)
+	 *
+	 * @param mirostatEta the MiroStat learning rate parameter eta
+	 * @return this builder
 	 */
 	public InferenceParameters setMiroStatEta(float mirostatEta) {
 		parameters.put(PARAM_MIROSTAT_ETA, String.valueOf(mirostatEta));
@@ -219,6 +279,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Whether to penalize newline tokens
+	 *
+	 * @param penalizeNl whether to penalize newline tokens
+	 * @return this builder
 	 */
 	public InferenceParameters setPenalizeNl(boolean penalizeNl) {
 		parameters.put(PARAM_PENALIZE_NL, String.valueOf(penalizeNl));
@@ -227,6 +290,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the number of tokens to keep from the initial prompt (default: 0, -1 = all)
+	 *
+	 * @param nKeep the number of tokens to keep from the initial prompt (-1 = all)
+	 * @return this builder
 	 */
 	public InferenceParameters setNKeep(int nKeep) {
 		parameters.put(PARAM_N_KEEP, String.valueOf(nKeep));
@@ -235,6 +301,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the RNG seed (default: -1, use random seed for &lt; 0)
+	 *
+	 * @param seed the RNG seed (use a negative value for a random seed)
+	 * @return this builder
 	 */
 	public InferenceParameters setSeed(int seed) {
 		parameters.put(PARAM_SEED, String.valueOf(seed));
@@ -243,6 +312,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the amount top tokens probabilities to output if greater than 0.
+	 *
+	 * @param nProbs the number of top token probabilities to output
+	 * @return this builder
 	 */
 	public InferenceParameters setNProbs(int nProbs) {
 		parameters.put(PARAM_N_PROBS, String.valueOf(nProbs));
@@ -251,6 +323,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set the amount of tokens the samplers should return at least (0 = disabled)
+	 *
+	 * @param minKeep the minimum number of tokens samplers should return (0 = disabled)
+	 * @return this builder
 	 */
 	public InferenceParameters setMinKeep(int minKeep) {
 		parameters.put(PARAM_MIN_KEEP, String.valueOf(minKeep));
@@ -259,6 +334,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set BNF-like grammar to constrain generations (see samples in grammars/ dir)
+	 *
+	 * @param grammar the BNF-like grammar string
+	 * @return this builder
 	 */
 	public InferenceParameters setGrammar(String grammar) {
 		parameters.put(PARAM_GRAMMAR, toJsonString(grammar));
@@ -269,6 +347,9 @@ public final class InferenceParameters extends JsonParameters {
 	 * Override which part of the prompt is penalized for repetition.
 	 * E.g. if original prompt is "Alice: Hello!" and penaltyPrompt is "Hello!", only the latter will be penalized if
 	 * repeated. See <a href="https://github.com/ggerganov/llama.cpp/pull/3727">pull request 3727</a> for more details.
+	 *
+	 * @param penaltyPrompt the string portion of the prompt to penalize for repetition
+	 * @return this builder
 	 */
 	public InferenceParameters setPenaltyPrompt(String penaltyPrompt) {
 		parameters.put(PARAM_PENALTY_PROMPT, toJsonString(penaltyPrompt));
@@ -280,6 +361,9 @@ public final class InferenceParameters extends JsonParameters {
 	 * E.g. if original prompt is "Alice: Hello!" and penaltyPrompt corresponds to the token ids of "Hello!", only the
 	 * latter will be penalized if repeated.
 	 * See <a href="https://github.com/ggerganov/llama.cpp/pull/3727">pull request 3727</a> for more details.
+	 *
+	 * @param tokens the token ids of the prompt portion to penalize for repetition
+	 * @return this builder
 	 */
 	public InferenceParameters setPenaltyPrompt(int[] tokens) {
 		if (tokens.length > 0) {
@@ -299,6 +383,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set whether to ignore end of stream token and continue generating (implies --logit-bias 2-inf)
+	 *
+	 * @param ignoreEos whether to ignore the end-of-stream token
+	 * @return this builder
 	 */
 	public InferenceParameters setIgnoreEos(boolean ignoreEos) {
 		parameters.put(PARAM_IGNORE_EOS, String.valueOf(ignoreEos));
@@ -314,6 +401,9 @@ public final class InferenceParameters extends JsonParameters {
 	 *     <li>{@link #disableTokens(Collection)}</li>
 	 *     <li>{@link #disableTokenIds(Collection)}}</li>
 	 * </ul>
+	 *
+	 * @param logitBias a map from token id to bias value
+	 * @return this builder
 	 */
 	public InferenceParameters setTokenIdBias(Map<Integer, Float> logitBias) {
 		if (!logitBias.isEmpty()) {
@@ -347,6 +437,9 @@ public final class InferenceParameters extends JsonParameters {
 	 *     <li>{@link #setTokenBias(Map)}</li>
 	 *     <li>{@link #disableTokens(Collection)}</li>
 	 * </ul>
+	 *
+	 * @param tokenIds the collection of token ids to disable
+	 * @return this builder
 	 */
 	public InferenceParameters disableTokenIds(Collection<Integer> tokenIds) {
 		if (!tokenIds.isEmpty()) {
@@ -378,6 +471,9 @@ public final class InferenceParameters extends JsonParameters {
 	 *     <li>{@link #disableTokens(Collection)}</li>
 	 *     <li>{@link #disableTokenIds(Collection)}}</li>
 	 * </ul>
+	 *
+	 * @param logitBias a map from token string to bias value
+	 * @return this builder
 	 */
 	public InferenceParameters setTokenBias(Map<String, Float> logitBias) {
 		if (!logitBias.isEmpty()) {
@@ -411,6 +507,9 @@ public final class InferenceParameters extends JsonParameters {
 	 *     <li>{@link #setTokenIdBias(Map)}</li>
 	 *     <li>{@link #disableTokenIds(Collection)}</li>
 	 * </ul>
+	 *
+	 * @param tokens the collection of token strings to disable
+	 * @return this builder
 	 */
 	public InferenceParameters disableTokens(Collection<String> tokens) {
 		if (!tokens.isEmpty()) {
@@ -435,6 +534,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set strings upon seeing which token generation is stopped
+	 *
+	 * @param stopStrings one or more strings that stop generation when encountered
+	 * @return this builder
 	 */
 	public InferenceParameters setStopStrings(String... stopStrings) {
 		if (stopStrings.length > 0) {
@@ -454,6 +556,9 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set which samplers to use for token generation in the given order
+	 *
+	 * @param samplers the samplers to use for token generation, in order
+	 * @return this builder
 	 */
 	public InferenceParameters setSamplers(Sampler... samplers) {
 		if (samplers.length > 0) {
@@ -486,12 +591,21 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
 	 * Set whether generate should apply a chat template (default: false)
+	 *
+	 * @param useChatTemplate whether to apply a chat template
+	 * @return this builder
 	 */
 	public InferenceParameters setUseChatTemplate(boolean useChatTemplate) {
 		parameters.put(PARAM_USE_JINJA, String.valueOf(useChatTemplate));
 		return this;
 	}
 
+	/**
+	 * Set the chat template string.
+	 *
+	 * @param chatTemplate the Jinja-style chat template to use
+	 * @return this builder
+	 */
 	public InferenceParameters setChatTemplate(String chatTemplate) {
 		parameters.put(PARAM_CHAT_TEMPLATE, toJsonString(chatTemplate));
 		return this;
@@ -499,8 +613,12 @@ public final class InferenceParameters extends JsonParameters {
 
 	/**
      * Set the messages for chat-based inference.
-     * - Allows **only one** system message.
-     * - Allows **one or more** user/assistant messages.
+     * - Allows <b>only one</b> system message.
+     * - Allows <b>one or more</b> user/assistant messages.
+     *
+     * @param systemMessage an optional system message (may be null or empty)
+     * @param messages a list of user/assistant message pairs (role as key, content as value)
+     * @return this builder
      */
     public InferenceParameters setMessages(String systemMessage, List<Pair<String, String>> messages) {
 		StringBuilder messagesBuilder = new StringBuilder();

--- a/src/main/java/de/kherud/llama/LlamaModel.java
+++ b/src/main/java/de/kherud/llama/LlamaModel.java
@@ -108,7 +108,7 @@ public class LlamaModel implements AutoCloseable {
 	 * invoked with log messages of the GGML backend, while JSON mode can only access request log messages.
 	 * In JSON mode, GGML messages will still be written to stdout.
 	 * To only change the log format but keep logging to stdout, the given callback can be <code>null</code>.
-	 * To disable logging, pass an empty callback, i.e., <code>(level, msg) -> {}</code>.
+	 * To disable logging, pass an empty callback, i.e., <code>(level, msg) {@literal ->} {}</code>.
 	 *
 	 * @param format the log format to use
 	 * @param callback a method to call for log messages

--- a/src/main/java/de/kherud/llama/LlamaModel.java
+++ b/src/main/java/de/kherud/llama/LlamaModel.java
@@ -49,6 +49,7 @@ public class LlamaModel implements AutoCloseable {
 	 * Generate and return a whole answer with custom parameters. Note, that the prompt isn't preprocessed in any
 	 * way, nothing like "User: ", "###Instruction", etc. is added.
 	 *
+	 * @param parameters the inference configuration
 	 * @return an LLM response
 	 */
 	public String complete(InferenceParameters parameters) {
@@ -62,6 +63,7 @@ public class LlamaModel implements AutoCloseable {
 	 * Generate and stream outputs with custom inference parameters. Note, that the prompt isn't preprocessed in any
 	 * way, nothing like "User: ", "###Instruction", etc. is added.
 	 *
+	 * @param parameters the inference configuration
 	 * @return iterable LLM outputs
 	 */
 	public LlamaIterable generate(InferenceParameters parameters) {
@@ -135,10 +137,24 @@ public class LlamaModel implements AutoCloseable {
 
 	private static native byte[] jsonSchemaToGrammarBytes(String schema);
 	
+	/**
+	 * Converts a JSON schema to a grammar string usable by {@link ModelParameters#setGrammar(String)}.
+	 *
+	 * @param schema the JSON schema as a string
+	 * @return the converted grammar string
+	 */
 	public static String jsonSchemaToGrammar(String schema) {
 		return new String(jsonSchemaToGrammarBytes(schema), StandardCharsets.UTF_8);
 	}
 	
+	/**
+	 * Rerank the given documents against the query.
+	 *
+	 * @param reRank whether to sort results by score in descending order
+	 * @param query the query string
+	 * @param documents the documents to rank
+	 * @return a list of document/score pairs, sorted if {@code reRank} is {@code true}
+	 */
 	public List<Pair<String, Float>> rerank(boolean reRank, String query, String ... documents) {
 		LlamaOutput output = rerank(query, documents);
 		
@@ -162,7 +178,13 @@ public class LlamaModel implements AutoCloseable {
 	
 	public native LlamaOutput rerank(String query, String... documents);
 	
-	public  String applyTemplate(InferenceParameters parameters) {
+	/**
+	 * Applies the chat template to the given inference parameters and returns the formatted string.
+	 *
+	 * @param parameters the inference parameters containing message configuration
+	 * @return the formatted chat template string
+	 */
+	public String applyTemplate(InferenceParameters parameters) {
 		return applyTemplate(parameters.toString());
 	}
 	public native String applyTemplate(String parametersJson);

--- a/src/main/java/de/kherud/llama/ModelParameters.java
+++ b/src/main/java/de/kherud/llama/ModelParameters.java
@@ -195,6 +195,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the logical maximum batch size (default: 0).
+     *
+     * @param batchSize the logical maximum batch size
+     * @return this builder
      */
     public ModelParameters setBatchSize(int batchSize) {
         parameters.put("--batch-size", String.valueOf(batchSize));
@@ -203,6 +206,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the physical maximum batch size (default: 0).
+     *
+     * @param ubatchSize the physical maximum batch size
+     * @return this builder
      */
     public ModelParameters setUbatchSize(int ubatchSize) {
         parameters.put("--ubatch-size", String.valueOf(ubatchSize));
@@ -211,6 +217,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the number of tokens to keep from the initial prompt (default: -1 = all).
+     *
+     * @param keep the number of tokens to keep from the initial prompt (-1 = all)
+     * @return this builder
      */
     public ModelParameters setKeep(int keep) {
         parameters.put("--keep", String.valueOf(keep));
@@ -219,6 +228,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Disable context shift on infinite text generation (default: enabled).
+     *
+     * @return this builder
      */
     public ModelParameters disableContextShift() {
         parameters.put("--no-context-shift", null);
@@ -227,6 +238,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable Flash Attention (default: disabled).
+     *
+     * @return this builder
      */
     public ModelParameters enableFlashAttn() {
         parameters.put("--flash-attn", null);
@@ -235,6 +248,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Disable internal libllama performance timings (default: false).
+     *
+     * @return this builder
      */
     public ModelParameters disablePerf() {
         parameters.put("--no-perf", null);
@@ -243,6 +258,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Process escape sequences (default: true).
+     *
+     * @return this builder
      */
     public ModelParameters enableEscape() {
         parameters.put("--escape", null);
@@ -251,6 +268,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Do not process escape sequences (default: false).
+     *
+     * @return this builder
      */
     public ModelParameters disableEscape() {
         parameters.put("--no-escape", null);
@@ -259,6 +278,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable special tokens output (default: true).
+     *
+     * @return this builder
      */
     public ModelParameters enableSpecial() {
         parameters.put("--special", null);
@@ -267,6 +288,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Skip warming up the model with an empty run (default: false).
+     *
+     * @return this builder
      */
     public ModelParameters skipWarmup() {
         parameters.put("--no-warmup", null);
@@ -276,6 +299,8 @@ public final class ModelParameters extends CliParameters {
     /**
      * Use Suffix/Prefix/Middle pattern for infill (instead of Prefix/Suffix/Middle) as some models prefer this.
      * (default: disabled)
+     *
+     * @return this builder
      */
     public ModelParameters setSpmInfill() {
         parameters.put("--spm-infill", null);
@@ -284,6 +309,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set samplers that will be used for generation in the order, separated by ';' (default: all).
+     *
+     * @param samplers the samplers to use, separated by semicolons
+     * @return this builder
      */
     public ModelParameters setSamplers(Sampler... samplers) {
         if (samplers.length > 0) {
@@ -302,6 +330,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set RNG seed (default: -1, use random seed).
+     *
+     * @param seed the RNG seed (-1 = random)
+     * @return this builder
      */
     public ModelParameters setSeed(long seed) {
         parameters.put("--seed", String.valueOf(seed));
@@ -310,6 +341,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Ignore end of stream token and continue generating (implies --logit-bias EOS-inf).
+     *
+     * @return this builder
      */
     public ModelParameters ignoreEos() {
         parameters.put("--ignore-eos", null);
@@ -318,6 +351,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set temperature for sampling (default: 0.8).
+     *
+     * @param temp the sampling temperature
+     * @return this builder
      */
     public ModelParameters setTemp(float temp) {
         parameters.put("--temp", String.valueOf(temp));
@@ -326,6 +362,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set top-k sampling (default: 40, 0 = disabled).
+     *
+     * @param topK the top-k value (0 = disabled)
+     * @return this builder
      */
     public ModelParameters setTopK(int topK) {
         parameters.put("--top-k", String.valueOf(topK));
@@ -334,6 +373,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set top-p sampling (default: 0.95, 1.0 = disabled).
+     *
+     * @param topP the top-p value (1.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setTopP(float topP) {
         parameters.put("--top-p", String.valueOf(topP));
@@ -342,6 +384,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set min-p sampling (default: 0.05, 0.0 = disabled).
+     *
+     * @param minP the min-p value (0.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setMinP(float minP) {
         parameters.put("--min-p", String.valueOf(minP));
@@ -350,6 +395,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set xtc probability (default: 0.0, 0.0 = disabled).
+     *
+     * @param xtcProbability the XTC probability (0.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setXtcProbability(float xtcProbability) {
         parameters.put("--xtc-probability", String.valueOf(xtcProbability));
@@ -358,6 +406,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set xtc threshold (default: 0.1, 1.0 = disabled).
+     *
+     * @param xtcThreshold the XTC threshold (1.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setXtcThreshold(float xtcThreshold) {
         parameters.put("--xtc-threshold", String.valueOf(xtcThreshold));
@@ -366,6 +417,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set locally typical sampling parameter p (default: 1.0, 1.0 = disabled).
+     *
+     * @param typP the locally typical sampling parameter p (1.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setTypical(float typP) {
         parameters.put("--typical", String.valueOf(typP));
@@ -374,6 +428,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set last n tokens to consider for penalize (default: 64, 0 = disabled, -1 = ctx_size).
+     *
+     * @param repeatLastN the number of last tokens to consider for penalties (0 = disabled, -1 = ctx_size)
+     * @return this builder
      */
     public ModelParameters setRepeatLastN(int repeatLastN) {
         if (repeatLastN < -1) {
@@ -385,6 +442,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set penalize repeat sequence of tokens (default: 1.0, 1.0 = disabled).
+     *
+     * @param repeatPenalty the repeat penalty (1.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setRepeatPenalty(float repeatPenalty) {
         parameters.put("--repeat-penalty", String.valueOf(repeatPenalty));
@@ -393,6 +453,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set repeat alpha presence penalty (default: 0.0, 0.0 = disabled).
+     *
+     * @param presencePenalty the alpha presence penalty (0.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setPresencePenalty(float presencePenalty) {
         parameters.put("--presence-penalty", String.valueOf(presencePenalty));
@@ -401,6 +464,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set repeat alpha frequency penalty (default: 0.0, 0.0 = disabled).
+     *
+     * @param frequencyPenalty the alpha frequency penalty (0.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setFrequencyPenalty(float frequencyPenalty) {
         parameters.put("--frequency-penalty", String.valueOf(frequencyPenalty));
@@ -409,6 +475,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set DRY sampling multiplier (default: 0.0, 0.0 = disabled).
+     *
+     * @param dryMultiplier the DRY sampling multiplier (0.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setDryMultiplier(float dryMultiplier) {
         parameters.put("--dry-multiplier", String.valueOf(dryMultiplier));
@@ -417,6 +486,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set DRY sampling base value (default: 1.75).
+     *
+     * @param dryBase the DRY sampling base value
+     * @return this builder
      */
     public ModelParameters setDryBase(float dryBase) {
         parameters.put("--dry-base", String.valueOf(dryBase));
@@ -425,6 +497,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set allowed length for DRY sampling (default: 2).
+     *
+     * @param dryAllowedLength the allowed length for DRY sampling
+     * @return this builder
      */
     public ModelParameters setDryAllowedLength(int dryAllowedLength) {
         parameters.put("--dry-allowed-length", String.valueOf(dryAllowedLength));
@@ -433,6 +508,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set DRY penalty for the last n tokens (default: -1, 0 = disable, -1 = context size).
+     *
+     * @param dryPenaltyLastN the DRY penalty window (-1 = context size, 0 = disabled)
+     * @return this builder
      */
     public ModelParameters setDryPenaltyLastN(int dryPenaltyLastN) {
         if (dryPenaltyLastN < -1) {
@@ -444,6 +522,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Add sequence breaker for DRY sampling, clearing out default breakers (default: none).
+     *
+     * @param drySequenceBreaker the sequence breaker string for DRY sampling
+     * @return this builder
      */
     public ModelParameters setDrySequenceBreaker(String drySequenceBreaker) {
         parameters.put("--dry-sequence-breaker", drySequenceBreaker);
@@ -452,6 +533,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set dynamic temperature range (default: 0.0, 0.0 = disabled).
+     *
+     * @param dynatempRange the dynamic temperature range (0.0 = disabled)
+     * @return this builder
      */
     public ModelParameters setDynatempRange(float dynatempRange) {
         parameters.put("--dynatemp-range", String.valueOf(dynatempRange));
@@ -460,6 +544,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set dynamic temperature exponent (default: 1.0).
+     *
+     * @param dynatempExponent the dynamic temperature exponent
+     * @return this builder
      */
     public ModelParameters setDynatempExponent(float dynatempExponent) {
         parameters.put("--dynatemp-exp", String.valueOf(dynatempExponent));
@@ -468,6 +555,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Use Mirostat sampling (default: PLACEHOLDER, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0).
+     *
+     * @param mirostat the Mirostat sampling mode
+     * @return this builder
      */
     public ModelParameters setMirostat(MiroStat mirostat) {
         parameters.put("--mirostat", String.valueOf(mirostat.ordinal()));
@@ -476,6 +566,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set Mirostat learning rate, parameter eta (default: 0.1).
+     *
+     * @param mirostatLR the Mirostat learning rate (eta)
+     * @return this builder
      */
     public ModelParameters setMirostatLR(float mirostatLR) {
         parameters.put("--mirostat-lr", String.valueOf(mirostatLR));
@@ -484,6 +577,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set Mirostat target entropy, parameter tau (default: 5.0).
+     *
+     * @param mirostatEnt the Mirostat target entropy (tau)
+     * @return this builder
      */
     public ModelParameters setMirostatEnt(float mirostatEnt) {
         parameters.put("--mirostat-ent", String.valueOf(mirostatEnt));
@@ -492,6 +588,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Modify the likelihood of token appearing in the completion.
+     *
+     * @param tokenIdAndBias token id and bias value as a formatted string
+     * @return this builder
      */
     public ModelParameters setLogitBias(String tokenIdAndBias) {
         parameters.put("--logit-bias", tokenIdAndBias);
@@ -500,6 +599,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set BNF-like grammar to constrain generations (default: empty).
+     *
+     * @param grammar the BNF-like grammar string
+     * @return this builder
      */
     public ModelParameters setGrammar(String grammar) {
         parameters.put("--grammar", grammar);
@@ -508,6 +610,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Specify the file to read grammar from.
+     *
+     * @param fileName the path to a file containing the grammar
+     * @return this builder
      */
     public ModelParameters setGrammarFile(String fileName) {
         parameters.put("--grammar-file", fileName);
@@ -516,6 +621,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Specify the JSON schema to constrain generations (default: empty).
+     *
+     * @param schema the JSON schema string
+     * @return this builder
      */
     public ModelParameters setJsonSchema(String schema) {
         parameters.put("--json-schema", schema);
@@ -524,6 +632,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set pooling type for embeddings (default: model default if unspecified).
+     *
+     * @param type the pooling type for embeddings
+     * @return this builder
      */
     public ModelParameters setPoolingType(PoolingType type) {
         parameters.put("--pooling", type.getArgValue());
@@ -532,6 +643,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set RoPE frequency scaling method (default: linear unless specified by the model).
+     *
+     * @param type the RoPE frequency scaling method
+     * @return this builder
      */
     public ModelParameters setRopeScaling(RopeScalingType type) {
         parameters.put("--rope-scaling", type.getArgValue());
@@ -540,6 +654,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set RoPE context scaling factor, expands context by a factor of N.
+     *
+     * @param ropeScale the RoPE context scaling factor
+     * @return this builder
      */
     public ModelParameters setRopeScale(float ropeScale) {
         parameters.put("--rope-scale", String.valueOf(ropeScale));
@@ -548,6 +665,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set RoPE base frequency, used by NTK-aware scaling (default: loaded from model).
+     *
+     * @param ropeFreqBase the RoPE base frequency
+     * @return this builder
      */
     public ModelParameters setRopeFreqBase(float ropeFreqBase) {
         parameters.put("--rope-freq-base", String.valueOf(ropeFreqBase));
@@ -556,6 +676,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set RoPE frequency scaling factor, expands context by a factor of 1/N.
+     *
+     * @param ropeFreqScale the RoPE frequency scaling factor
+     * @return this builder
      */
     public ModelParameters setRopeFreqScale(float ropeFreqScale) {
         parameters.put("--rope-freq-scale", String.valueOf(ropeFreqScale));
@@ -564,6 +687,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set YaRN: original context size of model (default: model training context size).
+     *
+     * @param yarnOrigCtx the original context size of the model
+     * @return this builder
      */
     public ModelParameters setYarnOrigCtx(int yarnOrigCtx) {
         parameters.put("--yarn-orig-ctx", String.valueOf(yarnOrigCtx));
@@ -572,6 +698,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set YaRN: extrapolation mix factor (default: 0.0 = full interpolation).
+     *
+     * @param yarnExtFactor the YaRN extrapolation mix factor (0.0 = full interpolation)
+     * @return this builder
      */
     public ModelParameters setYarnExtFactor(float yarnExtFactor) {
         parameters.put("--yarn-ext-factor", String.valueOf(yarnExtFactor));
@@ -580,6 +709,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set YaRN: scale sqrt(t) or attention magnitude (default: 1.0).
+     *
+     * @param yarnAttnFactor the YaRN attention scale factor
+     * @return this builder
      */
     public ModelParameters setYarnAttnFactor(float yarnAttnFactor) {
         parameters.put("--yarn-attn-factor", String.valueOf(yarnAttnFactor));
@@ -588,6 +720,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set YaRN: high correction dim or alpha (default: 1.0).
+     *
+     * @param yarnBetaSlow the YaRN high correction dimension (alpha)
+     * @return this builder
      */
     public ModelParameters setYarnBetaSlow(float yarnBetaSlow) {
         parameters.put("--yarn-beta-slow", String.valueOf(yarnBetaSlow));
@@ -596,6 +731,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set YaRN: low correction dim or beta (default: 32.0).
+     *
+     * @param yarnBetaFast the YaRN low correction dimension (beta)
+     * @return this builder
      */
     public ModelParameters setYarnBetaFast(float yarnBetaFast) {
         parameters.put("--yarn-beta-fast", String.valueOf(yarnBetaFast));
@@ -604,6 +742,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set group-attention factor (default: 1).
+     *
+     * @param grpAttnN the group-attention factor
+     * @return this builder
      */
     public ModelParameters setGrpAttnN(int grpAttnN) {
         parameters.put("--grp-attn-n", String.valueOf(grpAttnN));
@@ -612,6 +753,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set group-attention width (default: 512).
+     *
+     * @param grpAttnW the group-attention width
+     * @return this builder
      */
     public ModelParameters setGrpAttnW(int grpAttnW) {
         parameters.put("--grp-attn-w", String.valueOf(grpAttnW));
@@ -620,6 +764,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable verbose printing of the KV cache.
+     *
+     * @return this builder
      */
     public ModelParameters enableDumpKvCache() {
         parameters.put("--dump-kv-cache", null);
@@ -628,6 +774,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Disable KV offload.
+     *
+     * @return this builder
      */
     public ModelParameters disableKvOffload() {
         parameters.put("--no-kv-offload", null);
@@ -636,6 +784,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set KV cache data type for K (allowed values: F16).
+     *
+     * @param type the KV cache data type for K
+     * @return this builder
      */
     public ModelParameters setCacheTypeK(CacheType type) {
         parameters.put("--cache-type-k", type.name().toLowerCase());
@@ -644,6 +795,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set KV cache data type for V (allowed values: F16).
+     *
+     * @param type the KV cache data type for V
+     * @return this builder
      */
     public ModelParameters setCacheTypeV(CacheType type) {
         parameters.put("--cache-type-v", type.name().toLowerCase());
@@ -652,6 +806,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set KV cache defragmentation threshold (default: 0.1, &lt; 0 - disabled).
+     *
+     * @param defragThold the KV cache defragmentation threshold (negative = disabled)
+     * @return this builder
      */
     public ModelParameters setDefragThold(float defragThold) {
         parameters.put("--defrag-thold", String.valueOf(defragThold));
@@ -660,6 +817,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the number of parallel sequences to decode (default: 1).
+     *
+     * @param nParallel the number of parallel sequences to decode
+     * @return this builder
      */
     public ModelParameters setParallel(int nParallel) {
         parameters.put("--parallel", String.valueOf(nParallel));
@@ -668,6 +828,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable continuous batching (a.k.a dynamic batching) (default: disabled).
+     *
+     * @return this builder
      */
     public ModelParameters enableContBatching() {
         parameters.put("--cont-batching", null);
@@ -676,6 +838,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Disable continuous batching.
+     *
+     * @return this builder
      */
     public ModelParameters disableContBatching() {
         parameters.put("--no-cont-batching", null);
@@ -684,6 +848,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Force system to keep model in RAM rather than swapping or compressing.
+     *
+     * @return this builder
      */
     public ModelParameters enableMlock() {
         parameters.put("--mlock", null);
@@ -692,6 +858,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Do not memory-map model (slower load but may reduce pageouts if not using mlock).
+     *
+     * @return this builder
      */
     public ModelParameters disableMmap() {
         parameters.put("--no-mmap", null);
@@ -700,6 +868,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set NUMA optimization type for system.
+     *
+     * @param numaStrategy the NUMA optimization strategy
+     * @return this builder
      */
     public ModelParameters setNuma(NumaStrategy numaStrategy) {
         parameters.put("--numa", numaStrategy.name().toLowerCase());
@@ -708,6 +879,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set comma-separated list of devices to use for offloading &lt;dev1,dev2,..&gt; (none = don't offload).
+     *
+     * @param devices comma-separated list of device names to use for offloading
+     * @return this builder
      */
     public ModelParameters setDevices(String devices) {
         parameters.put("--device", devices);
@@ -716,6 +890,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the number of layers to store in VRAM.
+     *
+     * @param gpuLayers the number of model layers to store in VRAM
+     * @return this builder
      */
     public ModelParameters setGpuLayers(int gpuLayers) {
         parameters.put("--gpu-layers", String.valueOf(gpuLayers));
@@ -724,6 +901,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set how to split the model across multiple GPUs (none, layer, row).
+     *
+     * @param splitMode how to split the model across multiple GPUs
+     * @return this builder
      */
     public ModelParameters setSplitMode(GpuSplitMode splitMode) {
         parameters.put("--split-mode", splitMode.name().toLowerCase());
@@ -732,6 +912,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set fraction of the model to offload to each GPU, comma-separated list of proportions N0,N1,N2,....
+     *
+     * @param tensorSplit comma-separated proportions for offloading to each GPU
+     * @return this builder
      */
     public ModelParameters setTensorSplit(String tensorSplit) {
         parameters.put("--tensor-split", tensorSplit);
@@ -740,6 +923,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the GPU to use for the model (with split-mode = none), or for intermediate results and KV (with split-mode = row).
+     *
+     * @param mainGpu the index of the primary GPU
+     * @return this builder
      */
     public ModelParameters setMainGpu(int mainGpu) {
         parameters.put("--main-gpu", String.valueOf(mainGpu));
@@ -748,6 +934,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable checking model tensor data for invalid values.
+     *
+     * @return this builder
      */
     public ModelParameters enableCheckTensors() {
         parameters.put("--check-tensors", null);
@@ -756,6 +944,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Override model metadata by key. This option can be specified multiple times.
+     *
+     * @param keyValue the key-value metadata override string
+     * @return this builder
      */
     public ModelParameters setOverrideKv(String keyValue) {
         parameters.put("--override-kv", keyValue);
@@ -764,6 +955,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Add a LoRA adapter (can be repeated to use multiple adapters).
+     *
+     * @param fname the file path of the LoRA adapter
+     * @return this builder
      */
     public ModelParameters addLoraAdapter(String fname) {
         parameters.put("--lora", fname);
@@ -772,6 +966,10 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Add a LoRA adapter with user-defined scaling (can be repeated to use multiple adapters).
+     *
+     * @param fname the file path of the LoRA adapter
+     * @param scale the user-defined scaling factor
+     * @return this builder
      */
     public ModelParameters addLoraScaledAdapter(String fname, float scale) {
         parameters.put("--lora-scaled", fname + "," + scale);
@@ -780,6 +978,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Add a control vector (this argument can be repeated to add multiple control vectors).
+     *
+     * @param fname the file path of the control vector
+     * @return this builder
      */
     public ModelParameters addControlVector(String fname) {
         parameters.put("--control-vector", fname);
@@ -788,6 +989,10 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Add a control vector with user-defined scaling (can be repeated to add multiple scaled control vectors).
+     *
+     * @param fname the file path of the control vector
+     * @param scale the user-defined scaling factor
+     * @return this builder
      */
     public ModelParameters addControlVectorScaled(String fname, float scale) {
         parameters.put("--control-vector-scaled", fname + "," + scale);
@@ -796,6 +1001,10 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the layer range to apply the control vector(s) to (start and end inclusive).
+     *
+     * @param start the first layer to apply the control vector to (inclusive)
+     * @param end the last layer to apply the control vector to (inclusive)
+     * @return this builder
      */
     public ModelParameters setControlVectorLayerRange(int start, int end) {
         parameters.put("--control-vector-layer-range", start + "," + end);
@@ -804,6 +1013,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the model path from which to load the base model.
+     *
+     * @param model the file path of the base model
+     * @return this builder
      */
     public ModelParameters setModel(String model) {
         parameters.put("--model", model);
@@ -812,6 +1024,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the model download URL (default: unused).
+     *
+     * @param modelUrl the URL from which to download the model
+     * @return this builder
      */
     public ModelParameters setModelUrl(String modelUrl) {
         parameters.put("--model-url", modelUrl);
@@ -820,6 +1035,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the Hugging Face model repository (default: unused).
+     *
+     * @param hfRepo the Hugging Face repository identifier
+     * @return this builder
      */
     public ModelParameters setHfRepo(String hfRepo) {
         parameters.put("--hf-repo", hfRepo);
@@ -828,6 +1046,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the Hugging Face model file (default: unused).
+     *
+     * @param hfFile the model file within the Hugging Face repository
+     * @return this builder
      */
     public ModelParameters setHfFile(String hfFile) {
         parameters.put("--hf-file", hfFile);
@@ -836,6 +1057,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the Hugging Face model repository for the vocoder model (default: unused).
+     *
+     * @param hfRepoV the Hugging Face repository for the vocoder model
+     * @return this builder
      */
     public ModelParameters setHfRepoV(String hfRepoV) {
         parameters.put("--hf-repo-v", hfRepoV);
@@ -844,6 +1068,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the Hugging Face model file for the vocoder model (default: unused).
+     *
+     * @param hfFileV the vocoder model file within the Hugging Face repository
+     * @return this builder
      */
     public ModelParameters setHfFileV(String hfFileV) {
         parameters.put("--hf-file-v", hfFileV);
@@ -852,6 +1079,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the Hugging Face access token (default: value from HF_TOKEN environment variable).
+     *
+     * @param hfToken the Hugging Face API access token
+     * @return this builder
      */
     public ModelParameters setHfToken(String hfToken) {
         parameters.put("--hf-token", hfToken);
@@ -860,6 +1090,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable embedding use case; use only with dedicated embedding models.
+     *
+     * @return this builder
      */
     public ModelParameters enableEmbedding() {
         parameters.put("--embedding", null);
@@ -868,6 +1100,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable reranking endpoint on server.
+     *
+     * @return this builder
      */
     public ModelParameters enableReranking() {
         parameters.put("--reranking", null);
@@ -876,6 +1110,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set minimum chunk size to attempt reusing from the cache via KV shifting.
+     *
+     * @param cacheReuse the minimum chunk size to attempt reusing from KV cache
+     * @return this builder
      */
     public ModelParameters setCacheReuse(int cacheReuse) {
         parameters.put("--cache-reuse", String.valueOf(cacheReuse));
@@ -884,6 +1121,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the path to save the slot kv cache.
+     *
+     * @param slotSavePath the directory path for saving slot KV cache
+     * @return this builder
      */
     public ModelParameters setSlotSavePath(String slotSavePath) {
         parameters.put("--slot-save-path", slotSavePath);
@@ -892,6 +1132,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set custom jinja chat template.
+     *
+     * @param chatTemplate the custom Jinja chat template string
+     * @return this builder
      */
     public ModelParameters setChatTemplate(String chatTemplate) {
         parameters.put("--chat-template", chatTemplate);
@@ -900,6 +1143,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set how much the prompt of a request must match the prompt of a slot in order to use that slot.
+     *
+     * @param similarity the minimum similarity threshold for slot reuse
+     * @return this builder
      */
     public ModelParameters setSlotPromptSimilarity(float similarity) {
         parameters.put("--slot-prompt-similarity", String.valueOf(similarity));
@@ -908,6 +1154,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Load LoRA adapters without applying them (apply later via POST /lora-adapters).
+     *
+     * @return this builder
      */
     public ModelParameters setLoraInitWithoutApply() {
         parameters.put("--lora-init-without-apply", null);
@@ -916,6 +1164,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Disable logging.
+     *
+     * @return this builder
      */
     public ModelParameters disableLog() {
         parameters.put("--log-disable", null);
@@ -924,6 +1174,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the log file path.
+     *
+     * @param logFile the path to the log file
+     * @return this builder
      */
     public ModelParameters setLogFile(String logFile) {
         parameters.put("--log-file", logFile);
@@ -932,6 +1185,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set verbosity level to infinity (log all messages, useful for debugging).
+     *
+     * @return this builder
      */
     public ModelParameters setVerbose() {
         parameters.put("--verbose", null);
@@ -940,6 +1195,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the verbosity threshold (messages with a higher verbosity will be ignored).
+     *
+     * @param verbosity the verbosity threshold level
+     * @return this builder
      */
     public ModelParameters setLogVerbosity(int verbosity) {
         parameters.put("--log-verbosity", String.valueOf(verbosity));
@@ -948,6 +1206,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable prefix in log messages.
+     *
+     * @return this builder
      */
     public ModelParameters enableLogPrefix() {
         parameters.put("--log-prefix", null);
@@ -956,6 +1216,8 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Enable timestamps in log messages.
+     *
+     * @return this builder
      */
     public ModelParameters enableLogTimestamps() {
         parameters.put("--log-timestamps", null);
@@ -964,6 +1226,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the number of tokens to draft for speculative decoding.
+     *
+     * @param draftMax the number of tokens to draft for speculative decoding
+     * @return this builder
      */
     public ModelParameters setDraftMax(int draftMax) {
         parameters.put("--draft-max", String.valueOf(draftMax));
@@ -972,6 +1237,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the minimum number of draft tokens to use for speculative decoding.
+     *
+     * @param draftMin the minimum number of draft tokens for speculative decoding
+     * @return this builder
      */
     public ModelParameters setDraftMin(int draftMin) {
         parameters.put("--draft-min", String.valueOf(draftMin));
@@ -980,6 +1248,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the minimum speculative decoding probability for greedy decoding.
+     *
+     * @param draftPMin the minimum speculative decoding probability for greedy decoding
+     * @return this builder
      */
     public ModelParameters setDraftPMin(float draftPMin) {
         parameters.put("--draft-p-min", String.valueOf(draftPMin));
@@ -988,6 +1259,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the size of the prompt context for the draft model.
+     *
+     * @param ctxSizeDraft the prompt context size for the draft model
+     * @return this builder
      */
     public ModelParameters setCtxSizeDraft(int ctxSizeDraft) {
         parameters.put("--ctx-size-draft", String.valueOf(ctxSizeDraft));
@@ -996,6 +1270,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the comma-separated list of devices to use for offloading the draft model.
+     *
+     * @param deviceDraft comma-separated list of devices for offloading the draft model
+     * @return this builder
      */
     public ModelParameters setDeviceDraft(String deviceDraft) {
         parameters.put("--device-draft", deviceDraft);
@@ -1004,6 +1281,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the number of layers to store in VRAM for the draft model.
+     *
+     * @param gpuLayersDraft the number of draft model layers to store in VRAM
+     * @return this builder
      */
     public ModelParameters setGpuLayersDraft(int gpuLayersDraft) {
         parameters.put("--gpu-layers-draft", String.valueOf(gpuLayersDraft));
@@ -1012,14 +1292,19 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the draft model for speculative decoding.
+     *
+     * @param modelDraft the file path of the draft model
+     * @return this builder
      */
     public ModelParameters setModelDraft(String modelDraft) {
         parameters.put("--model-draft", modelDraft);
         return this;
     }
-    
+
     /**
      * Enable jinja for templating
+     *
+     * @return this builder
      */
     public ModelParameters enableJinja() {
         parameters.put("--jinja", null);
@@ -1030,16 +1315,22 @@ public final class ModelParameters extends CliParameters {
      * Only load the vocabulary for tokenization, no weights (default: false).
      * A model loaded with this option can only be used for {@link LlamaModel#encode(String)}
      * and {@link LlamaModel#decode(int[])}. Inference, embedding, and reranking will not work.
+     *
+     * @return this builder
      */
     public ModelParameters setVocabOnly() {
         parameters.put("--vocab-only", null);
         return this;
     }
 
+    /**
+     * Returns whether the given parameter key has not been explicitly set.
+     *
+     * @param key the parameter key without the {@code --} prefix
+     * @return {@code true} if the key is absent from the configured parameters
+     */
     public boolean isDefault(String key) {
         return !parameters.containsKey("--" + key);
     }
 
 }
-
-

--- a/src/main/java/de/kherud/llama/ModelParameters.java
+++ b/src/main/java/de/kherud/llama/ModelParameters.java
@@ -24,6 +24,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Whether to adjust unset arguments to fit in device memory (default: {@value #DEFAULT_FIT_VALUE}).
+     *
+     * @param fit whether to adjust unset arguments to fit in device memory
+     * @return this builder
      */
     public ModelParameters setFit(boolean fit) {
         parameters.put(ARG_FIT, fitValue(fit));
@@ -32,6 +35,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the number of threads to use during generation (default: -1).
+     *
+     * @param nThreads the number of threads to use during generation
+     * @return this builder
      */
     public ModelParameters setThreads(int nThreads) {
         parameters.put("--threads", String.valueOf(nThreads));
@@ -40,6 +46,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the number of threads to use during batch and prompt processing (default: same as --threads).
+     *
+     * @param nThreads the number of threads for batch and prompt processing
+     * @return this builder
      */
     public ModelParameters setThreadsBatch(int nThreads) {
         parameters.put("--threads-batch", String.valueOf(nThreads));
@@ -48,6 +57,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the CPU affinity mask: arbitrarily long hex. Complements cpu-range (default: "").
+     *
+     * @param mask the CPU affinity mask as an arbitrarily long hex string
+     * @return this builder
      */
     public ModelParameters setCpuMask(String mask) {
         parameters.put("--cpu-mask", mask);
@@ -56,6 +68,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the range of CPUs for affinity. Complements --cpu-mask.
+     *
+     * @param range the range of CPUs for affinity
+     * @return this builder
      */
     public ModelParameters setCpuRange(String range) {
         parameters.put("--cpu-range", range);
@@ -64,6 +79,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Use strict CPU placement (default: 0).
+     *
+     * @param strictCpu 1 to enable strict CPU placement, 0 to disable
+     * @return this builder
      */
     public ModelParameters setCpuStrict(int strictCpu) {
         parameters.put("--cpu-strict", String.valueOf(strictCpu));
@@ -72,6 +90,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set process/thread priority: 0-normal, 1-medium, 2-high, 3-realtime (default: 0).
+     *
+     * @param priority process/thread priority (0=normal, 1=medium, 2=high, 3=realtime)
+     * @return this builder
      */
     public ModelParameters setPriority(int priority) {
         if (priority < 0 || priority > 3) {
@@ -83,6 +104,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the polling level to wait for work (0 - no polling, default: 0).
+     *
+     * @param poll the polling level (0 = no polling)
+     * @return this builder
      */
     public ModelParameters setPoll(int poll) {
         parameters.put("--poll", String.valueOf(poll));
@@ -91,6 +115,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the CPU affinity mask for batch processing: arbitrarily long hex. Complements cpu-range-batch (default: same as --cpu-mask).
+     *
+     * @param mask the CPU affinity mask for batch processing
+     * @return this builder
      */
     public ModelParameters setCpuMaskBatch(String mask) {
         parameters.put("--cpu-mask-batch", mask);
@@ -99,6 +126,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the ranges of CPUs for batch affinity. Complements --cpu-mask-batch.
+     *
+     * @param range the ranges of CPUs for batch affinity
+     * @return this builder
      */
     public ModelParameters setCpuRangeBatch(String range) {
         parameters.put("--cpu-range-batch", range);
@@ -107,6 +137,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Use strict CPU placement for batch processing (default: same as --cpu-strict).
+     *
+     * @param strictCpuBatch 1 to enable strict CPU placement for batch processing, 0 to disable
+     * @return this builder
      */
     public ModelParameters setCpuStrictBatch(int strictCpuBatch) {
         parameters.put("--cpu-strict-batch", String.valueOf(strictCpuBatch));
@@ -115,6 +148,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set process/thread priority for batch processing: 0-normal, 1-medium, 2-high, 3-realtime (default: 0).
+     *
+     * @param priorityBatch batch process/thread priority (0=normal, 1=medium, 2=high, 3=realtime)
+     * @return this builder
      */
     public ModelParameters setPriorityBatch(int priorityBatch) {
         if (priorityBatch < 0 || priorityBatch > 3) {
@@ -126,6 +162,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the polling level for batch processing (default: same as --poll).
+     *
+     * @param pollBatch the polling level for batch processing
+     * @return this builder
      */
     public ModelParameters setPollBatch(int pollBatch) {
         parameters.put("--poll-batch", String.valueOf(pollBatch));
@@ -134,6 +173,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the size of the prompt context (default: 0, 0 = loaded from model).
+     *
+     * @param ctxSize the prompt context size in tokens (0 = loaded from model)
+     * @return this builder
      */
     public ModelParameters setCtxSize(int ctxSize) {
         parameters.put("--ctx-size", String.valueOf(ctxSize));
@@ -142,6 +184,9 @@ public final class ModelParameters extends CliParameters {
 
     /**
      * Set the number of tokens to predict (default: -1 = infinity, -2 = until context filled).
+     *
+     * @param nPredict the maximum number of tokens to predict (-1 = infinity, -2 = until context filled)
+     * @return this builder
      */
     public ModelParameters setPredict(int nPredict) {
         parameters.put("--predict", String.valueOf(nPredict));


### PR DESCRIPTION
- InferenceParameters: all 38 public setters documented
- LlamaModel: complete, generate, jsonSchemaToGrammar, rerank, applyTemplate documented
- ModelParameters: first 15 setters documented (setFit through setPredict)
- pom.xml: remove <doclint>none</doclint> from maven-javadoc-plugin

Remaining ~100 ModelParameters setters still need tags (follow-up).

https://claude.ai/code/session_01JcdEN1KgpRnbE76ZJhdF35