### PR TITLE
Add snapshot publishing to GitHub Packages and README snapshot section

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -586,13 +586,15 @@ jobs:
           path: target/*.jar
 
   publish-snapshot:
-    name: Publish Snapshot to GitHub Releases
+    name: Publish Snapshot to GitHub Releases and GitHub Packages
     needs: [ package ]
     if: github.event_name == 'push' && needs.package.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v6
         with:
           name: llama-jars
@@ -608,6 +610,26 @@ jobs:
             --notes "Snapshot from ${{ github.sha }} — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --prerelease \
             --target ${{ github.sha }}
+      - name: Set up Maven for GitHub Packages
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+      - name: Publish to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          mvn --batch-mode deploy:deploy-file \
+            -Durl=https://maven.pkg.github.com/${{ github.repository }} \
+            -DrepositoryId=github \
+            -Dfile=snapshot-jars/llama-${VERSION}.jar \
+            -DpomFile=pom.xml \
+            -Dsources=snapshot-jars/llama-${VERSION}-sources.jar \
+            -Djavadoc=snapshot-jars/llama-${VERSION}-javadoc.jar
 
   publish:
     if: ${{ github.event_name == 'release' || (github.event.inputs.release_to_maven_central == 'true' && needs.crosscompile-linux-x86_64-cuda.outputs.built == 'true') }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
 [![llama.cpp b9049](https://img.shields.io/badge/llama.cpp-%23b9049-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9049)
+[![Snapshot](https://img.shields.io/badge/snapshot-latest-informational)](https://github.com/bernardladenthin/java-llama.cpp/releases/tag/snapshot)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 
@@ -33,7 +34,7 @@ Inference of Meta's LLaMA model (and others) in pure C/C++.
 
 ## Quick Start
 
-Access this library via Maven:
+Access this library via Maven (released versions on Maven Central):
 
 ```xml
 <dependency>
@@ -44,6 +45,42 @@ Access this library via Maven:
 ```
 
 There are multiple [examples](src/test/java/examples).
+
+### Snapshot builds
+
+Every push to `master` publishes a snapshot to [GitHub Packages](https://github.com/bernardladenthin/java-llama.cpp/packages) and attaches JARs to the [snapshot release](https://github.com/bernardladenthin/java-llama.cpp/releases/tag/snapshot).
+
+To use the snapshot as a Maven dependency, add the repository and a GitHub token to your `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github-java-llama</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>  <!-- token needs read:packages scope -->
+    </server>
+  </servers>
+</settings>
+```
+
+Then add to your `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>github-java-llama</id>
+    <url>https://maven.pkg.github.com/bernardladenthin/java-llama.cpp</url>
+    <snapshots><enabled>true</enabled></snapshots>
+  </repository>
+</repositories>
+
+<dependency>
+    <groupId>net.ladenthin</groupId>
+    <artifactId>llama</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+</dependency>
+```
 
 ### No Setup required
 


### PR DESCRIPTION
- publish-snapshot now also deploys to GitHub Packages (Maven registry) using deploy:deploy-file with the pre-built JARs from the package job; no native rebuild needed — uploads main, sources, and javadoc JARs
- Add packages:write permission and checkout step to publish-snapshot
- README: add snapshot badge linking to the rolling releases/tag/snapshot page and a new "Snapshot builds" section documenting GitHub Packages usage with the required settings.xml / pom.xml snippets

https://claude.ai/code/session_014bbPDNVsvvcWDK3eWaWZdt