### PR TITLE
Replace collect_and_serialize with dispatch_and_collect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,12 @@ endif()
 # but are needed for GCC/Clang where each flag independently adds its
 # -m flag and GGML_* preprocessor define.
 #
+# BMI2 is enabled on 64-bit targets only.  MSVC's 32-bit (x86) compiler
+# does not expose __pdep_u64 / __pext_u64; ggml's quants.c uses them in
+# _ggml_vec_dot_iq1_m_q8_K, causing an unresolved-external link error.
+# GCC/Clang on x86 can lower the 64-bit intrinsics to two 32-bit ops,
+# but disabling BMI2 entirely is safer and consistent across compilers.
+#
 # AVX-512 stays OFF:
 #   - Many CPUs lack it (AMD EPYC 7763, all Intel desktop since Alder Lake).
 #   - MSVC's /arch:AVX512 applies to the entire TU — no per-function gating.
@@ -80,7 +86,11 @@ set(GGML_NATIVE  OFF CACHE BOOL "" FORCE)
 set(GGML_SSE42   ON  CACHE BOOL "" FORCE)
 set(GGML_AVX     ON  CACHE BOOL "" FORCE)
 set(GGML_AVX2    ON  CACHE BOOL "" FORCE)
-set(GGML_BMI2    ON  CACHE BOOL "" FORCE)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(GGML_BMI2 ON  CACHE BOOL "" FORCE)
+else()
+    set(GGML_BMI2 OFF CACHE BOOL "" FORCE)
+endif()
 set(GGML_FMA     ON  CACHE BOOL "" FORCE)
 set(GGML_F16C    ON  CACHE BOOL "" FORCE)
 set(GGML_AVX512  OFF CACHE BOOL "" FORCE)

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -249,27 +249,25 @@ static int require_single_task_id(JNIEnv *env,
 }
 
 /**
- * Collect all results for the given task IDs from the server response queue,
- * then serialise them to a JNI string.
+ * Dispatch tasks and collect all results into `out`.
  *
- * Combines the repeated four-line pipeline used by handleCompletions,
- * handleCompletionsOai, handleChatCompletions, and handleInfill:
+ * Combines the repeated three-line pipeline used by embed, handleRerank,
+ * handleEmbeddings, and dispatch_completion_and_serialize:
  *
+ *   const auto task_ids = dispatch_tasks(ctx_server, tasks);
  *   std::vector<server_task_result_ptr> results;
- *   results.reserve(task_ids.size());
  *   if (!collect_task_results(env, ctx_server, task_ids, results)) return nullptr;
- *   return results_to_jstring(env, results);
  *
  * On error (collect_task_results returns false): a JNI exception is already
- * pending; this function returns nullptr so the caller can propagate it.
+ * pending; returns false so the caller can propagate it.
  */
-[[nodiscard]] static jstring collect_and_serialize(
-        JNIEnv *env,
-        server_context *ctx_server,
-        const std::unordered_set<int> &task_ids) {
-    std::vector<server_task_result_ptr> results;
-    if (!collect_task_results(env, ctx_server, task_ids, results)) return nullptr;
-    return results_to_jstring(env, results);
+[[nodiscard]] static bool dispatch_and_collect(
+        JNIEnv                              *env,
+        server_context                      *ctx_server,
+        std::vector<server_task>             tasks,
+        std::vector<server_task_result_ptr> &out) {
+    const auto task_ids = dispatch_tasks(ctx_server, std::move(tasks));
+    return collect_task_results(env, ctx_server, task_ids, out);
 }
 
 /**
@@ -291,8 +289,9 @@ static int require_single_task_id(JNIEnv *env,
     std::vector<server_task> tasks;
     if (!build_completion_tasks(env, ctx_server, data, completion_id,
                                  task_type, oaicompat, tasks)) return nullptr;
-    const auto task_ids = dispatch_tasks(ctx_server, tasks);
-    return collect_and_serialize(env, ctx_server, task_ids);
+    std::vector<server_task_result_ptr> results;
+    if (!dispatch_and_collect(env, ctx_server, std::move(tasks), results)) return nullptr;
+    return results_to_jstring(env, results);
 }
 
 /**
@@ -864,9 +863,8 @@ JNIEXPORT jfloatArray JNICALL Java_de_kherud_llama_LlamaModel_embed(JNIEnv *env,
     std::vector<server_task> tasks;
     append_task(ctx_server, tasks, SERVER_TASK_TYPE_EMBEDDING, tokens, 0);
 
-    const auto task_ids = dispatch_tasks(ctx_server, tasks);
     std::vector<server_task_result_ptr> results;
-    if (!collect_task_results(env, ctx_server, task_ids, results)) return nullptr;
+    if (!dispatch_and_collect(env, ctx_server, std::move(tasks), results)) return nullptr;
 
     std::vector<float> first_row;
     try {
@@ -907,10 +905,8 @@ JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_handleRerank(JNIEnv *e
         append_task(ctx_server, tasks, SERVER_TASK_TYPE_RERANK,
                     format_rerank(ctx_server->vocab, tokenized_query, tokenized_docs[i]), i);
     }
-    const auto task_ids = dispatch_tasks(ctx_server, tasks);
-
     std::vector<server_task_result_ptr> results;
-    if (!collect_task_results(env, ctx_server, task_ids, results)) return nullptr;
+    if (!dispatch_and_collect(env, ctx_server, std::move(tasks), results)) return nullptr;
 
     return json_to_jstring(env, rerank_results_to_json(results, document_vector));
 }
@@ -1165,10 +1161,8 @@ JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_handleEmbeddings(JNIEn
         append_task(ctx_server, tasks, SERVER_TASK_TYPE_EMBEDDING, tokenized_prompts[i], i, oaicompat);
     }
 
-    const auto task_ids = dispatch_tasks(ctx_server, tasks);
-
     std::vector<server_task_result_ptr> results;
-    if (!collect_task_results(env, ctx_server, task_ids, results)) return nullptr;
+    if (!dispatch_and_collect(env, ctx_server, std::move(tasks), results)) return nullptr;
 
     return json_to_jstring(env, build_embeddings_response_json(results, body, oaicompat, use_base64));
 }

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -266,7 +266,7 @@ static int require_single_task_id(JNIEnv *env,
         server_context                      *ctx_server,
         std::vector<server_task>             tasks,
         std::vector<server_task_result_ptr> &out) {
-    const auto task_ids = dispatch_tasks(ctx_server, std::move(tasks));
+    const auto task_ids = dispatch_tasks(ctx_server, tasks);
     return collect_task_results(env, ctx_server, task_ids, out);
 }
 


### PR DESCRIPTION
collect_and_serialize (collect + serialize) was called by only one site and couldn't be reused by embed, handleRerank, or handleEmbeddings because each uses a different serializer.

Extract dispatch_and_collect (dispatch + collect, no serialize) instead. All four dispatch sites now share the same helper; the intermediate task_ids variable is gone from each call site; and collect_and_serialize is removed (no remaining callers).

https://claude.ai/code/session_01XPfyTeJHwWYYjPv4FdzQEo