### PR TITLE
Add attribution to original java-llama.cpp fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/net.ladenthin/llama)](https://central.sonatype.com/artifact/net.ladenthin/llama)
 [![Snapshot](https://img.shields.io/badge/snapshot-latest-informational)](https://central.sonatype.com/repository/maven-snapshots/net/ladenthin/llama/)
 
+> **Forked from** [kherud/java-llama.cpp](https://github.com/kherud/java-llama.cpp): many thanks to [@kherud](https://github.com/kherud) for the great work!
+
 # Java Bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp)
 
 Inference of Meta's LLaMA model (and others) in pure C/C++.


### PR DESCRIPTION
## Summary
Add a prominent attribution notice in the README acknowledging that this project is forked from [kherud/java-llama.cpp](https://github.com/kherud/java-llama.cpp) and crediting [@kherud](https://github.com/kherud) for the original work.

## Changes
- Added a blockquote notice at the top of README.md (after badges) clearly stating the fork origin and thanking the original author

## Rationale
This change ensures proper attribution to the original project maintainer and makes the fork relationship transparent to users discovering this repository.

https://claude.ai/code/session_01ARt8uaa73YqxMLw1KThMjW