### PR TITLE
Upgrade llama.cpp from b8611 to b8645

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8611**
+Current llama.cpp pinned version: **b8645**
 
 ## Upgrading CUDA Version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(LLAMA_BUILD_COMMON ON)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8611
+	GIT_TAG        b8645
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)
-[![llama.cpp b8611](https://img.shields.io/badge/llama.cpp-%23b8611-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8611)
+[![llama.cpp b8645](https://img.shields.io/badge/llama.cpp-%23b8645-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8645)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 
@@ -17,7 +17,7 @@ Inference of Meta's LLaMA model (and others) in pure C/C++.
 3. [Android](#importing-in-android)
 
 > [!NOTE]
-> Now with support for Gemma 3
+> Now with support for Gemma 3 and Gemma 4
 
 ## Download
 


### PR DESCRIPTION
Adds Gemma 4 model support (including vision, tool calling, MoE), LFM2.5 and Granite 4.0 chat templates, NVFP4 MMQ/SYCL support, flash attention for 512 head dim, and KV cache attention rotation.

https://claude.ai/code/session_017p43gV1F9TmyNXu4dz23X7