### PR TITLE
chore: migrate CI to unified publish.yml with Sonatype Central Portal

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,24 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "12 1 * * 0"
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with: { java-version: '8', distribution: zulu }
+      - uses: github/codeql-action/init@v3
+        with: { languages: java, queries: +security-and-quality }
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3
+        with: { category: "/language:java" }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with: { java-version: '8', distribution: zulu }
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/analyze@v4
         with: { category: "/language:java" }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -665,6 +665,8 @@ jobs:
       (needs.publish-snapshot.result == 'success' ||
        needs.publish-release.result == 'success')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
-name: Build, Test and Release
+name: Publish
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
+    tags: ['v*']
   pull_request:
   workflow_dispatch:
     inputs:
@@ -10,11 +11,9 @@ on:
         required: false
         default: 'false'
       enable_cuda_build:
-        description: 'Compile CUDA artifacts (slow — nvcc install + build). Auto-enabled on release events.'
+        description: 'Compile CUDA artifacts (slow — nvcc install + build). Auto-enabled on tag pushes.'
         required: false
         default: 'false'
-  release:
-    types: [ created ]
 env:
   MODEL_URL: "https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q2_K.gguf"
   MODEL_NAME: "codellama-7b.Q2_K.gguf"
@@ -49,7 +48,7 @@ jobs:
         id: build
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "release" || "${{ github.event.inputs.enable_cuda_build }}" == "true" ]]; then
+          if [[ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" || "${{ github.event.inputs.enable_cuda_build }}" == "true" ]]; then
             .github/dockcross/dockcross-manylinux_2_28-x64 .github/build_cuda_linux.sh "-DOS_NAME=Linux -DOS_ARCH=x86_64"
             echo "built=true" >> "$GITHUB_OUTPUT"
           else
@@ -588,59 +587,46 @@ jobs:
           path: target/*.jar
 
   publish-snapshot:
-    name: Publish Snapshot to GitHub Releases and GitHub Packages
+    name: Publish Snapshot to Central
     needs: [ package ]
-    if: github.event_name != 'pull_request' && needs.package.result == 'success'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
+    environment: maven-central
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
         with:
           name: llama-jars
           path: snapshot-jars/
-      - name: Publish rolling snapshot release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          gh release delete snapshot --yes --cleanup-tag || true
-          gh release create snapshot snapshot-jars/*.jar \
-            --title "Snapshot Build" \
-            --notes "Snapshot from ${{ github.sha }} — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --prerelease \
-            --target ${{ github.sha }}
-      - name: Set up Maven for GitHub Packages
-        uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
           java-version: '8'
-          server-id: github
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
-      - name: Delete snapshot package from GitHub Packages
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh api --method DELETE /user/packages/maven/net.ladenthin.llama || true
-      - name: Publish to GitHub Packages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          distribution: zulu
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Deploy snapshot
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           mvn --batch-mode deploy:deploy-file \
-            -Durl=https://maven.pkg.github.com/${{ github.repository }} \
-            -DrepositoryId=github \
+            -Durl=https://central.sonatype.com/repository/maven-snapshots \
+            -DrepositoryId=central \
             -Dfile=snapshot-jars/llama-${VERSION}.jar \
             -DpomFile=pom.xml \
             -Dsources=snapshot-jars/llama-${VERSION}-sources.jar \
             -Djavadoc=snapshot-jars/llama-${VERSION}-javadoc.jar
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
 
-  publish:
-    if: ${{ github.event_name == 'release' || (github.event.inputs.release_to_maven_central == 'true' && needs.crosscompile-linux-x86_64-cuda.outputs.built == 'true') }}
+  publish-release:
+    name: Publish Release to Central
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.release_to_maven_central == 'true'
     needs: [ package, crosscompile-linux-x86_64-cuda ]
     runs-on: ubuntu-latest
+    environment: maven-central
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
@@ -658,14 +644,29 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      - name: Publish package
+      - name: Publish release
         run: mvn --batch-mode -P release -Dmaven.test.skip=true deploy
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+  post-publish:
+    name: Post-Publish
+    needs: [package, publish-snapshot, publish-release]
+    if: >-
+      always() &&
+      needs.package.result == 'success' &&
+      (needs.publish-snapshot.result == 'success' ||
+       needs.publish-release.result == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with: { java-version: '8', distribution: zulu }
+      - uses: advanced-security/maven-dependency-submission-action@v5

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,13 @@
 		<url>https://github.com/bernardladenthin/java-llama.cpp/tree/master</url>
 	</scm>
 
+	<distributionManagement>
+		<snapshotRepository>
+			<id>central</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
+
 	<properties>
 		<jna.version>5.18.1</jna.version>
 		<junit.version>4.13.2</junit.version>


### PR DESCRIPTION
## Summary

- **Rename** `release.yaml` → `publish.yml` and update triggers/jobs
- **Replace** `release` event trigger with `tags: ['v*']` push trigger
- **`publish-snapshot`** (new): deploys to Sonatype Central Portal snapshot repo on every push to `main` or manual dispatch; uses `deploy:deploy-file` with the pre-built JARs from the `package` job; uses `environment: maven-central`
- **`publish-release`** (renamed from `publish`): switches `server-id` ossrh→central, fixes GPG secret name (`GPG_SIGNING_KEY`→`GPG_PRIVATE_KEY`), uses `CENTRAL_USERNAME`/`CENTRAL_TOKEN`
- **Add `codeql.yml`**: GitHub Advanced Security scanning on PRs, pushes to `main`, and weekly schedule
- **Add `post-publish`** job: Maven dependency graph submission
- **`pom.xml`**: add `distributionManagement` `snapshotRepository` pointing to Central Portal
- All GitHub Actions on latest major versions (checkout@v6, setup-java@v5, upload-artifact@v7, download-artifact@v8, maven-dependency-submission-action@v5)

## Prerequisites (must be done in GitHub UI before workflows run)

1. Go to **Settings → Environments → `maven-central`**
2. Under "Deployment branches and tags", add `main` as an allowed branch so `publish-snapshot` passes the environment gate automatically on main pushes
3. Secrets required in the `maven-central` environment: `CENTRAL_USERNAME`, `CENTRAL_TOKEN`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`

## Test plan

- [ ] Push to `main` → package (all platform cross-compiles) + publish-snapshot + post-publish
- [ ] Push `v*` tag → package + publish-release (pauses at environment approval) + post-publish
- [ ] Feature branch push / PR → package only; publish jobs skipped
- [ ] CodeQL runs on PRs targeting `main` and weekly on schedule

https://claude.ai/code/session_01TPLSUAgEHPFGSoDesiPZ5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPLSUAgEHPFGSoDesiPZ5N)_