### PR TITLE
Upgrade llama.cpp to b9103 and cpp-httplib to v0.44.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b9102**
+Current llama.cpp pinned version: **b9103**
 
 ## Upgrading CUDA Version
 
@@ -249,6 +249,7 @@ Also review the project `CMakeLists.txt` for build-system-level breaks (e.g. ren
 | ~b9094–b9102 | `src/llama-model.cpp` | `n_vocab` loading moved from `llama_model_base::load_hparams()` to per-model `load_arch_hparams()` (e.g. `src/models/deepseek2.cpp`, `src/models/llama.cpp`); internal model-loading refactor, no project changes required |
 | ~b9094–b9102 | `src/llama-model.cpp` | `ggml/src/ggml-virtgpu/ggml-backend-device.cpp` gains `#include <mutex>` for `std::once_flag`; internal backend fix, no project changes required |
 | ~b9094–b9102 | `vendor/cpp-httplib/httplib.cpp` + `httplib.h` | Security fix: chunk-size parsing replaced `strtoul` with manual hex-digit scanning to prevent overflow and reject invalid chunk extensions; version bumped to 0.43.4; compiled automatically, no project changes required |
+| ~b9102–b9103 | `vendor/cpp-httplib/httplib.cpp` + `httplib.h` | cpp-httplib bumped to v0.44.0: (1) RFC 9110 §5.5 compliance — header field values are no longer percent-decoded by the recipient in `parse_header`; `Location`/`Referer` special-casing removed; callers that need URI-component decoding must call `decode_uri_component()` explicitly; (2) `ThreadPool` constructor is now exception-safe — if thread creation fails partway through, already-started workers are signalled to exit and joined before rethrowing, preventing `std::terminate` from joinable threads in the destructor; compiled automatically, no project changes required |
 
 ## Build Commands
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(GGML_AVX512  OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b9102
+	GIT_TAG        b9103
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
-[![llama.cpp b9102](https://img.shields.io/badge/llama.cpp-%23b9102-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9102)
+[![llama.cpp b9103](https://img.shields.io/badge/llama.cpp-%23b9103-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9103)
 [![Snapshot](https://img.shields.io/badge/snapshot-latest-informational)](https://github.com/bernardladenthin/java-llama.cpp/releases/tag/snapshot)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)


### PR DESCRIPTION
## Summary
This PR upgrades the pinned llama.cpp version from b9102 to b9103, which includes an update to cpp-httplib from v0.43.4 to v0.44.0.

## Key Changes
- Updated llama.cpp pinned version to **b9103** in `CMakeLists.txt`
- Updated documentation references to reflect the new llama.cpp version in `CLAUDE.md` and `README.md`
- Added changelog entry documenting cpp-httplib v0.44.0 changes:
  - **RFC 9110 §5.5 compliance**: Header field values are no longer percent-decoded by the recipient in `parse_header`. The `Location` and `Referer` special-casing has been removed. Callers requiring URI-component decoding must now explicitly call `decode_uri_component()`
  - **ThreadPool exception safety**: The `ThreadPool` constructor is now exception-safe. If thread creation fails partway through, already-started workers are signalled to exit and joined before rethrowing, preventing `std::terminate` from joinable threads in the destructor

## Notes
- These are upstream changes compiled automatically; no project-level code modifications are required
- The changes are internal to the vendored cpp-httplib dependency and llama.cpp core

https://claude.ai/code/session_01SHKJvYNEcFfJi1CdqPjfPS