### PR TITLE
Add read-only permissions to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ env:
   RERANKING_MODEL_NAME: "jina-reranker-v1-tiny-en-Q4_0.gguf"
   DRAFT_MODEL_URL: "https://huggingface.co/QuantFactory/AMD-Llama-135m-code-GGUF/resolve/main/AMD-Llama-135m-code.Q2_K.gguf"
   DRAFT_MODEL_NAME: "AMD-Llama-135m-code.Q2_K.gguf"
+permissions:
+  contents: read
 jobs:
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This change adds explicit permission configuration to the release workflow to follow GitHub Actions security best practices by implementing the principle of least privilege.

## Key Changes
- Added `permissions` section to the release workflow with `contents: read` access level
- This restricts the workflow to read-only access to repository contents, preventing unintended modifications

## Implementation Details
The `permissions: contents: read` configuration ensures that the release workflow can only read repository contents and cannot make changes to the codebase, which is appropriate for a release workflow that should primarily be reading configuration and model information rather than modifying repository state.

https://claude.ai/code/session_018GqGrJWwE6Fhw9UPy6ViEv