### PR TITLE
Expand snapshot publishing to non-pull request events

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -590,7 +590,7 @@ jobs:
   publish-snapshot:
     name: Publish Snapshot to GitHub Releases and GitHub Packages
     needs: [ package ]
-    if: github.event_name == 'push' && needs.package.result == 'success'
+    if: github.event_name != 'pull_request' && needs.package.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
Updated the conditional logic for the snapshot publishing workflow to trigger on a broader set of events beyond just push events.

## Key Changes
- Modified the `publish-snapshot` job condition from `github.event_name == 'push'` to `github.event_name != 'pull_request'`
- This allows snapshot publishing to occur on push events, workflow_dispatch, and other non-pull-request triggers

## Implementation Details
The change enables snapshot artifacts to be published for additional event types while still preventing publication during pull request events. This is useful for scenarios where snapshots should be published from manual workflow triggers or other repository events beyond standard push operations.

https://claude.ai/code/session_01XkYMtHTs5PKue1mm8a8sfE