### PR TITLE
Extract duplicate logic to reduce LOC across C++ and Java

### DIFF
--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -351,6 +351,19 @@ static json parse_json_params(JNIEnv *env, jstring jparams) {
 }
 
 /**
+ * Throws if the model was not loaded with embedding support.  Returns false
+ * (after throwing) when embedding is unavailable, true otherwise.
+ */
+[[nodiscard]] static bool require_embedding_support(JNIEnv *env, server_context *ctx_server) {
+    if (!ctx_server->params_base.embedding) {
+        env->ThrowNew(c_llama_error,
+                      "Model was not loaded with embedding support (see ModelParameters#setEmbedding(boolean))");
+        return false;
+    }
+    return true;
+}
+
+/**
  * Validates `jfilename`, builds a SAVE or RESTORE slot task, dispatches it,
  * and returns the result as a jstring.  Shared by the SAVE (case 1) and
  * RESTORE (case 2) branches of handleSlotAction, which are identical except
@@ -849,11 +862,7 @@ JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_receiveCompletionJson(
 JNIEXPORT jfloatArray JNICALL Java_de_kherud_llama_LlamaModel_embed(JNIEnv *env, jobject obj, jstring jprompt) {
     REQUIRE_SERVER_CONTEXT(nullptr);
 
-    if (!ctx_server->params_base.embedding) {
-        env->ThrowNew(c_llama_error,
-                      "model was not loaded with embedding support (see ModelParameters#setEmbedding(boolean))");
-        return nullptr;
-    }
+    if (!require_embedding_support(env, ctx_server)) return nullptr;
 
     const std::string prompt = parse_jstring(env, jprompt);
 
@@ -1117,11 +1126,7 @@ JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_handleEmbeddings(JNIEn
                                                                            jstring jparams, jboolean joaiCompat) {
     REQUIRE_SERVER_CONTEXT(nullptr);
 
-    if (!ctx_server->params_base.embedding) {
-        env->ThrowNew(c_llama_error,
-                      "Model was not loaded with embedding support (see ModelParameters#enableEmbedding())");
-        return nullptr;
-    }
+    if (!require_embedding_support(env, ctx_server)) return nullptr;
 
     oaicompat_type oaicompat = joaiCompat ? OAICOMPAT_TYPE_EMBEDDING : OAICOMPAT_TYPE_NONE;
 

--- a/src/main/cpp/jni_helpers.hpp
+++ b/src/main/cpp/jni_helpers.hpp
@@ -353,48 +353,46 @@ inline void append_task(server_context           *ctx_server,
 }
 
 // ---------------------------------------------------------------------------
-// embedding_to_jfloat_array_impl
+// vec_to_jarray_impl
 //
-// Converts a float vector to a Java jfloatArray.
-//
-// On success: returns a new jfloatArray filled with the embedding values.
+// Generic helper: converts a C++ vector to a JNI primitive array.
+// Parameterized on JNI array/element types and the alloc/copy member fns.
 // On allocation failure: throws via JNI with oom_class and returns nullptr.
 // ---------------------------------------------------------------------------
+template <typename JArray, typename JElem, typename CppElem>
+[[nodiscard]] inline JArray vec_to_jarray_impl(
+        JNIEnv                     *env,
+        const std::vector<CppElem> &values,
+        jclass                      oom_class,
+        const char                 *oom_msg,
+        JArray (JNIEnv_::*alloc)(jsize),
+        void (JNIEnv_::*copy)(JArray, jsize, jsize, const JElem *)) {
+    const jsize len = static_cast<jsize>(values.size());
+    JArray arr = (env->*alloc)(len);
+    if (arr == nullptr) {
+        env->ThrowNew(oom_class, oom_msg);
+        return nullptr;
+    }
+    (env->*copy)(arr, 0, len, reinterpret_cast<const JElem *>(values.data()));
+    return arr;
+}
+
+// Converts a float vector to a Java jfloatArray.
 [[nodiscard]] inline jfloatArray embedding_to_jfloat_array_impl(
         JNIEnv                   *env,
         const std::vector<float> &values,
         jclass                    oom_class) {
-    const jsize len = static_cast<jsize>(values.size());
-    jfloatArray arr = env->NewFloatArray(len);
-    if (arr == nullptr) {
-        env->ThrowNew(oom_class, "could not allocate embedding");
-        return nullptr;
-    }
-    env->SetFloatArrayRegion(arr, 0, len,
-                             reinterpret_cast<const jfloat *>(values.data()));
-    return arr;
+    return vec_to_jarray_impl<jfloatArray, jfloat>(
+            env, values, oom_class, "could not allocate embedding",
+            &JNIEnv_::NewFloatArray, &JNIEnv_::SetFloatArrayRegion);
 }
 
-// ---------------------------------------------------------------------------
-// tokens_to_jint_array_impl
-//
-// Converts a token vector to a Java jintArray.  Symmetric with
-// embedding_to_jfloat_array_impl for the int (token) case.
-//
-// On success: returns a new jintArray filled with the token values.
-// On allocation failure: throws via JNI with oom_class and returns nullptr.
-// ---------------------------------------------------------------------------
+// Converts a token vector to a Java jintArray.
 [[nodiscard]] inline jintArray tokens_to_jint_array_impl(
         JNIEnv                       *env,
         const std::vector<int32_t>   &tokens,
         jclass                        oom_class) {
-    const jsize len = static_cast<jsize>(tokens.size());
-    jintArray arr = env->NewIntArray(len);
-    if (arr == nullptr) {
-        env->ThrowNew(oom_class, "could not allocate token memory");
-        return nullptr;
-    }
-    env->SetIntArrayRegion(arr, 0, len,
-                           reinterpret_cast<const jint *>(tokens.data()));
-    return arr;
+    return vec_to_jarray_impl<jintArray, jint>(
+            env, tokens, oom_class, "could not allocate token memory",
+            &JNIEnv_::NewIntArray, &JNIEnv_::SetIntArrayRegion);
 }

--- a/src/main/java/de/kherud/llama/InferenceParameters.java
+++ b/src/main/java/de/kherud/llama/InferenceParameters.java
@@ -408,23 +408,7 @@ public final class InferenceParameters extends JsonParameters {
 	 */
 	public InferenceParameters setTokenIdBias(Map<Integer, Float> logitBias) {
 		if (!logitBias.isEmpty()) {
-			StringBuilder builder = new StringBuilder();
-			builder.append("[");
-			int i = 0;
-			for (Map.Entry<Integer, Float> entry : logitBias.entrySet()) {
-				Integer key = entry.getKey();
-				Float value = entry.getValue();
-				builder.append("[")
-						.append(key)
-						.append(", ")
-						.append(value)
-						.append("]");
-				if (i++ < logitBias.size() - 1) {
-					builder.append(", ");
-				}
-			}
-			builder.append("]");
-			parameters.put(PARAM_LOGIT_BIAS, builder.toString());
+			parameters.put(PARAM_LOGIT_BIAS, buildBiasPairArray(logitBias, String::valueOf));
 		}
 		return this;
 	}
@@ -444,21 +428,7 @@ public final class InferenceParameters extends JsonParameters {
 	 */
 	public InferenceParameters disableTokenIds(Collection<Integer> tokenIds) {
 		if (!tokenIds.isEmpty()) {
-			StringBuilder builder = new StringBuilder();
-			builder.append("[");
-			int i = 0;
-			for (Integer token : tokenIds) {
-				builder.append("[")
-						.append(token)
-						.append(", ")
-						.append(false)
-						.append("]");
-				if (i++ < tokenIds.size() - 1) {
-					builder.append(", ");
-				}
-			}
-			builder.append("]");
-			parameters.put(PARAM_LOGIT_BIAS, builder.toString());
+			parameters.put(PARAM_LOGIT_BIAS, buildDisablePairArray(tokenIds, String::valueOf));
 		}
 		return this;
 	}
@@ -478,23 +448,7 @@ public final class InferenceParameters extends JsonParameters {
 	 */
 	public InferenceParameters setTokenBias(Map<String, Float> logitBias) {
 		if (!logitBias.isEmpty()) {
-			StringBuilder builder = new StringBuilder();
-			builder.append("[");
-			int i = 0;
-			for (Map.Entry<String, Float> entry : logitBias.entrySet()) {
-				String key = entry.getKey();
-				Float value = entry.getValue();
-				builder.append("[")
-						.append(toJsonString(key))
-						.append(", ")
-						.append(value)
-						.append("]");
-				if (i++ < logitBias.size() - 1) {
-					builder.append(", ");
-				}
-			}
-			builder.append("]");
-			parameters.put(PARAM_LOGIT_BIAS, builder.toString());
+			parameters.put(PARAM_LOGIT_BIAS, buildBiasPairArray(logitBias, this::toJsonString));
 		}
 		return this;
 	}
@@ -514,21 +468,7 @@ public final class InferenceParameters extends JsonParameters {
 	 */
 	public InferenceParameters disableTokens(Collection<String> tokens) {
 		if (!tokens.isEmpty()) {
-			StringBuilder builder = new StringBuilder();
-			builder.append("[");
-			int i = 0;
-			for (String token : tokens) {
-				builder.append("[")
-						.append(toJsonString(token))
-						.append(", ")
-						.append(false)
-						.append("]");
-				if (i++ < tokens.size() - 1) {
-					builder.append(", ");
-				}
-			}
-			builder.append("]");
-			parameters.put(PARAM_LOGIT_BIAS, builder.toString());
+			parameters.put(PARAM_LOGIT_BIAS, buildDisablePairArray(tokens, this::toJsonString));
 		}
 		return this;
 	}
@@ -627,15 +567,7 @@ public final class InferenceParameters extends JsonParameters {
 	 * @return this builder
 	 */
 	public InferenceParameters setChatTemplateKwargs(java.util.Map<String, String> kwargs) {
-		StringBuilder sb = new StringBuilder("{");
-		boolean first = true;
-		for (java.util.Map.Entry<String, String> entry : kwargs.entrySet()) {
-			if (!first) sb.append(",");
-			sb.append("\"").append(entry.getKey()).append("\":").append(entry.getValue());
-			first = false;
-		}
-		sb.append("}");
-		parameters.put(PARAM_CHAT_TEMPLATE_KWARGS, sb.toString());
+		parameters.put(PARAM_CHAT_TEMPLATE_KWARGS, mapToJsonObject(kwargs));
 		return this;
 	}
 
@@ -693,6 +625,40 @@ public final class InferenceParameters extends JsonParameters {
 	InferenceParameters setStream(boolean stream) {
 		parameters.put(PARAM_STREAM, String.valueOf(stream));
 		return this;
+	}
+
+	private static <K, V> String buildBiasPairArray(Map<K, V> map,
+			java.util.function.Function<K, String> keySerializer) {
+		StringBuilder builder = new StringBuilder("[");
+		int i = 0;
+		for (Map.Entry<K, V> entry : map.entrySet()) {
+			builder.append("[")
+					.append(keySerializer.apply(entry.getKey()))
+					.append(", ")
+					.append(entry.getValue())
+					.append("]");
+			if (i++ < map.size() - 1) {
+				builder.append(", ");
+			}
+		}
+		builder.append("]");
+		return builder.toString();
+	}
+
+	private static <T> String buildDisablePairArray(Collection<T> items,
+			java.util.function.Function<T, String> serializer) {
+		StringBuilder builder = new StringBuilder("[");
+		int i = 0;
+		for (T item : items) {
+			builder.append("[")
+					.append(serializer.apply(item))
+					.append(", false]");
+			if (i++ < items.size() - 1) {
+				builder.append(", ");
+			}
+		}
+		builder.append("]");
+		return builder.toString();
 	}
 
 }

--- a/src/main/java/de/kherud/llama/JsonParameters.java
+++ b/src/main/java/de/kherud/llama/JsonParameters.java
@@ -35,6 +35,18 @@ abstract class JsonParameters {
 		return builder.toString();
 	}
 
+	static String mapToJsonObject(Map<String, String> map) {
+		StringBuilder sb = new StringBuilder("{");
+		boolean first = true;
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			if (!first) sb.append(",");
+			sb.append("\"").append(entry.getKey()).append("\":").append(entry.getValue());
+			first = false;
+		}
+		sb.append("}");
+		return sb.toString();
+	}
+
 	// taken from org.json.JSONObject#quote(String, Writer)
 	String toJsonString(String text) {
 		if (text == null) return null;

--- a/src/main/java/de/kherud/llama/ModelParameters.java
+++ b/src/main/java/de/kherud/llama/ModelParameters.java
@@ -1164,15 +1164,7 @@ public final class ModelParameters extends CliParameters {
      * @return this builder
      */
     public ModelParameters setChatTemplateKwargs(java.util.Map<String, String> kwargs) {
-        StringBuilder sb = new StringBuilder("{");
-        boolean first = true;
-        for (java.util.Map.Entry<String, String> entry : kwargs.entrySet()) {
-            if (!first) sb.append(",");
-            sb.append("\"").append(entry.getKey()).append("\":").append(entry.getValue());
-            first = false;
-        }
-        sb.append("}");
-        parameters.put("--chat-template-kwargs", sb.toString());
+        parameters.put("--chat-template-kwargs", JsonParameters.mapToJsonObject(kwargs));
         return this;
     }
 


### PR DESCRIPTION
- jni_helpers.hpp: deduplicate embedding_to_jfloat_array_impl and tokens_to_jint_array_impl via a shared vec_to_jarray_impl template
- jllama.cpp: extract require_embedding_support() guard used by embed() and handleEmbeddings()
- JsonParameters.java: add mapToJsonObject() utility for map-to-JSON serialization, used by both setChatTemplateKwargs implementations
- InferenceParameters.java: extract buildBiasPairArray() and buildDisablePairArray() helpers to deduplicate four near-identical token bias serialization methods

https://claude.ai/code/session_01AGrb17h4jLeWr1de6RGubX