### PR TITLE
Upgrade Windows CI to windows-2025 with Visual Studio 2026

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -496,7 +496,7 @@ jobs:
           if-no-files-found: warn
 
   test-java-windows-x86_64:
-    name: Java Tests Windows 2025 x86_64
+    name: Java Tests Windows 2025 x86_64 (VS 2026)
     needs: build-windows-x86_64
     runs-on: windows-2025-vs2026
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,8 +196,8 @@ jobs:
           path: ${{ github.workspace }}/src/main/resources/net/ladenthin/llama/
 
   build-windows-x86_64:
-    name: Build and Test Windows 2022 x86_64
-    runs-on: windows-2022
+    name: Build and Test Windows 2025 x86_64 (VS 2026)
+    runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
       - name: Display CPU Info
@@ -214,7 +214,7 @@ jobs:
       - name: Build libraries
         shell: cmd
         run: |
-          .github\build.bat -G "Visual Studio 17 2022" -A "x64" -DOS_NAME=Windows -DOS_ARCH=x86_64 -DBUILD_TESTING=ON
+          .github\build.bat -G "Visual Studio 18 2026" -A "x64" -DOS_NAME=Windows -DOS_ARCH=x86_64 -DBUILD_TESTING=ON
       - name: Run C++ unit tests
         run: ctest --test-dir build --output-on-failure
       - name: Upload artifacts
@@ -224,8 +224,8 @@ jobs:
           path: ${{ github.workspace }}/src/main/resources/net/ladenthin/llama/
 
   build-windows-x86:
-    name: Build and Test Windows 2022 x86
-    runs-on: windows-2022
+    name: Build and Test Windows 2025 x86 (VS 2026)
+    runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
       - name: Display CPU Info
@@ -242,7 +242,7 @@ jobs:
       - name: Build libraries
         shell: cmd
         run: |
-          .github\build.bat -G "Visual Studio 17 2022" -A "Win32" -DOS_NAME=Windows -DOS_ARCH=x86 -DBUILD_TESTING=ON
+          .github\build.bat -G "Visual Studio 18 2026" -A "Win32" -DOS_NAME=Windows -DOS_ARCH=x86 -DBUILD_TESTING=ON
       - name: Run C++ unit tests
         run: ctest --test-dir build --output-on-failure
       - name: Upload artifacts
@@ -496,9 +496,9 @@ jobs:
           if-no-files-found: warn
 
   test-java-windows-x86_64:
-    name: Java Tests Windows Latest x86_64
+    name: Java Tests Windows 2025 x86_64
     needs: build-windows-x86_64
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6
       - name: Display CPU Info


### PR DESCRIPTION
## Summary
Updates the GitHub Actions CI workflow to use the latest Windows runner image (windows-2025) with Visual Studio 2026 for building and testing native Windows binaries.

## Changes
- **Windows x86_64 build job**: Updated runner from `windows-2022` to `windows-2025-vs2026` and CMake generator from "Visual Studio 17 2022" to "Visual Studio 18 2026"
- **Windows x86 build job**: Updated runner from `windows-2022` to `windows-2025-vs2026` and CMake generator from "Visual Studio 17 2022" to "Visual Studio 18 2026"
- **Java tests job**: Updated `test-java-windows-x86_64` runner from `windows-latest` to `windows-2025-vs2026` for consistency with the build jobs
- **Job naming**: Updated display names to reflect the new Windows 2025 and VS 2026 versions

## Details
These changes ensure the CI pipeline uses current tooling for Windows builds. The Visual Studio 2026 generator (version 18) replaces the previous Visual Studio 2022 generator (version 17), and the windows-2025-vs2026 runner provides the corresponding build environment. This maintains consistency across all Windows-based CI jobs.

https://claude.ai/code/session_01LgNyM3A3WK7KVdct3Dr8g4