### PR TITLE
fix: delete entire package instead of versions to avoid last-version …

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -620,13 +620,10 @@ jobs:
           server-id: github
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
-      - name: Delete old snapshot versions from GitHub Packages
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: 'net.ladenthin.llama'
-          package-type: 'maven'
-          min-versions-to-keep: 0
-        continue-on-error: true
+      - name: Delete snapshot package from GitHub Packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api --method DELETE /user/packages/maven/net.ladenthin.llama || true
       - name: Publish to GitHub Packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…error

actions/delete-package-versions cannot remove the last version of a package; the API requires deleting the package itself in that case. Switch to a direct gh api DELETE call which removes the whole package at once so mvn deploy always starts clean.