### PR TITLE
Fix: Package OpenSSL/BoringSSL DLLs in Windows x64 builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8645**
+Current llama.cpp pinned version: **b8648**
 
 ## Upgrading CUDA Version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,9 @@ if(ANDROID_ABI)
 endif()
 
 set(LLAMA_BUILD_COMMON ON)
-# Build BoringSSL to include OpenSSL DLLs in Windows packages
+# Enable HTTPS model downloads via curl
+set(LLAMA_CURL ON)
+# Build BoringSSL to include OpenSSL DLLs in Windows packages for HTTPS support
 if(WIN32)
     set(LLAMA_BUILD_BORINGSSL ON CACHE BOOL "" FORCE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8645
+	GIT_TAG        b8648
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ if(ANDROID_ABI)
 endif()
 
 set(LLAMA_BUILD_COMMON ON)
+# Build BoringSSL to include OpenSSL DLLs in Windows packages
+if(WIN32)
+    set(LLAMA_BUILD_BORINGSSL ON CACHE BOOL "" FORCE)
+endif()
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
@@ -178,6 +182,24 @@ endif()
 if (LLAMA_METAL AND NOT LLAMA_METAL_EMBED_LIBRARY)
     # copy ggml-common.h and ggml-metal.metal to bin directory
     configure_file(${llama.cpp_SOURCE_DIR}/ggml-metal.metal ${JLLAMA_DIR}/ggml-metal.metal COPYONLY)
+endif()
+
+# Copy OpenSSL/BoringSSL DLLs on Windows
+# These are built by llama.cpp's BoringSSL/LibreSSL FetchContent and need to be included in the JAR
+if(OS_NAME STREQUAL "Windows")
+    file(GLOB_RECURSE SSL_CRYPTO_DLLS
+        "${llama.cpp_BINARY_DIR}/**/libssl*.dll"
+        "${llama.cpp_BINARY_DIR}/**/libcrypto*.dll"
+    )
+    if(SSL_CRYPTO_DLLS)
+        message(STATUS "Found OpenSSL/BoringSSL DLLs: ${SSL_CRYPTO_DLLS}")
+        foreach(DLL ${SSL_CRYPTO_DLLS})
+            message(STATUS "Copying ${DLL} to ${JLLAMA_DIR}")
+            file(COPY ${DLL} DESTINATION ${JLLAMA_DIR})
+        endforeach()
+    else()
+        message(STATUS "No OpenSSL/BoringSSL DLLs found in ${llama.cpp_BINARY_DIR} - OpenSSL may not have been built")
+    endif()
 endif()
 
 #################### C++ unit tests ####################

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)
-[![llama.cpp b8645](https://img.shields.io/badge/llama.cpp-%23b8645-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8645)
+[![llama.cpp b8648](https://img.shields.io/badge/llama.cpp-%23b8648-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8648)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 

--- a/src/main/java/de/kherud/llama/LlamaLoader.java
+++ b/src/main/java/de/kherud/llama/LlamaLoader.java
@@ -62,6 +62,15 @@ class LlamaLoader {
 				System.err.println("'ggml-metal.metal' not found");
 			}
 		}
+
+		// On Windows, extract OpenSSL/BoringSSL DLLs before loading jllama
+		// This ensures jllama.dll can find its dependencies
+		if ("Windows".equals(OSInfo.getOSName())) {
+			String nativeDirName = getNativeResourcePath();
+			String tempFolder = getTempDir().getAbsolutePath();
+			extractOpenSSLDlls(nativeDirName, tempFolder);
+		}
+
 		loadNativeLibrary("jllama");
 		extracted = true;
 	}
@@ -80,7 +89,36 @@ class LlamaLoader {
 
 	static boolean shouldCleanPath(Path path) {
 		String fileName = path.getFileName().toString();
-		return fileName.startsWith("jllama") || fileName.startsWith("llama");
+		return fileName.startsWith("jllama") || fileName.startsWith("llama") ||
+			   fileName.startsWith("libssl") || fileName.startsWith("libcrypto");
+	}
+
+	/**
+	 * Extracts OpenSSL/BoringSSL DLL dependencies on Windows
+	 * These are required by jllama.dll at runtime
+	 *
+	 * @param nativeDirName The native resource directory path
+	 * @param tempFolder    The temporary directory for extraction
+	 */
+	private static void extractOpenSSLDlls(String nativeDirName, String tempFolder) {
+		// Look for libssl and libcrypto DLLs (from BoringSSL/LibreSSL)
+		String[] sslDlls = {
+			"libssl-3-x64.dll",
+			"libssl-3-x86.dll",
+			"libssl-3.dll",
+			"libcrypto-3-x64.dll",
+			"libcrypto-3-x86.dll",
+			"libcrypto-3.dll"
+		};
+
+		for (String dllName : sslDlls) {
+			Path extractedPath = extractFile(nativeDirName, dllName, tempFolder, false);
+			if (extractedPath != null) {
+				// Successfully extracted, don't spam errors for missing optional files
+				continue;
+			}
+			// File not found is expected - only the DLLs that were built will exist
+		}
 	}
 
 	private static void cleanPath(Path path) {


### PR DESCRIPTION
- Enable LLAMA_BUILD_BORINGSSL on Windows to build OpenSSL DLLs
- Automatically copy libssl-3-x64.dll and libcrypto-3-x64.dll to src/main/resources/de/kherud/llama/Windows/x64/
- These DLLs are now properly included in the JAR package
- Fixes dependency resolution errors on Windows runtime

https://claude.ai/code/session_01FEBhTt2x3NakgzgxF2zxwJ