### PR TITLE
Add automatic snapshot release workflow on master push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,7 @@
 name: Build, Test and Release
 on:
+  push:
+    branches: [ master ]
   pull_request:
   workflow_dispatch:
     inputs:
@@ -583,6 +585,32 @@ jobs:
         with:
           name: llama-jars
           path: target/*.jar
+
+  publish-snapshot:
+    name: Publish Snapshot to GitHub Releases
+    needs: [ package ]
+    if: github.event_name == 'push' && needs.package.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: llama-jars
+          path: snapshot-jars/
+      - name: Publish rolling snapshot release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release delete snapshot --yes --cleanup-tag || true
+          gh release create snapshot snapshot-jars/*.jar \
+            --title "Snapshot Build" \
+            --notes "Auto-generated snapshot build from commit ${{ github.sha }}.
+
+          [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" \
+            --prerelease \
+            --target ${{ github.sha }}
 
   publish:
     # Manual dispatch must set BOTH release_to_maven_central=true AND


### PR DESCRIPTION
## Summary
This PR adds an automated snapshot release workflow that publishes JAR artifacts to GitHub Releases whenever code is pushed to the master branch.

## Key Changes
- **Trigger on master push**: Added `push` event trigger to the release workflow that activates on commits to the master branch
- **New snapshot publishing job**: Added `publish-snapshot` job that:
  - Runs after successful package job completion
  - Downloads the built JAR artifacts
  - Deletes the previous snapshot release and tag
  - Creates a new rolling snapshot release with the current build artifacts
  - Tags the release as a prerelease pointing to the current commit
  - Includes workflow run link in release notes for traceability

## Implementation Details
- The snapshot job only runs on `push` events to master (not on pull requests or manual dispatch)
- Uses GitHub CLI (`gh`) to manage the snapshot release lifecycle
- The snapshot release is always recreated, replacing the previous one (rolling release pattern)
- Includes proper permissions configuration (`contents: write`) for release management
- Release notes automatically include the commit SHA and link to the workflow run for easy debugging

https://claude.ai/code/session_014bbPDNVsvvcWDK3eWaWZdt