### PR TITLE
Downgrade Java target to 1.8 and update CI Java version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,9 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
-        with: { java-version: '8', distribution: zulu }
+        with: { java-version: '21', distribution: temurin }
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }
-      - uses: github/codeql-action/autobuild@v4
+      - name: Build with Maven
+        run: mvn --batch-mode compile
       - uses: github/codeql-action/analyze@v4
         with: { category: "/language:java" }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
-        with: { java-version: '21', distribution: temurin }
+        with: { java-version: '11', distribution: temurin }
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@ SPDX-License-Identifier: MIT
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.15.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 				<executions>
 					<!-- We have to perform a separate build pass for cuda
@@ -170,7 +170,7 @@ SPDX-License-Identifier: MIT
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.12.0</version>
 				<configuration>
-					<source>11</source>
+					<source>1.8</source>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
## Summary

- Downgrade Maven compiler source/target from Java 11 to Java 1.8 in `pom.xml` (main compiler and javadoc plugin)
- Update CodeQL workflow to use Java 11 with Temurin distribution instead of Java 8 with Zulu
- Replace autobuild with explicit `mvn --batch-mode compile` in CodeQL workflow for better build control

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01VDAzqXPDgejeWrWSEd1MZZ