### PR TITLE
Support OpenSSL/BoringSSL libraries across all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,21 +186,19 @@ if (LLAMA_METAL AND NOT LLAMA_METAL_EMBED_LIBRARY)
     configure_file(${llama.cpp_SOURCE_DIR}/ggml-metal.metal ${JLLAMA_DIR}/ggml-metal.metal COPYONLY)
 endif()
 
-# Copy OpenSSL/BoringSSL DLLs on Windows
+# Copy OpenSSL/BoringSSL libraries (static or shared, depending on BUILD_SHARED_LIBS)
 # These are built by llama.cpp's BoringSSL/LibreSSL FetchContent and need to be included in the JAR
-# Uses POST_BUILD so DLLs exist when the command runs
-if(OS_NAME STREQUAL "Windows")
-    if(TARGET ssl AND TARGET crypto)
-        add_custom_command(TARGET jllama POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                $<TARGET_FILE:ssl>
-                $<TARGET_FILE:crypto>
-                ${JLLAMA_DIR}
-            COMMENT "Copying OpenSSL/BoringSSL DLLs to ${JLLAMA_DIR}"
-        )
-    else()
-        message(STATUS "ssl/crypto targets not found - OpenSSL DLLs will not be bundled")
-    endif()
+# Uses POST_BUILD so libraries exist when the command runs
+if(TARGET ssl AND TARGET crypto)
+    add_custom_command(TARGET jllama POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:ssl>
+            $<TARGET_FILE:crypto>
+            ${JLLAMA_DIR}
+        COMMENT "Copying OpenSSL/BoringSSL libraries to ${JLLAMA_DIR}"
+    )
+else()
+    message(STATUS "ssl/crypto targets not found - OpenSSL libraries will not be bundled")
 endif()
 
 #################### C++ unit tests ####################

--- a/src/main/java/de/kherud/llama/LlamaLoader.java
+++ b/src/main/java/de/kherud/llama/LlamaLoader.java
@@ -94,30 +94,46 @@ class LlamaLoader {
 	}
 
 	/**
-	 * Extracts OpenSSL/BoringSSL DLL dependencies on Windows
-	 * These are required by jllama.dll at runtime
+	 * Extracts OpenSSL/BoringSSL library dependencies across all platforms
+	 * These are required by jllama at runtime
 	 *
 	 * @param nativeDirName The native resource directory path
 	 * @param tempFolder    The temporary directory for extraction
 	 */
 	private static void extractOpenSSLDlls(String nativeDirName, String tempFolder) {
-		// Look for libssl and libcrypto DLLs (from BoringSSL/LibreSSL)
-		String[] sslDlls = {
+		// Look for libssl and libcrypto libraries (from BoringSSL/LibreSSL)
+		// Windows: .dll (runtime), .lib (import library)
+		// Linux: .a (static), .so (shared)
+		// macOS: .dylib (dynamic), .a (static)
+		String[] sslLibraries = {
+			// Windows DLLs
 			"libssl-3-x64.dll",
 			"libssl-3-x86.dll",
 			"libssl-3.dll",
 			"libcrypto-3-x64.dll",
 			"libcrypto-3-x86.dll",
-			"libcrypto-3.dll"
+			"libcrypto-3.dll",
+			// Windows import libraries
+			"ssl.lib",
+			"crypto.lib",
+			// Linux static libraries
+			"libssl.a",
+			"libcrypto.a",
+			// Linux shared libraries
+			"libssl.so",
+			"libcrypto.so",
+			// macOS dynamic libraries
+			"libssl.dylib",
+			"libcrypto.dylib"
 		};
 
-		for (String dllName : sslDlls) {
-			Path extractedPath = extractFile(nativeDirName, dllName, tempFolder, false);
+		for (String libName : sslLibraries) {
+			Path extractedPath = extractFile(nativeDirName, libName, tempFolder, false);
 			if (extractedPath != null) {
 				// Successfully extracted, don't spam errors for missing optional files
 				continue;
 			}
-			// File not found is expected - only the DLLs that were built will exist
+			// File not found is expected - only the libraries that were built will exist
 		}
 	}
 


### PR DESCRIPTION
- CMakeLists.txt: Remove Windows-only check, copy libraries on all platforms (Windows: .lib/.dll, Linux: .a/.so, macOS: .dylib/.a)
- LlamaLoader.java: Extend extractOpenSSLDlls() to extract all library types across Windows, Linux, and macOS

$<TARGET_FILE:ssl> and $<TARGET_FILE:crypto> work on all platforms and resolve to the appropriate library file type for each OS.

https://claude.ai/code/session_01FEBhTt2x3NakgzgxF2zxwJ