### PR TITLE
Upgrade llama.cpp from b9022 to b9049

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b9022**
+Current llama.cpp pinned version: **b9049**
 
 ## Upgrading CUDA Version
 
@@ -257,6 +257,14 @@ Also review the project `CMakeLists.txt` for build-system-level breaks (e.g. ren
 | ~b9016–b9022 | `common/reasoning-budget.cpp` | Forced token logit now set to `+INFINITY` (previously left at whatever the model computed); reasoning budget enforcement is now absolute; upstream only, no project changes required |
 | ~b9016–b9022 | `common/chat.cpp` | `thinking_start_tag` and `thinking_end_tag` now trimmed via `trim_whitespace()`; upstream only, no project changes required |
 | ~b9016–b9022 | `examples/diffusion/` | `diffusion_generate` extracted from `diffusion-cli.cpp` to new `diffusion.h`/`diffusion.cpp` static library; enum names prefixed: `ORIGIN`→`DIFFUSION_ALGORITHM_ORIGIN`, `TIMESTEP_BASED`→`DIFFUSION_TRANSFER_SCHEDULE_TIMESTEP_BASED` etc.; examples only, no project changes required |
+| ~b9022–b9049 | `include/llama.h` | New `LLAMA_STATE_SEQ_FLAGS_ON_DEVICE 2` macro added alongside existing `LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY 1`; enables on-device KV cache state save/restore without host round-trip via `llama_state_seq_get_size_ext`/`get_data_ext`/`set_data_ext`; no project call-site changes required (not used by JNI layer) |
+| ~b9022–b9049 | `src/llama-context.cpp` | State seq data format breaking change: `llama_state_seq_get_data`/`set_data` now prepend a 4-byte magic (`0xaf143cd8`) + 4-byte `seq_id` header; state data saved with ≤b9022 is **incompatible** with b9049+; internal I/O classes renamed `llama_io_write_buffer`→`llama_io_write_host`, `llama_io_read_buffer`→`llama_io_read_host`; new `llama_io_write_device`/`llama_io_read_device` classes for on-device paths; no project changes required (not called by JNI layer) |
+| ~b9022–b9049 | `ggml/include/ggml.h` | New `ggml_op_hint` enum (`GGML_HINT_DEFAULT=0`, `GGML_HINT_SRC0_IS_HADAMARD=1`) and `ggml_mul_mat_set_hint()` function added for FWHT (Fast Walsh-Hadamard Transform) support; used internally in `llama-graph.cpp` / `llama-kv-cache.cpp`; no project call-site changes required |
+| ~b9022–b9049 | `src/llama.cpp` | `llama_backend_init()` now auto-calls `ggml_backend_load_all()` if no backends are yet registered; `ggml_backend_load_all()` removed from `common_params_parser_init()` (was in `common/arg.cpp`); no project changes required — backend loading still happens correctly |
+| ~b9022–b9049 | `tools/server/server-context.cpp` | `server_prompt_checkpoint_update()` gained an `on_device` bool parameter; speculative checkpoints now use `LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY \| LLAMA_STATE_SEQ_FLAGS_ON_DEVICE`; compiled directly into jllama from upstream source — no project call-site changes required |
+| ~b9022–b9049 | `src/llama-model.cpp` | Unsupported model architecture now throws `std::runtime_error` instead of calling `GGML_ABORT`; allows callers to catch unknown-arch errors gracefully; no project changes required |
+| ~b9022–b9049 | `ggml/CMakeLists.txt` | GGML version bumped 0.10.2 → 0.11.0; no project changes required |
+| ~b9022–b9049 | `vendor/cpp-httplib/` | Updated to 0.43.3: `str2tag` converted to iterative loop (eliminates recursion stack depth risk), `res.body.reserve` now OOM-safe; upstream server header, no project changes required |
 
 ## Build Commands
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(GGML_AVX512  OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b9022
+	GIT_TAG        b9049
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
-[![llama.cpp b9022](https://img.shields.io/badge/llama.cpp-%23b9022-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9022)
+[![llama.cpp b9049](https://img.shields.io/badge/llama.cpp-%23b9049-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9049)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 


### PR DESCRIPTION
## Summary
This PR upgrades the pinned llama.cpp dependency from version b9022 to b9049, incorporating upstream improvements and new features for KV cache state management, FWHT support, and backend initialization.

## Key Changes

- **KV Cache State Management**: New `LLAMA_STATE_SEQ_FLAGS_ON_DEVICE` flag enables on-device KV cache state save/restore without host round-trips. State data format now includes 4-byte magic header and seq_id, making saved state from b9022 incompatible with b9049+.

- **FWHT Support**: New `ggml_op_hint` enum and `ggml_mul_mat_set_hint()` function added for Fast Walsh-Hadamard Transform support in graph operations.

- **Backend Initialization**: `llama_backend_init()` now automatically calls `ggml_backend_load_all()` if no backends are registered, simplifying initialization flow.

- **Error Handling**: Unsupported model architectures now throw `std::runtime_error` instead of calling `GGML_ABORT`, allowing graceful error handling by callers.

- **Speculative Decoding**: Server context checkpoints now support on-device state flags for improved speculative decoding performance.

- **Dependencies**: GGML version bumped from 0.10.2 to 0.11.0; cpp-httplib updated to 0.43.3 with recursion elimination and OOM-safe improvements.

## Notes
No JNI layer call-site changes are required. The new on-device state features and FWHT hints are not currently used by the Java bindings but are available for future optimization.

https://claude.ai/code/session_01TZ2Gvm2dyeRVoy5dCzMXNn