### PR TITLE
Downgrade jacoco-maven-plugin from 0.8.15 to 0.8.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ SPDX-License-Identifier: MIT
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.15</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>


### PR DESCRIPTION
## Summary

- Downgrade jacoco-maven-plugin dependency from version 0.8.15 to 0.8.14 in `pom.xml`
- This is a minor version downgrade of the code coverage tool used during the build process

## Test plan

- [ ] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_019ChutLUhAfj7eoC7hESTTK