### PR TITLE
Add tracking link for llama.cpp reasoning_budget_tokens bug

### DIFF
--- a/src/test/java/net/ladenthin/llama/ReasoningBudgetTest.java
+++ b/src/test/java/net/ladenthin/llama/ReasoningBudgetTest.java
@@ -120,6 +120,7 @@ public class ReasoningBudgetTest {
      * <p>This assertion will start <b>failing</b> once the llama.cpp bug is fixed —
      * that is the signal to remove this test and enable
      * {@link #testReasoningBudgetZero_expectedBehavior_suppressesThinking}.
+     * Tracked in <a href="https://github.com/ggml-org/llama.cpp/pull/23116">llama.cpp PR #23116</a>.
      */
     @Test
     public void testReasoningBudgetZero_parameterAccepted_thinkingNotSuppressed() {
@@ -169,6 +170,7 @@ public class ReasoningBudgetTest {
      * <p>Once this fix is applied: remove {@code @Ignore}, confirm this test passes,
      * and remove
      * {@link #testReasoningBudgetZero_parameterAccepted_thinkingNotSuppressed}.
+     * Tracked in <a href="https://github.com/ggml-org/llama.cpp/pull/23116">llama.cpp PR #23116</a>.
      */
     @Ignore("llama.cpp bug: per-request reasoning_budget_tokens is overwritten by model default " +
             "in oaicompat_chat_params_parse (server-common.cpp). " +


### PR DESCRIPTION
## Summary
Added references to the upstream llama.cpp issue tracking the `reasoning_budget_tokens` parameter bug in test documentation.

## Changes
- Added tracking link to llama.cpp PR #23116 in the JavaDoc comment for `testReasoningBudgetZero_parameterAccepted_thinkingNotSuppressed()` test
- Added the same tracking link to the JavaDoc comment for `testReasoningBudgetZero_expectedBehavior_suppressesThinking()` test

## Details
These changes improve test maintainability by explicitly linking the known llama.cpp bug (where per-request `reasoning_budget_tokens` is overwritten by model default in `oaicompat_chat_params_parse`) to its upstream tracking issue. This helps future maintainers understand:
1. Why the workaround test exists
2. When the bug is fixed (the PR will be merged)
3. What action to take when the fix is released (remove the workaround test and enable the expected behavior test)

https://claude.ai/code/session_01FbMXaE5XHF4JAJ68NwkYdA