### PR TITLE
Release version 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Access this library via Maven (released versions on Maven Central):
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama</artifactId>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>5.0.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary
This release prepares the llama library for version 5.0.0 by removing the SNAPSHOT suffix from version identifiers.

## Changes
- Updated version from `5.0.0-SNAPSHOT` to `5.0.0` in `pom.xml`
- Updated version from `5.0.0-SNAPSHOT` to `5.0.0` in `README.md` Maven dependency documentation

## Details
This is a standard release cut that transitions the project from development/snapshot status to a stable release version. The version is now ready for publication to Maven Central Repository.

https://claude.ai/code/session_01UpoSZ4ZknnF7G5vctxM4ac