### PR TITLE
Move results.reserve() into collect_task_results_impl

### DIFF
--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -269,7 +269,6 @@ static int require_single_task_id(JNIEnv *env,
         server_context *ctx_server,
         const std::unordered_set<int> &task_ids) {
     std::vector<server_task_result_ptr> results;
-    results.reserve(task_ids.size());
     if (!collect_task_results(env, ctx_server, task_ids, results)) return nullptr;
     return results_to_jstring(env, results);
 }
@@ -913,7 +912,6 @@ JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_handleRerank(JNIEnv *e
     const auto task_ids = dispatch_tasks(ctx_server, tasks);
 
     std::vector<server_task_result_ptr> results;
-    results.reserve(task_ids.size());
     if (!collect_task_results(env, ctx_server, task_ids, results)) return nullptr;
 
     return json_to_jstring(env, rerank_results_to_json(results, document_vector));
@@ -1222,7 +1220,6 @@ JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_handleEmbeddings(JNIEn
     const auto task_ids = dispatch_tasks(ctx_server, tasks);
 
     std::vector<server_task_result_ptr> results;
-    results.reserve(task_ids.size());
     if (!collect_task_results(env, ctx_server, task_ids, results)) return nullptr;
 
     json responses = json::array();

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -1250,18 +1250,7 @@ JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_handleTokenize(JNIEnv 
     if (with_pieces) {
         for (const auto &token : tokens) {
             std::string piece = common_token_to_piece(ctx_server->ctx, token);
-            json piece_json;
-
-            if (is_valid_utf8(piece)) {
-                piece_json = piece;
-            } else {
-                piece_json = json::array();
-                for (unsigned char c : piece) {
-                    piece_json.push_back(static_cast<int>(c));
-                }
-            }
-
-            tokens_response.push_back({{"id", token}, {"piece", piece_json}});
+            tokens_response.push_back({{"id", token}, {"piece", token_piece_value(piece)}});
         }
     } else {
         tokens_response = tokens;

--- a/src/main/cpp/jni_server_helpers.hpp
+++ b/src/main/cpp/jni_server_helpers.hpp
@@ -175,6 +175,7 @@
                                        const std::unordered_set<int>       &task_ids,
                                        std::vector<server_task_result_ptr> &out,
                                        jclass                               error_class) {
+    out.reserve(task_ids.size());
     for (size_t i = 0; i < task_ids.size(); i++) {
         server_task_result_ptr result = queue.recv(task_ids);
         if (result->is_error()) {

--- a/src/main/cpp/server.hpp
+++ b/src/main/cpp/server.hpp
@@ -627,14 +627,10 @@ struct completion_token_output {
     json to_json(bool post_sampling_probs) const {
         json probs_for_token = json::array();
         for (const auto &p : probs) {
-            std::string txt(p.txt);
-            txt.resize(validate_utf8(txt));
-            probs_for_token.push_back(json{
-                {"id", p.tok},
-                {"token", txt},
-                {"bytes", str_to_bytes(p.txt)},
-                {post_sampling_probs ? "prob" : "logprob", post_sampling_probs ? p.prob : logarithm(p.prob)},
-            });
+            json entry = token_piece_oai_fields(p.txt);
+            entry["id"] = p.tok;
+            entry[post_sampling_probs ? "prob" : "logprob"] = post_sampling_probs ? p.prob : logarithm(p.prob);
+            probs_for_token.push_back(entry);
         }
         return probs_for_token;
     }
@@ -642,15 +638,11 @@ struct completion_token_output {
     static json probs_vector_to_json(const std::vector<completion_token_output> &probs, bool post_sampling_probs) {
         json out = json::array();
         for (const auto &p : probs) {
-            std::string txt(p.text_to_send);
-            txt.resize(validate_utf8(txt));
-            out.push_back(json{
-                {"id", p.tok},
-                {"token", txt},
-                {"bytes", str_to_bytes(p.text_to_send)},
-                {post_sampling_probs ? "prob" : "logprob", post_sampling_probs ? p.prob : logarithm(p.prob)},
-                {post_sampling_probs ? "top_probs" : "top_logprobs", p.to_json(post_sampling_probs)},
-            });
+            json entry = token_piece_oai_fields(p.text_to_send);
+            entry["id"] = p.tok;
+            entry[post_sampling_probs ? "prob" : "logprob"] = post_sampling_probs ? p.prob : logarithm(p.prob);
+            entry[post_sampling_probs ? "top_probs" : "top_logprobs"] = p.to_json(post_sampling_probs);
+            out.push_back(entry);
         }
         return out;
     }
@@ -658,15 +650,6 @@ struct completion_token_output {
     static float logarithm(float x) {
         // nlohmann::json converts -inf to null, so we need to prevent that
         return x == 0.0f ? std::numeric_limits<float>::lowest() : std::log(x);
-    }
-
-    static std::vector<unsigned char> str_to_bytes(const std::string &str) {
-        std::vector<unsigned char> bytes;
-        bytes.reserve(str.size());
-        for (unsigned char c : str) {
-            bytes.push_back(c);
-        }
-        return bytes;
     }
 };
 

--- a/src/main/cpp/utils.hpp
+++ b/src/main/cpp/utils.hpp
@@ -262,6 +262,38 @@ static size_t validate_utf8(const std::string &text) {
     return len;
 }
 
+static bool is_valid_utf8(const std::string &str) {
+    const unsigned char *bytes = reinterpret_cast<const unsigned char *>(str.data());
+    const unsigned char *end = bytes + str.length();
+
+    while (bytes < end) {
+        if (*bytes <= 0x7F) {
+            // 1-byte sequence (0xxxxxxx)
+            bytes++;
+        } else if ((*bytes & 0xE0) == 0xC0) {
+            // 2-byte sequence (110xxxxx 10xxxxxx)
+            if (end - bytes < 2 || (bytes[1] & 0xC0) != 0x80)
+                return false;
+            bytes += 2;
+        } else if ((*bytes & 0xF0) == 0xE0) {
+            // 3-byte sequence (1110xxxx 10xxxxxx 10xxxxxx)
+            if (end - bytes < 3 || (bytes[1] & 0xC0) != 0x80 || (bytes[2] & 0xC0) != 0x80)
+                return false;
+            bytes += 3;
+        } else if ((*bytes & 0xF8) == 0xF0) {
+            // 4-byte sequence (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
+            if (end - bytes < 4 || (bytes[1] & 0xC0) != 0x80 || (bytes[2] & 0xC0) != 0x80 || (bytes[3] & 0xC0) != 0x80)
+                return false;
+            bytes += 4;
+        } else {
+            // Invalid UTF-8 lead byte
+            return false;
+        }
+    }
+
+    return true;
+}
+
 // ---------------------------------------------------------------------------
 // Token-piece JSON serialisation helpers
 //
@@ -974,38 +1006,6 @@ static json format_response_rerank(const json &request, const json &ranks, bool 
                    {"results", results}};
 
     return res;
-}
-
-static bool is_valid_utf8(const std::string &str) {
-    const unsigned char *bytes = reinterpret_cast<const unsigned char *>(str.data());
-    const unsigned char *end = bytes + str.length();
-
-    while (bytes < end) {
-        if (*bytes <= 0x7F) {
-            // 1-byte sequence (0xxxxxxx)
-            bytes++;
-        } else if ((*bytes & 0xE0) == 0xC0) {
-            // 2-byte sequence (110xxxxx 10xxxxxx)
-            if (end - bytes < 2 || (bytes[1] & 0xC0) != 0x80)
-                return false;
-            bytes += 2;
-        } else if ((*bytes & 0xF0) == 0xE0) {
-            // 3-byte sequence (1110xxxx 10xxxxxx 10xxxxxx)
-            if (end - bytes < 3 || (bytes[1] & 0xC0) != 0x80 || (bytes[2] & 0xC0) != 0x80)
-                return false;
-            bytes += 3;
-        } else if ((*bytes & 0xF8) == 0xF0) {
-            // 4-byte sequence (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
-            if (end - bytes < 4 || (bytes[1] & 0xC0) != 0x80 || (bytes[2] & 0xC0) != 0x80 || (bytes[3] & 0xC0) != 0x80)
-                return false;
-            bytes += 4;
-        } else {
-            // Invalid UTF-8 lead byte
-            return false;
-        }
-    }
-
-    return true;
 }
 
 static json format_tokenizer_response(const json &tokens) { return json{{"tokens", tokens}}; }

--- a/src/main/cpp/utils.hpp
+++ b/src/main/cpp/utils.hpp
@@ -262,6 +262,73 @@ static size_t validate_utf8(const std::string &text) {
     return len;
 }
 
+// ---------------------------------------------------------------------------
+// Token-piece JSON serialisation helpers
+//
+// There are two distinct wire formats for representing a token piece that may
+// not be valid UTF-8, used in different parts of the API.  The helpers below
+// implement each format exactly once and are documented so the two are never
+// accidentally conflated.
+//
+// 1. token_piece_value()   — llama.cpp /tokenize endpoint (native format)
+//    Schema  : a single JSON value that is EITHER a string OR a byte array.
+//    Use for : handleTokenize, and any endpoint that follows the llama.cpp
+//              /tokenize wire format.
+//    Example : {"id": 123, "piece": "hello"}
+//              {"id": 456, "piece": [195, 169]}
+//
+// 2. token_piece_oai_fields() — OpenAI completion probabilities format
+//    Schema  : a partial JSON object with BOTH "token" (truncated UTF-8
+//              string) AND "bytes" (full raw-byte array) always present.
+//    Use for : completion_token_output::to_json / probs_vector_to_json, and
+//              any endpoint that follows the OpenAI logprobs wire format.
+//    Example : {"token": "hell", "bytes": [104,101,108,108,111], ...}
+//
+// Shared building block used by both:
+//
+// 3. str_to_bytes() — converts every byte of a string to an int in a JSON
+//    array.  Used directly by token_piece_value (invalid-UTF-8 branch) and
+//    token_piece_oai_fields ("bytes" field).
+// ---------------------------------------------------------------------------
+
+// Converts every byte of `str` to its integer value and returns them as a
+// JSON array.  The raw bytes are preserved exactly — no UTF-8 truncation.
+static json str_to_bytes(const std::string &str) {
+    json bytes = json::array();
+    bytes.get_ref<json::array_t &>().reserve(str.size());
+    for (unsigned char c : str) {
+        bytes.push_back(static_cast<int>(c));
+    }
+    return bytes;
+}
+
+// Returns the JSON value for the "piece" key in a llama.cpp /tokenize
+// response.  Valid UTF-8 pieces become a JSON string; invalid ones become a
+// JSON array of byte values (via str_to_bytes).
+//
+// NEVER use this for completion probability responses — use
+// token_piece_oai_fields() instead, which always emits both "token" and
+// "bytes" per the OpenAI spec.
+static json token_piece_value(const std::string &piece) {
+    if (is_valid_utf8(piece)) {
+        return piece;
+    }
+    return str_to_bytes(piece);
+}
+
+// Returns a partial JSON object {"token": <truncated-utf8>, "bytes": <raw>}
+// for use in OpenAI-compatible completion probability responses.
+// "token" is always a string (piece truncated at the last valid UTF-8
+// boundary).  "bytes" is always the full raw-byte array via str_to_bytes.
+//
+// NEVER use this for /tokenize responses — use token_piece_value() instead,
+// which follows the llama.cpp native "piece" field schema.
+static json token_piece_oai_fields(const std::string &piece) {
+    std::string txt = piece;
+    txt.resize(validate_utf8(txt));
+    return json{{"token", txt}, {"bytes", str_to_bytes(piece)}};
+}
+
 //
 // template utils
 //

--- a/src/test/cpp/test_server.cpp
+++ b/src/test/cpp/test_server.cpp
@@ -288,23 +288,23 @@ TEST(CompletionTokenOutput, Logarithm_PositiveIsNaturalLog) {
     EXPECT_NEAR(completion_token_output::logarithm(std::exp(1.0f)), 1.0f, 1e-5f);
 }
 
-TEST(CompletionTokenOutput, StrToBytes_AsciiChars) {
-    auto bytes = completion_token_output::str_to_bytes("ABC");
+TEST(StrToBytes, AsciiChars) {
+    json bytes = str_to_bytes("ABC");
     ASSERT_EQ(bytes.size(), 3u);
-    EXPECT_EQ(bytes[0], static_cast<unsigned char>('A'));
-    EXPECT_EQ(bytes[1], static_cast<unsigned char>('B'));
-    EXPECT_EQ(bytes[2], static_cast<unsigned char>('C'));
+    EXPECT_EQ(bytes[0].get<int>(), static_cast<int>('A'));
+    EXPECT_EQ(bytes[1].get<int>(), static_cast<int>('B'));
+    EXPECT_EQ(bytes[2].get<int>(), static_cast<int>('C'));
 }
 
-TEST(CompletionTokenOutput, StrToBytes_EmptyString) {
-    EXPECT_TRUE(completion_token_output::str_to_bytes("").empty());
+TEST(StrToBytes, EmptyString) {
+    EXPECT_TRUE(str_to_bytes("").empty());
 }
 
-TEST(CompletionTokenOutput, StrToBytes_HighBytes) {
+TEST(StrToBytes, HighByte) {
     // Byte 0xFF must survive the conversion unchanged
-    auto bytes = completion_token_output::str_to_bytes("\xFF");
+    json bytes = str_to_bytes("\xFF");
     ASSERT_EQ(bytes.size(), 1u);
-    EXPECT_EQ(bytes[0], static_cast<unsigned char>(0xFF));
+    EXPECT_EQ(bytes[0].get<int>(), 0xFF);
 }
 
 TEST(CompletionTokenOutput, ToJson_PostSampling_UsesProbLabel) {


### PR DESCRIPTION
The three call sites (collect_and_serialize, handleRerank, handleEmbeddings) all preceded collect_task_results with an identical results.reserve(task_ids.size()) line. The impl already receives both out and task_ids, so it can reserve internally, making the pattern impossible to forget at future call sites.

https://claude.ai/code/session_01EToYgwXD4DPqpiDuCT3kiT