### PR TITLE
Upgrade llama.cpp from b8831 to b8838

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8831**
+Current llama.cpp pinned version: **b8838**
 
 ## Upgrading CUDA Version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(GGML_AVX512  OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8831
+	GIT_TAG        b8838
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
-[![llama.cpp b8831](https://img.shields.io/badge/llama.cpp-%23b8831-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8831)
+[![llama.cpp b8838](https://img.shields.io/badge/llama.cpp-%23b8838-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8838)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 


### PR DESCRIPTION
No C++ changes needed: b8831→b8838 contains only internal ggml/CUDA/WebGPU refactoring, CI workflow additions, and CPU-only memory-fitting improvements in src/llama.cpp. No public header API changes affect this project.

https://claude.ai/code/session_011Ng1rVpZswncx1hWjjoHB1