### PR TITLE
Upgrade Java version to 21 and switch to Temurin distribution

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
-        with: { java-version: '11', distribution: temurin }
+        with: { java-version: '21', distribution: temurin }
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }
       - name: Build with Maven

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ on:
         required: false
         default: 'false'
 env:
+  JAVA_VERSION: '21'
   MODEL_URL: "https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q2_K.gguf"
   MODEL_NAME: "codellama-7b.Q2_K.gguf"
   RERANKING_MODEL_URL: "https://huggingface.co/gpustack/jina-reranker-v1-tiny-en-GGUF/resolve/main/jina-reranker-v1-tiny-en-Q4_0.gguf"
@@ -167,8 +168,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Display CPU Info
         shell: bash
         run: |
@@ -198,8 +199,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Display CPU Info
         shell: bash
         run: |
@@ -291,8 +292,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Display CPU Info
         run: |
           echo "=== CPU Information ==="
@@ -315,8 +316,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Display CPU Info
         shell: bash
         run: |
@@ -397,8 +398,8 @@ jobs:
         run: bash .github/validate-models.sh
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Memory before tests
         run: free -h
       - name: Enable core dumps
@@ -459,8 +460,8 @@ jobs:
         run: bash .github/validate-models.sh
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Memory before tests
         run: vm_stat && sysctl hw.memsize hw.physmem
       - name: Enable core dumps
@@ -512,8 +513,8 @@ jobs:
         run: bash .github/validate-models.sh
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Memory before tests
         run: vm_stat && sysctl hw.memsize hw.physmem
       - name: Enable core dumps
@@ -568,8 +569,8 @@ jobs:
         run: .github\validate-models.bat
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Memory before tests
         run: Get-CimInstance Win32_OperatingSystem | Select-Object FreePhysicalMemory,TotalVisibleMemorySize | Format-List
         shell: pwsh
@@ -622,8 +623,8 @@ jobs:
           path: ${{ github.workspace }}/src/main/resources_linux_cuda/net/ladenthin/llama/
       - uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Build JARs
         run: mvn --batch-mode --no-transfer-progress -P release -Dmaven.test.skip=true -Dgpg.skip=true package
       - name: Upload JARs
@@ -641,7 +642,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
-        with: { java-version: '8', distribution: zulu }
+        with: { java-version: '${{ env.JAVA_VERSION }}', distribution: temurin }
       - uses: actions/download-artifact@v8
         with: { name: jacoco-report, path: target/site/jacoco/ }
         continue-on-error: true
@@ -720,8 +721,8 @@ jobs:
           path: snapshot-jars/
       - uses: actions/setup-java@v5
         with:
-          java-version: '8'
-          distribution: zulu
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -762,8 +763,8 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -613,7 +613,7 @@ EXPECT_FALSE(j.contains("stop_type"));  // filtered out
 
 ## Key Constraints
 
-- **Java 11+** required.
+- **Java 8+** runtime required. Built with JDK 21 targeting bytecode 1.8 for broad compatibility.
 - Native memory allocated by llama.cpp is not GC-managed — always use `LlamaModel` in try-with-resources or call `close()` explicitly.
 - The `server.hpp` file is adapted from llama.cpp upstream — minimize modifications to ease future upgrades.
 - Platform-specific native libraries must be pre-built and placed under `src/main/resources/` before packaging for distribution.

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ SPDX-License-Identifier: MIT
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.14</version>
+				<version>0.8.15</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>


### PR DESCRIPTION
## Summary

- Upgrade build and CI Java version from 8/11/17 to 21 across all workflows
- Switch Java distribution from Zulu to Temurin for better long-term support
- Centralize Java version configuration via `JAVA_VERSION` environment variable
- Update documentation to clarify Java 8+ runtime requirement with JDK 21 build target
- Bump JaCoCo plugin from 0.8.14 to 0.8.15 for Java 21 compatibility

## Test plan

- [x] CI is green on this branch (all workflow jobs use updated Java 21 + Temurin)
- [x] Docs updated (CLAUDE.md clarifies Java 8+ runtime with JDK 21 build target)

## Related issues / PRs

<!-- None -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01LsRLQoBtsgebZ7AwS1zAWS