### PR TITLE
Upgrade llama.cpp from b8579 to b8609

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8579**
+Current llama.cpp pinned version: **b8609**
 
 ## Upgrading CUDA Version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(LLAMA_BUILD_COMMON ON)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8579
+	GIT_TAG        b8609
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)
-[![llama.cpp b8579](https://img.shields.io/badge/llama.cpp-%23b8579-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8579)
+[![llama.cpp b8609](https://img.shields.io/badge/llama.cpp-%23b8609-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8609)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 


### PR DESCRIPTION
Updated CMakeLists.txt, README.md, and CLAUDE.md to pin llama.cpp version to b8609. The existing C++ code already uses the compatible APIs for this version range.

https://claude.ai/code/session_01PEdyaueuW55WSPzWSiFHM6