### PR TITLE
Claude/update b8841 compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b8838**
+Current llama.cpp pinned version: **b8841**
 
 ## Upgrading CUDA Version
 
@@ -137,7 +137,7 @@ Also review the project `CMakeLists.txt` for build-system-level breaks (e.g. ren
 `ggml/include/ggml.h`, `ggml/include/ggml-backend.h`, `ggml/include/ggml-opt.h`,
 `ggml-alloc.h`, `ggml-cpu.h`, `peg-parser.h`, `base64.hpp`
 
-**Known breaking changes by version range** (b5022 → b8831):
+**Known breaking changes by version range** (b5022 → b8841):
 
 | Version | File | Change |
 |---------|------|--------|
@@ -155,6 +155,7 @@ Also review the project `CMakeLists.txt` for build-system-level breaks (e.g. ren
 | ~b8808–b8831 | project `CMakeLists.txt` | CMake target `common` renamed to `llama-common`; update `target_link_libraries` for `jllama` and `jllama_test` |
 | ~b8808–b8831 | `common/common.h` → new `common/build-info.h` | `build_info` `std::string` removed; replaced by `llama_build_info()` (`const char*`) in new `build-info.h`; add `#include "build-info.h"` in `server.hpp` and `utils.hpp`; call sites: `std::string(llama_build_info())` in `server.hpp` (6×), `llama_build_info()` in `jllama.cpp` (1×) and `utils.hpp` (1×) |
 | ~b8808–b8831 | `ggml/src/ggml.c` | New `ggml_graph_next_uid()` calls `_InterlockedIncrement64` via `<intrin.h>` on x86; intrinsic unavailable on 32-bit MSVC; fix: `src/main/cpp/compat/ggml_x86_compat.c` provides `__cdecl _InterlockedIncrement64` via `InterlockedIncrement64` (CMPXCHG8B), added to `ggml-base` via `target_sources` guarded by `MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4` |
+| ~b8838–b8841 | `src/llama-model.h` | Attention bias fields renamed: `bq`→`wq_b`, `bk`→`wk_b`, `bv`→`wv_b`, `bo`→`wo_b`, `bqkv`→`wqkv_b`; internal to llama.cpp, no impact on this project |
 
 ## Build Commands
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(GGML_AVX512  OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b8838
+	GIT_TAG        b8841
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
-[![llama.cpp b8838](https://img.shields.io/badge/llama.cpp-%23b8838-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8838)
+[![llama.cpp b8841](https://img.shields.io/badge/llama.cpp-%23b8841-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b8841)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
 			<version>24.1.0</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.19.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -820,6 +820,11 @@ JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_loadModel(JNIEnv *env, jo
     env->SetLongField(obj, f_model_pointer, reinterpret_cast<jlong>(jctx));
 }
 
+JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_getModelMetaJson(JNIEnv *env, jobject obj) {
+    REQUIRE_SERVER_CONTEXT(nullptr);
+    return json_to_jstring(env, ctx_server->model_meta());
+}
+
 JNIEXPORT jint JNICALL Java_de_kherud_llama_LlamaModel_requestCompletion(JNIEnv *env, jobject obj, jstring jparams) {
     REQUIRE_SERVER_CONTEXT(0);
 

--- a/src/main/cpp/jllama.h
+++ b/src/main/cpp/jllama.h
@@ -128,6 +128,13 @@ JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_handleSlotAction(JNIEn
 
 JNIEXPORT jboolean JNICALL Java_de_kherud_llama_LlamaModel_configureParallelInference(JNIEnv *, jobject, jstring);
 
+/*
+ * Class:     de_kherud_llama_LlamaModel
+ * Method:    getModelMetaJson
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_de_kherud_llama_LlamaModel_getModelMetaJson(JNIEnv *, jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/cpp/server.hpp
+++ b/src/main/cpp/server.hpp
@@ -3625,9 +3625,16 @@ struct server_context {
 
     json model_meta() const {
         return json{
-            {"vocab_type", llama_vocab_type(vocab)},         {"n_vocab", llama_vocab_n_tokens(vocab)},
-            {"n_ctx_train", llama_model_n_ctx_train(model)}, {"n_embd", llama_model_n_embd(model)},
-            {"n_params", llama_model_n_params(model)},       {"size", llama_model_size(model)},
+            {"vocab_type",  llama_vocab_type(vocab)},
+            {"n_vocab",     llama_vocab_n_tokens(vocab)},
+            {"n_ctx_train", llama_model_n_ctx_train(model)},
+            {"n_embd",      llama_model_n_embd(model)},
+            {"n_params",    llama_model_n_params(model)},
+            {"size",        llama_model_size(model)},
+            {"modalities",  json{
+                {"vision", mctx ? mtmd_support_vision(mctx) : false},
+                {"audio",  mctx ? mtmd_support_audio(mctx)  : false},
+            }},
         };
     }
 };

--- a/src/main/java/de/kherud/llama/LlamaModel.java
+++ b/src/main/java/de/kherud/llama/LlamaModel.java
@@ -316,6 +316,31 @@ public class LlamaModel implements AutoCloseable {
 		return handleSlotAction(0, 0, null);
 	}
 
+	private static final com.fasterxml.jackson.databind.ObjectMapper OBJECT_MAPPER =
+			new com.fasterxml.jackson.databind.ObjectMapper();
+
+	/**
+	 * Returns model metadata with typed accessors for vocab, context, embedding,
+	 * parameter count, size, and modality support flags (vision, audio).
+	 * <p>
+	 * The returned {@link ModelMeta} wraps the raw JSON from the native layer.
+	 * Call {@link ModelMeta#toString()} to re-serialize to compact JSON for use
+	 * in {@code assertEquals}.
+	 * </p>
+	 *
+	 * @return {@link ModelMeta} parsed from the native {@code model_meta()} response
+	 * @throws LlamaException if the native call fails or the response cannot be parsed
+	 */
+	public ModelMeta getModelMeta() throws LlamaException {
+		try {
+			return new ModelMeta(OBJECT_MAPPER.readTree(getModelMetaJson()));
+		} catch (java.io.IOException e) {
+			throw new LlamaException("Failed to parse model meta JSON: " + e.getMessage());
+		}
+	}
+
+	native String getModelMetaJson() throws LlamaException;
+
 	/**
 	 * Erase the KV cache for a specific slot.
 	 *

--- a/src/main/java/de/kherud/llama/ModelMeta.java
+++ b/src/main/java/de/kherud/llama/ModelMeta.java
@@ -1,0 +1,76 @@
+package de.kherud.llama;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Model metadata returned by {@link LlamaModel#getModelMeta()}.
+ * <p>
+ * Typed getters cover all fields currently returned by the native {@code model_meta()}
+ * function. The underlying {@link JsonNode} is also exposed via {@link #asJson()} so
+ * that future fields added on the C++ side remain accessible without code changes.
+ * </p>
+ * <p>{@link #toString()} re-serializes to compact JSON and is suitable for
+ * {@code assertEquals} in unit tests.</p>
+ */
+public final class ModelMeta {
+
+    private final JsonNode node;
+
+    ModelMeta(JsonNode node) {
+        this.node = node;
+    }
+
+    /** Vocabulary type identifier (e.g. SPM = 2, BPE = 1). */
+    public int getVocabType() {
+        return node.path("vocab_type").asInt(0);
+    }
+
+    /** Total number of tokens in the model vocabulary. */
+    public int getNVocab() {
+        return node.path("n_vocab").asInt(0);
+    }
+
+    /** Context length the model was trained with. */
+    public int getNCtxTrain() {
+        return node.path("n_ctx_train").asInt(0);
+    }
+
+    /** Embedding dimension of the model. */
+    public int getNEmbd() {
+        return node.path("n_embd").asInt(0);
+    }
+
+    /** Total number of model parameters. */
+    public long getNParams() {
+        return node.path("n_params").asLong(0L);
+    }
+
+    /** Model file size in bytes. */
+    public long getSize() {
+        return node.path("size").asLong(0L);
+    }
+
+    /** Returns true if the model supports vision (image) input. */
+    public boolean supportsVision() {
+        return node.at("/modalities/vision").asBoolean(false);
+    }
+
+    /** Returns true if the model supports audio input. */
+    public boolean supportsAudio() {
+        return node.at("/modalities/audio").asBoolean(false);
+    }
+
+    /**
+     * Returns the underlying {@link JsonNode} for direct access to any field,
+     * including fields added in future llama.cpp versions.
+     */
+    public JsonNode asJson() {
+        return node;
+    }
+
+    /** Re-serializes to compact JSON. Suitable for {@code assertEquals} in tests. */
+    @Override
+    public String toString() {
+        return node.toString();
+    }
+}

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -926,4 +926,42 @@ public class LlamaModelTest {
 			Assert.assertFalse("Expected non-empty response from speculative complete", response.isEmpty());
 		}
 	}
+
+	@Test
+	public void testGetModelMeta() throws LlamaException {
+		ModelMeta meta = model.getModelMeta();
+
+		// Typed getters — exact values depend on the loaded model; fill in after first run
+		Assert.assertTrue("n_vocab must be positive", meta.getNVocab() > 0);
+		Assert.assertTrue("n_ctx_train must be positive", meta.getNCtxTrain() > 0);
+		Assert.assertTrue("n_embd must be positive", meta.getNEmbd() > 0);
+		Assert.assertTrue("n_params must be positive", meta.getNParams() > 0);
+		Assert.assertTrue("size must be positive", meta.getSize() > 0);
+
+		// CodeLlama (text-only model) must not report multimodal support
+		Assert.assertFalse("text-only model must not report vision support", meta.supportsVision());
+		Assert.assertFalse("text-only model must not report audio support", meta.supportsAudio());
+
+		// Dynamic access via the underlying JsonNode
+		Assert.assertTrue("modalities field must be present", meta.asJson().has("modalities"));
+		Assert.assertTrue("vocab_type field must be present", meta.asJson().has("vocab_type"));
+
+		// Round-trip: toString() must produce valid compact JSON containing all top-level keys
+		String json = meta.toString();
+		Assert.assertNotNull(json);
+		Assert.assertTrue(json.contains("\"vocab_type\""));
+		Assert.assertTrue(json.contains("\"n_vocab\""));
+		Assert.assertTrue(json.contains("\"n_ctx_train\""));
+		Assert.assertTrue(json.contains("\"n_embd\""));
+		Assert.assertTrue(json.contains("\"n_params\""));
+		Assert.assertTrue(json.contains("\"size\""));
+		Assert.assertTrue(json.contains("\"modalities\""));
+		Assert.assertTrue(json.contains("\"vision\""));
+		Assert.assertTrue(json.contains("\"audio\""));
+
+		// Uncomment and fill in after running once to pin exact values:
+		// Assert.assertEquals("{\"vocab_type\":2,\"n_vocab\":32016,\"n_ctx_train\":16384,"
+		//         + "\"n_embd\":4096,\"n_params\":6738415616,\"size\":2744325024,"
+		//         + "\"modalities\":{\"vision\":false,\"audio\":false}}", json);
+	}
 }

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -960,8 +960,8 @@ public class LlamaModelTest {
 		Assert.assertTrue(json.contains("\"audio\""));
 
 		// Fill in the expected value from the failure message and re-run to pin exact output:
-		Assert.assertEquals("{\"vocab_type\":2,\"n_vocab\":32016,\"n_ctx_train\":16384,"
-				+ "\"n_embd\":4096,\"n_params\":6738415616,\"size\":2744325024,"
+		Assert.assertEquals("{\"vocab_type\":1,\"n_vocab\":32016,\"n_ctx_train\":16384,"
+				+ "\"n_embd\":4096,\"n_params\":6738546688,\"size\":2825274880,"
 				+ "\"modalities\":{\"vision\":false,\"audio\":false}}", json);
 	}
 }

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -959,9 +959,9 @@ public class LlamaModelTest {
 		Assert.assertTrue(json.contains("\"vision\""));
 		Assert.assertTrue(json.contains("\"audio\""));
 
-		// Uncomment and fill in after running once to pin exact values:
-		// Assert.assertEquals("{\"vocab_type\":2,\"n_vocab\":32016,\"n_ctx_train\":16384,"
-		//         + "\"n_embd\":4096,\"n_params\":6738415616,\"size\":2744325024,"
-		//         + "\"modalities\":{\"vision\":false,\"audio\":false}}", json);
+		// Fill in the expected value from the failure message and re-run to pin exact output:
+		Assert.assertEquals("{\"vocab_type\":2,\"n_vocab\":32016,\"n_ctx_train\":16384,"
+				+ "\"n_embd\":4096,\"n_params\":6738415616,\"size\":2744325024,"
+				+ "\"modalities\":{\"vision\":false,\"audio\":false}}", json);
 	}
 }


### PR DESCRIPTION
## Upgrade llama.cpp b8838 → b8841 + ModelMeta API
### Summary
- Bump llama.cpp from b8838 to b8841
- Add `ModelMeta` Java class exposing typed accessors for all `model_meta()` fields
- Expose model modalities (vision / audio) via `model_meta()` in the C++ layer
- Fix: add `getModelMetaJson` to `jllama.h` so the JNI symbol gets C linkage
### llama.cpp b8838 → b8841 patch analysis
The patch is a pure internal refactor with **no breaking changes** to this project:
| Change | Impact |
|--------|--------|
| `llama_layer` attention bias fields renamed (`bq/bk/bv/bo/bqkv` → `wq_b/wk_b/wv_b/wo_b/wqkv_b`) | Internal to llama.cpp; this project never references `llama_layer` |
| `ggml-rpc` transport extracted into `transport.cpp`/`transport.h` (pimpl) | Not used by this project |
| `server-context.cpp` adds `media_marker` to `/props` response | Requires `server-common.h` not included in our `server.hpp`; skipped |
| `is_sleeping` slot field | No infrastructure in our adapted `server.hpp`; skipped |
### ModelMeta API
New `LlamaModel#getModelMeta()` returns a `ModelMeta` object wrapping the JSON from the
native `model_meta()` function. The wrapper provides:
- **Typed getters**: `getNVocab()`, `getNCtxTrain()`, `getNEmbd()`, `getNParams()`,
  `getSize()`, `getVocabType()`, `supportsVision()`, `supportsAudio()`
- **Dynamic fallback**: `asJson()` exposes the raw `JsonNode` for any future fields
  added on the C++ side without requiring Java changes
- **Round-trip serialization**: `toString()` re-serializes to compact JSON, making
  `assertEquals(expectedJson, meta.toString())` straightforward in unit tests
Jackson 2.x (`jackson-databind:2.19.0`) was chosen over Jackson 3.x for Java 8
compatibility. Only the new `ModelMeta` path uses it.
```java
ModelMeta meta = model.getModelMeta();
System.out.println(meta.getNVocab());       // 32016
System.out.println(meta.getNCtxTrain());    // 16384
System.out.println(meta.supportsVision());  // false (text-only model)
System.out.println(meta.toString());        // compact JSON for assertEquals
```
### Modalities in `model_meta()`
`server.hpp::model_meta()` now includes a `modalities` object, querying
`mtmd_support_vision(mctx)` / `mtmd_support_audio(mctx)` (both already called
internally by the server for other purposes):
```javascript
{
  "vocab_type": 1,
  "n_vocab": 32016,
  "n_ctx_train": 16384,
  "n_embd": 4096,
  "n_params": 6738546688,
  "size": 2825274880,
  "modalities": { "vision": false, "audio": false }
}
```
### Bug fix: `jllama.h` missing `getModelMetaJson` declaration
`jllama.cpp` includes `jllama.h` (the auto-generated JNI header) for its `extern "C"`
block. Every native method in `LlamaModel.java` must have a forward declaration in
this header; otherwise the C++ compiler applies name mangling and the JVM cannot
find the symbol at runtime (`UnsatisfiedLinkError`). The header was not regenerated
after `getModelMetaJson` was added to `LlamaModel.java`, so the declaration was
missing. Fixed by adding it manually (consistent with the other hand-written entries
at the bottom of the file).
### Test plan
- [x] `mvn compile` — Java compiles cleanly; JNI header up to date
- [x] `cmake -B build && cmake --build build --config Release` — native library builds with b8841
- [x] `mvn test -Dtest=LlamaModelTest` — all existing tests pass; `testGetModelMeta` passes with pinned JSON values
- [x] `mvn test` — full suite: 581 tests run, 0 failures, 0 errors
