### PR TITLE
Add code coverage reporting with JaCoCo and Coveralls/Codecov

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -373,6 +373,12 @@ jobs:
           echo "${{ github.workspace }}/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
       - name: Run tests
         run: mvn --no-transfer-progress test
+      - uses: actions/upload-artifact@v7
+        if: success()
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/jacoco.xml
+          if-no-files-found: ignore
       - name: Memory after tests
         if: always()
         run: free -h
@@ -586,9 +592,37 @@ jobs:
           name: llama-jars
           path: target/*.jar
 
+  report:
+    name: Report
+    needs: [package]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with: { java-version: '8', distribution: zulu }
+      - uses: actions/download-artifact@v8
+        with: { name: jacoco-report, path: target/site/jacoco/ }
+        continue-on-error: true
+      - uses: advanced-security/maven-dependency-submission-action@v5
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/site/jacoco/jacoco.xml
+          format: jacoco
+        continue-on-error: true
+      - name: Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/site/jacoco/jacoco.xml
+        continue-on-error: true
+
   publish-snapshot:
     name: Publish Snapshot to Central
-    needs: [ package ]
+    needs: [report]
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
@@ -624,7 +658,7 @@ jobs:
   publish-release:
     name: Publish Release to Central
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.release_to_maven_central == 'true'
-    needs: [ package, crosscompile-linux-x86_64-cuda ]
+    needs: [report, crosscompile-linux-x86_64-cuda]
     runs-on: ubuntu-latest
     environment: maven-central
     steps:
@@ -672,20 +706,3 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: release-assets/*
-
-  post-publish:
-    name: Post-Publish
-    needs: [package, publish-snapshot, publish-release]
-    if: >-
-      always() &&
-      needs.package.result == 'success' &&
-      (needs.publish-snapshot.result == 'success' ||
-       needs.publish-release.result == 'success')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with: { java-version: '8', distribution: zulu }
-      - uses: advanced-security/maven-dependency-submission-action@v5

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,26 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.14</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive code coverage tracking and reporting to the CI/CD pipeline by integrating JaCoCo for coverage analysis and submitting reports to Coveralls and Codecov.

## Key Changes
- **JaCoCo Integration**: Added JaCoCo Maven plugin (v0.8.14) to `pom.xml` to generate code coverage reports during test execution
- **Coverage Report Upload**: Modified the test job in the publish workflow to upload the generated JaCoCo XML report as an artifact
- **New Report Job**: Created a dedicated `report` job that:
  - Downloads the JaCoCo coverage report artifact
  - Submits coverage data to Coveralls via `coverallsapp/github-action`
  - Submits coverage data to Codecov via `codecov/codecov-action`
  - Runs Maven dependency submission action for security scanning
- **Updated Job Dependencies**: 
  - Changed `publish-snapshot` to depend on the new `report` job instead of directly on `package`
  - Changed `publish-release` to depend on `report` instead of `package`
- **Removed Post-Publish Job**: Consolidated the Maven dependency submission action into the new `report` job, eliminating the separate `post-publish` job

## Implementation Details
- JaCoCo is configured to run the `prepare-agent` goal before tests and generate reports after test execution
- Coverage reports are uploaded with `if-no-files-found: ignore` to prevent failures if coverage data is unavailable
- Both Coveralls and Codecov submissions are marked with `continue-on-error: true` to prevent blocking the pipeline if external services are unavailable
- The report job has `contents: write` permissions to support the Maven dependency submission action

https://claude.ai/code/session_015QvayxAG8vHDVH1fcqUZ8w