### PR TITLE
Upgrade llama.cpp from b9145 to b9150

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b9145**
+Current llama.cpp pinned version: **b9150**
 
 ## Upgrading CUDA Version
 
@@ -265,6 +265,9 @@ Also review the project `CMakeLists.txt` for build-system-level breaks (e.g. ren
 | ~b9134–b9145 | `ggml/src/ggml-cuda/allreduce.cu` | AllReduce accumulation now routed through `float` intermediate for precision (avoids BF16 truncation); internal CUDA backend, no project changes required |
 | ~b9134–b9145 | `ggml/src/ggml-hexagon/` | `GGML_UNARY_OP_TANH` added to Hexagon HTP backend; internal DSP backend, no project changes required |
 | ~b9134–b9145 | `ggml/src/ggml-webgpu/ggml-webgpu-shader-lib.hpp` | `use_subgroup_matrix` condition now also checks `sg_mat_k > 0 && sg_mat_n > 0` and alignment; prevents crash on devices reporting subgroup matrix support with zero k/n; internal WebGPU backend, no project changes required |
+| ~b9145–b9150 | `ggml/src/ggml-vulkan/ggml-vulkan.cpp` | Bug fix: `mul_mat_l_int[i]` / `mul_mat_m_int[i]` / `mul_mat_s_int[i]` / `mul_mat_id_l_int[i]` / `mul_mat_id_m_int[i]` / `mul_mat_id_s_int[i]` were unconditionally set to `true` instead of mirroring the actual device pipeline capabilities from `mul_mat_l[i]` etc.; now properly initialized; internal Vulkan backend bug fix, no project changes required |
+| ~b9145–b9150 | `src/unicode.cpp` | New `unicode_regex_split_custom_qwen35()` function registered for the Qwen 3.5 tokenizer regex pattern; uses `[\p{L}\p{M}]+` letter-plus-combining-mark runs vs. Qwen2's `\p{L}+`; additive internal tokenizer change, no project changes required |
+| ~b9145–b9150 | `ggml/src/ggml-cpu/ggml-cpu-riscv64-spacemit/` | SpaceMIT RISC-V IME backend major refactor: IME2 kernels, expanded quantization (Q2_K, Q3_K, Q6_K, Q8_0, Q5_0, Q5_1, Q5_K, MXFP4), TCM (Tightly Coupled Memory) pool; new source files `ime2_kernels.cpp`, `ime_env.cpp`, `repack.cpp`, `rvv_kernels.cpp`, `spine_mem_pool.cpp`; guarded by `GGML_CPU_RISCV64_SPACEMIT` build flag; no project changes required |
 
 ## Build Commands
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ set(GGML_AVX512  OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b9145
+	GIT_TAG        b9150
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Java 8+](https://img.shields.io/badge/Java-8%2B-informational)
-[![llama.cpp b9145](https://img.shields.io/badge/llama.cpp-%23b9145-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9145)
+[![llama.cpp b9150](https://img.shields.io/badge/llama.cpp-%23b9150-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9150)
 [![Maven Central](https://img.shields.io/maven-central/v/net.ladenthin/llama)](https://central.sonatype.com/artifact/net.ladenthin/llama)
 [![Snapshot](https://img.shields.io/badge/snapshot-latest-informational)](https://central.sonatype.com/repository/maven-snapshots/net/ladenthin/llama/)
 


### PR DESCRIPTION
## Summary
Upgrades the pinned llama.cpp version from b9145 to b9150, incorporating bug fixes and enhancements to the Vulkan backend, tokenizer support for Qwen 3.5, and a major refactor of the SpaceMIT RISC-V IME backend.

## Changes Made
- **CMakeLists.txt**: Updated `GIT_TAG` from `b9145` to `b9150`
- **README.md**: Updated llama.cpp version badge and link from `b9145` to `b9150`
- **CLAUDE.md**: 
  - Updated pinned version reference from `b9145` to `b9150`
  - Added three new changelog entries documenting upstream changes:
    - Vulkan backend bug fix for `mul_mat_*_int` initialization
    - New `unicode_regex_split_custom_qwen35()` tokenizer function for Qwen 3.5
    - SpaceMIT RISC-V IME backend major refactor with IME2 kernels and expanded quantization support

## Notable Details
All upstream changes are internal to the llama.cpp library (Vulkan backend, tokenizer, and RISC-V backend implementations). No breaking API changes or Java binding modifications are required.

Per project conventions, the build should be tested with `cmake -B build && cmake --build build --config Release` to catch any compatibility issues early.

https://claude.ai/code/session_01YAtkgRoknmSdbbQooZCMDs