### PR TITLE
Use nproc for dynamic parallel build jobs

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -2,4 +2,4 @@
 
 mkdir -p build
 cmake -Bbuild $@ || exit 1
-cmake --build build --config Release -j4 || exit 1
+cmake --build build --config Release -j$(nproc) || exit 1


### PR DESCRIPTION
## Summary
Updated the build script to dynamically determine the number of parallel build jobs based on the system's CPU count instead of using a hardcoded value.

## Changes
- Replaced hardcoded `-j4` flag with `-j$(nproc)` in the CMake build command
- This allows the build system to automatically utilize all available CPU cores on any machine

## Details
The `nproc` command returns the number of available processors on the system, making the build process more efficient across different hardware configurations. This change eliminates the need to manually adjust the job count for different machines and ensures optimal resource utilization.

https://claude.ai/code/session_01FGcSB1yAJpNN38xnUq2KXV