### PR TITLE
Add Maven Central badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
 [![llama.cpp b9106](https://img.shields.io/badge/llama.cpp-%23b9106-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9106)
+[![Maven Central](https://img.shields.io/maven-central/v/net.ladenthin/llama)](https://central.sonatype.com/artifact/net.ladenthin/llama)
 [![Snapshot](https://img.shields.io/badge/snapshot-latest-informational)](https://github.com/bernardladenthin/java-llama.cpp/releases/tag/snapshot)
 
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)


### PR DESCRIPTION
## Summary
Added a Maven Central badge to the README to display the latest published version of the library on Maven Central Repository.

## Changes
- Added Maven Central version badge linking to the artifact page on Maven Central for `net.ladenthin:llama`

## Details
This badge provides users with quick visibility into the latest stable release version available on Maven Central, making it easier for developers to identify the current published version of the library.

https://claude.ai/code/session_01RY63FKuVuP1J59YCJuqAKU