### PR TITLE
Upgrade llama.cpp b8648 → b8664; expose KV cache idle-eviction API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8648**
+Current llama.cpp pinned version: **b8664**
 
 ## Upgrading CUDA Version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8648
+	GIT_TAG        b8664
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)
-[![llama.cpp b8648](https://img.shields.io/badge/llama.cpp-%23b8648-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8648)
+![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
+[![llama.cpp b8664](https://img.shields.io/badge/llama.cpp-%23b8664-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8664)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 

--- a/src/main/java/de/kherud/llama/ModelParameters.java
+++ b/src/main/java/de/kherud/llama/ModelParameters.java
@@ -1359,6 +1359,60 @@ public final class ModelParameters extends CliParameters {
     }
 
     /**
+     * Enable or disable a single unified KV buffer shared across all sequences.
+     * <p>
+     * When enabled (the default when the number of slots is set to auto), all parallel slots
+     * share one contiguous KV buffer which enables features such as cross-slot cache reuse
+     * ({@link #setCacheRamMib}) and idle-slot eviction ({@link #setClearIdle}).
+     *
+     * @param kvUnified {@code true} to enable unified KV, {@code false} to disable
+     * @return this builder
+     */
+    public ModelParameters setKvUnified(boolean kvUnified) {
+        parameters.put(kvUnified ? "--kv-unified" : "--no-kv-unified", null);
+        parameters.remove(kvUnified ? "--no-kv-unified" : "--kv-unified");
+        return this;
+    }
+
+    /**
+     * Set the maximum RAM cache size in MiB used to store saved slot KV state.
+     * <p>
+     * Requires {@link #setKvUnified(boolean) unified KV} to be enabled.
+     * Set to {@code -1} for no limit, {@code 0} to disable (default: 8192 MiB).
+     * Together with {@link #setClearIdle} this allows idle slots to be evicted
+     * from GPU/CPU memory and restored quickly on the next matching request.
+     *
+     * @param cacheRamMib maximum cache size in MiB, or {@code -1} for unlimited
+     * @return this builder
+     */
+    public ModelParameters setCacheRamMib(int cacheRamMib) {
+        parameters.put("--cache-ram", String.valueOf(cacheRamMib));
+        return this;
+    }
+
+    /**
+     * Enable or disable saving and clearing idle slots when a new task starts.
+     * <p>
+     * When enabled (the default), idle slots have their KV state saved to the
+     * RAM cache ({@link #setCacheRamMib}) and are then cleared, freeing GPU/CPU
+     * memory for the active request.  The saved state is transparently restored
+     * on the next request that shares the same prompt prefix, so cache-hit
+     * latency is preserved.
+     * <p>
+     * Requires {@link #setKvUnified(boolean) unified KV} and a non-zero
+     * {@link #setCacheRamMib RAM cache}.  If either dependency is absent the
+     * server logs a warning and silently disables the feature.
+     *
+     * @param clearIdle {@code true} to enable idle-slot eviction (default), {@code false} to disable
+     * @return this builder
+     */
+    public ModelParameters setClearIdle(boolean clearIdle) {
+        parameters.put(clearIdle ? "--clear-idle" : "--no-clear-idle", null);
+        parameters.remove(clearIdle ? "--no-clear-idle" : "--clear-idle");
+        return this;
+    }
+
+    /**
      * Returns whether the given parameter key has not been explicitly set.
      *
      * @param key the parameter key without the {@code --} prefix

--- a/src/test/java/de/kherud/llama/ModelParametersExtendedTest.java
+++ b/src/test/java/de/kherud/llama/ModelParametersExtendedTest.java
@@ -409,6 +409,117 @@ public class ModelParametersExtendedTest {
         assertNull(p.parameters.get("--dump-kv-cache"));
     }
 
+    @Test
+    public void testSetKvUnifiedTrue() {
+        ModelParameters p = new ModelParameters().setKvUnified(true);
+        assertTrue(p.parameters.containsKey("--kv-unified"));
+        assertNull(p.parameters.get("--kv-unified"));
+        assertFalse(p.parameters.containsKey("--no-kv-unified"));
+    }
+
+    @Test
+    public void testSetKvUnifiedFalse() {
+        ModelParameters p = new ModelParameters().setKvUnified(false);
+        assertTrue(p.parameters.containsKey("--no-kv-unified"));
+        assertNull(p.parameters.get("--no-kv-unified"));
+        assertFalse(p.parameters.containsKey("--kv-unified"));
+    }
+
+    @Test
+    public void testSetKvUnifiedFlipFromTrueToFalse() {
+        ModelParameters p = new ModelParameters().setKvUnified(true).setKvUnified(false);
+        assertTrue(p.parameters.containsKey("--no-kv-unified"));
+        assertFalse(p.parameters.containsKey("--kv-unified"));
+    }
+
+    @Test
+    public void testSetKvUnifiedFlipFromFalseToTrue() {
+        ModelParameters p = new ModelParameters().setKvUnified(false).setKvUnified(true);
+        assertTrue(p.parameters.containsKey("--kv-unified"));
+        assertFalse(p.parameters.containsKey("--no-kv-unified"));
+    }
+
+    @Test
+    public void testSetCacheRamMib() {
+        ModelParameters p = new ModelParameters().setCacheRamMib(4096);
+        assertEquals("4096", p.parameters.get("--cache-ram"));
+    }
+
+    @Test
+    public void testSetCacheRamMibUnlimited() {
+        ModelParameters p = new ModelParameters().setCacheRamMib(-1);
+        assertEquals("-1", p.parameters.get("--cache-ram"));
+    }
+
+    @Test
+    public void testSetCacheRamMibDisabled() {
+        ModelParameters p = new ModelParameters().setCacheRamMib(0);
+        assertEquals("0", p.parameters.get("--cache-ram"));
+    }
+
+    @Test
+    public void testSetClearIdleTrue() {
+        ModelParameters p = new ModelParameters().setClearIdle(true);
+        assertTrue(p.parameters.containsKey("--clear-idle"));
+        assertNull(p.parameters.get("--clear-idle"));
+        assertFalse(p.parameters.containsKey("--no-clear-idle"));
+    }
+
+    @Test
+    public void testSetClearIdleFalse() {
+        ModelParameters p = new ModelParameters().setClearIdle(false);
+        assertTrue(p.parameters.containsKey("--no-clear-idle"));
+        assertNull(p.parameters.get("--no-clear-idle"));
+        assertFalse(p.parameters.containsKey("--clear-idle"));
+    }
+
+    @Test
+    public void testSetClearIdleFlipFromTrueToFalse() {
+        ModelParameters p = new ModelParameters().setClearIdle(true).setClearIdle(false);
+        assertTrue(p.parameters.containsKey("--no-clear-idle"));
+        assertFalse(p.parameters.containsKey("--clear-idle"));
+    }
+
+    @Test
+    public void testSetClearIdleFlipFromFalseToTrue() {
+        ModelParameters p = new ModelParameters().setClearIdle(false).setClearIdle(true);
+        assertTrue(p.parameters.containsKey("--clear-idle"));
+        assertFalse(p.parameters.containsKey("--no-clear-idle"));
+    }
+
+    @Test
+    public void testKvUnifiedCacheRamClearIdleChaining() {
+        // All three features wired together as they would be in production use
+        ModelParameters p = new ModelParameters()
+                .setKvUnified(true)
+                .setCacheRamMib(8192)
+                .setClearIdle(true);
+        assertTrue(p.parameters.containsKey("--kv-unified"));
+        assertEquals("8192", p.parameters.get("--cache-ram"));
+        assertTrue(p.parameters.containsKey("--clear-idle"));
+        // Opposite flags must be absent
+        assertFalse(p.parameters.containsKey("--no-kv-unified"));
+        assertFalse(p.parameters.containsKey("--no-clear-idle"));
+    }
+
+    @Test
+    public void testSetKvUnifiedReturnsSameInstance() {
+        ModelParameters p = new ModelParameters();
+        assertSame(p, p.setKvUnified(true));
+    }
+
+    @Test
+    public void testSetCacheRamMibReturnsSameInstance() {
+        ModelParameters p = new ModelParameters();
+        assertSame(p, p.setCacheRamMib(4096));
+    }
+
+    @Test
+    public void testSetClearIdleReturnsSameInstance() {
+        ModelParameters p = new ModelParameters();
+        assertSame(p, p.setClearIdle(true));
+    }
+
     // -------------------------------------------------------------------------
     // GPU / Split mode
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Version bump:
- CMakeLists.txt GIT_TAG b8648 → b8664
- README.md llama.cpp badge and link updated
- CLAUDE.md pinned version updated
- README.md Java badge corrected from 11+ to 8+ (pom.xml already targets 1.8)

New ModelParameters setters (all three work together to enable idle-slot eviction, a b8664 feature that saves KV state of idle slots to RAM and restores on cache-hit, freeing GPU memory between requests):
- setKvUnified(boolean)  → --kv-unified / --no-kv-unified
- setCacheRamMib(int)    → --cache-ram N (MiB; -1=unlimited, 0=disabled)
- setClearIdle(boolean)  → --clear-idle / --no-clear-idle (new in b8664)

Both boolean setters remove the opposite flag so flip calls are safe. All three are covered by 13 new unit tests in ModelParametersExtendedTest.

https://claude.ai/code/session_01UqHGktHkNpEri7QLZE5cjr