### PR TITLE
Upgrade llama.cpp from b8757 to b8762

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8757**
+Current llama.cpp pinned version: **b8762**
 
 ## Upgrading CUDA Version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(GGML_AVX512  OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8757
+	GIT_TAG        b8762
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
-[![llama.cpp b8757](https://img.shields.io/badge/llama.cpp-%23b8757-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8757)
+[![llama.cpp b8762](https://img.shields.io/badge/llama.cpp-%23b8762-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8762)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 


### PR DESCRIPTION
No API changes required — the patch adds Q5_K OpenCL acceleration, Q1_0 CPU op support, MERaLiON2 audio model support, and Qwen3Next view fixes, all internal to llama.cpp with no public header changes.

https://claude.ai/code/session_01KAy4Adh55fLBNMjaiMMxxi