### PR TITLE
Use static MSVC runtime (/MT) for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(jllama CXX)
+
+# Use static MSVC runtime (/MT) instead of the default DLL runtime (/MD).
+# This embeds the C++ runtime into jllama.dll so msvcp140.dll / vcruntime140.dll
+# are not required on the end-user's machine.
+# Must be set before any FetchContent_MakeAvailable() so that llama.cpp and all
+# other subprojects inherit the same CRT choice (mixing /MT and /MD in a single
+# link is a linker error).
+if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>" CACHE STRING "" FORCE)
+endif()
 
 include(FetchContent)
 
@@ -273,8 +283,9 @@ if(BUILD_TESTING)
         GIT_REPOSITORY https://github.com/google/googletest.git
         GIT_TAG        v1.15.2
     )
-    # Prevent GTest from overriding our compiler/linker settings on Windows
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    # Keep GTest on the same CRT as the rest of the project.
+    # OFF means GTest respects CMAKE_MSVC_RUNTIME_LIBRARY (static /MT here).
+    set(gtest_force_shared_crt OFF CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
 
     enable_testing()


### PR DESCRIPTION
## Summary
Configure the CMake build to use the static MSVC C++ runtime (`/MT`) instead of the dynamic runtime (`/MD`) on Windows. This embeds the C++ runtime directly into `jllama.dll`, eliminating the need for end-users to have `msvcp140.dll` and `vcruntime140.dll` installed.

## Changes
- **CMakeLists.txt**: 
  - Bumped minimum CMake version from 3.14 to 3.15 (required for `CMAKE_MSVC_RUNTIME_LIBRARY` support)
  - Added MSVC-specific configuration to set static runtime (`/MT` for Release, `/MTd` for Debug) before any `FetchContent_MakeAvailable()` calls, ensuring all subprojects (llama.cpp, googletest, etc.) inherit the same CRT choice
  - Updated googletest configuration: changed `gtest_force_shared_crt` from `ON` to `OFF` so GTest respects the project's `CMAKE_MSVC_RUNTIME_LIBRARY` setting instead of forcing dynamic CRT

## Implementation Details
The static runtime configuration is set early in the CMakeLists.txt (before FetchContent includes) to ensure all dependencies are built with the same CRT. This prevents linker errors that occur when mixing `/MT` and `/MD` in a single link operation. The googletest change from `gtest_force_shared_crt ON` to `OFF` allows it to respect the project-wide CRT choice rather than overriding it.

https://claude.ai/code/session_017esAFB4PjHUjGBqWhbWrXY