### PR TITLE
Add comprehensive JavaDoc documentation to public APIs

### DIFF
--- a/src/main/java/net/ladenthin/llama/InferenceParameters.java
+++ b/src/main/java/net/ladenthin/llama/InferenceParameters.java
@@ -57,6 +57,11 @@ public final class InferenceParameters extends JsonParameters {
 	private static final String PARAM_REASONING_FORMAT = "reasoning_format";
 	private static final String PARAM_REASONING_BUDGET_TOKENS = "reasoning_budget_tokens";
 
+	/**
+	 * Creates inference parameters with the given prompt.
+	 *
+	 * @param prompt the prompt to start generation with
+	 */
 	public InferenceParameters(String prompt) {
 		// we always need a prompt
 		setPrompt(prompt);

--- a/src/main/java/net/ladenthin/llama/JsonParameters.java
+++ b/src/main/java/net/ladenthin/llama/JsonParameters.java
@@ -16,6 +16,7 @@ abstract class JsonParameters {
 	// The JNI code for a proper Java-typed data object is comparatively too complex and hard to maintain.
 	final Map<String, String> parameters = new HashMap<>();
 
+	/** Serializer for converting Java values to JSON-safe strings. */
 	protected final ParameterJsonSerializer serializer = new ParameterJsonSerializer();
 
 	@Override

--- a/src/main/java/net/ladenthin/llama/LlamaModel.java
+++ b/src/main/java/net/ladenthin/llama/LlamaModel.java
@@ -200,6 +200,10 @@ public class LlamaModel implements AutoCloseable {
 	public String applyTemplate(InferenceParameters parameters) {
 		return applyTemplate(parameters.toString());
 	}
+	/**
+	 * @param parametersJson JSON-serialized inference parameters
+	 * @return the formatted chat template string
+	 */
 	public native String applyTemplate(String parametersJson);
 
 	/**

--- a/src/main/java/net/ladenthin/llama/ModelMeta.java
+++ b/src/main/java/net/ladenthin/llama/ModelMeta.java
@@ -20,12 +20,16 @@ public final class ModelMeta {
         this.node = node;
     }
 
-    /** Vocabulary type identifier (e.g. SPM = 2, BPE = 1). */
+    /**
+     * @return vocabulary type identifier (e.g. SPM = 2, BPE = 1)
+     */
     public int getVocabType() {
         return node.path("vocab_type").asInt(0);
     }
 
-    /** Total number of tokens in the model vocabulary. */
+    /**
+     * @return total number of tokens in the model vocabulary
+     */
     public int getNVocab() {
         return node.path("n_vocab").asInt(0);
     }

--- a/src/main/java/net/ladenthin/llama/Pair.java
+++ b/src/main/java/net/ladenthin/llama/Pair.java
@@ -2,20 +2,36 @@ package net.ladenthin.llama;
 
 import java.util.Objects;
 
+/**
+ * A generic immutable key-value pair.
+ *
+ * @param <K> the key type
+ * @param <V> the value type
+ */
 public class Pair<K, V> {
 
 	private final K key;
 	private final V value;
-	
+
+	/**
+	 * @param key   the key
+	 * @param value the value
+	 */
 	public Pair(K key, V value) {
 		this.key = key;
 		this.value = value;
 	}
-	
+
+	/**
+	 * @return the key
+	 */
 	public K getKey() {
 		return key;
 	}
-	
+
+	/**
+	 * @return the value
+	 */
 	public V getValue() {
 		return value;
 	}

--- a/src/main/java/net/ladenthin/llama/args/CacheType.java
+++ b/src/main/java/net/ladenthin/llama/args/CacheType.java
@@ -5,14 +5,23 @@ package net.ladenthin.llama.args;
  */
 public enum CacheType implements CliArg {
 
+    /** 32-bit float. */
     F32("f32"),
+    /** 16-bit float. */
     F16("f16"),
+    /** 16-bit brain float. */
     BF16("bf16"),
+    /** 8-bit quantization, scheme 0. */
     Q8_0("q8_0"),
+    /** 4-bit quantization, scheme 0. */
     Q4_0("q4_0"),
+    /** 4-bit quantization, scheme 1. */
     Q4_1("q4_1"),
+    /** 4-bit non-linear importance quantization. */
     IQ4_NL("iq4_nl"),
+    /** 5-bit quantization, scheme 0. */
     Q5_0("q5_0"),
+    /** 5-bit quantization, scheme 1. */
     Q5_1("q5_1");
 
     private final String argValue;

--- a/src/main/java/net/ladenthin/llama/args/GpuSplitMode.java
+++ b/src/main/java/net/ladenthin/llama/args/GpuSplitMode.java
@@ -5,8 +5,11 @@ package net.ladenthin.llama.args;
  */
 public enum GpuSplitMode implements CliArg {
 
+    /** No split; use a single GPU. */
     NONE("none"),
+    /** Split by transformer layer across GPUs. */
     LAYER("layer"),
+    /** Split by tensor row across GPUs. */
     ROW("row");
 
     private final String argValue;

--- a/src/main/java/net/ladenthin/llama/args/RopeScalingType.java
+++ b/src/main/java/net/ladenthin/llama/args/RopeScalingType.java
@@ -1,12 +1,21 @@
 package net.ladenthin.llama.args;
 
+/**
+ * RoPE (Rotary Position Embedding) scaling type for {@code --rope-scaling}.
+ */
 public enum RopeScalingType implements CliArg {
 
+    /** No scaling type specified; use the model default. */
     UNSPECIFIED("unspecified"),
+    /** No RoPE scaling applied. */
     NONE("none"),
+    /** Linear RoPE scaling. */
     LINEAR("linear"),
+    /** YaRN (Yet Another RoPE extensioN) scaling. */
     YARN2("yarn"),
+    /** LongRoPE scaling for extended context. */
     LONGROPE("longrope"),
+    /** Maximum value sentinel. */
     MAX_VALUE("maxvalue");
 
     private final String argValue;

--- a/src/main/java/net/ladenthin/llama/args/Sampler.java
+++ b/src/main/java/net/ladenthin/llama/args/Sampler.java
@@ -5,14 +5,23 @@ package net.ladenthin.llama.args;
  */
 public enum Sampler implements CliArg {
 
+    /** DRY (Don't Repeat Yourself) repetition penalty sampler. */
     DRY("dry"),
+    /** Top-K sampling: keep only the K most likely tokens. */
     TOP_K("top_k"),
+    /** Top-P (nucleus) sampling: keep tokens whose cumulative probability exceeds P. */
     TOP_P("top_p"),
+    /** Typical-P sampling: keep tokens whose local typicality exceeds P. */
     TYP_P("typ_p"),
+    /** Min-P sampling: remove tokens below a minimum probability threshold. */
     MIN_P("min_p"),
+    /** Temperature scaling applied to logits before sampling. */
     TEMPERATURE("temperature"),
+    /** XTC (eXclude Top Choices) sampler. */
     XTC("xtc"),
+    /** Infill-specific sampler for fill-in-the-middle tasks. */
     INFILL("infill"),
+    /** Repetition, frequency, and presence penalties sampler. */
     PENALTIES("penalties");
 
     private final String argValue;


### PR DESCRIPTION
## Summary
This PR adds JavaDoc documentation to public classes, methods, and enum constants across the codebase to improve API clarity and IDE support.

## Key Changes
- **Pair.java**: Added class-level JavaDoc with generic type parameters and method documentation for constructor and getters
- **CacheType.java**: Added inline documentation for all 9 cache type enum constants (F32, F16, BF16, Q8_0, Q4_0, Q4_1, IQ4_NL, Q5_0, Q5_1)
- **RopeScalingType.java**: Added class-level JavaDoc and documentation for all 6 RoPE scaling type enum constants
- **Sampler.java**: Added documentation for all 9 sampler enum constants (DRY, TOP_K, TOP_P, TYP_P, MIN_P, TEMPERATURE, XTC, INFILL, PENALTIES)
- **GpuSplitMode.java**: Added documentation for all 3 GPU split mode enum constants
- **ModelMeta.java**: Converted inline comments to proper JavaDoc format for `getVocabType()` and `getNVocab()` methods
- **InferenceParameters.java**: Added JavaDoc for the constructor
- **LlamaModel.java**: Added JavaDoc for the native `applyTemplate(String)` method
- **JsonParameters.java**: Added JavaDoc for the `serializer` field

## Implementation Details
- All changes maintain backward compatibility
- Documentation follows standard JavaDoc conventions with `@param` and `@return` tags where applicable
- Enum constant documentation uses inline `/** */` comments for clarity
- Minor formatting improvements (trailing whitespace cleanup) included

https://claude.ai/code/session_01CghtTrLwfpzFEeZMoEzNqM