### PR TITLE
Increase reasoning token budget to handle slow CI runners

### DIFF
--- a/src/test/java/net/ladenthin/llama/ReasoningBudgetTest.java
+++ b/src/test/java/net/ladenthin/llama/ReasoningBudgetTest.java
@@ -56,10 +56,14 @@ import org.junit.Test;
 public class ReasoningBudgetTest {
 
     /**
-     * Generous token budget: Qwen3-0.6B spends up to ~200 tokens thinking before answering.
-     * 500 is enough for thinking + a short answer on all tested platforms.
+     * Generous token budget: Qwen3-0.6B typically spends ~200 tokens thinking before
+     * answering, but on slow/contended CI runners (e.g. 2-thread GitHub-hosted x86_64)
+     * the model occasionally rambles past 500 tokens while still inside the
+     * {@code <think>} block, leaving {@code content} empty and failing
+     * {@link #testThinkingDefault_reasoningContentAndAnswerPresent}. 1500 leaves
+     * comfortable headroom for thinking + a short answer across all tested platforms.
      */
-    private static final int N_PREDICT = 500;
+    private static final int N_PREDICT = 1500;
 
     private static LlamaModel model;
     private final ChatResponseParser parser = new ChatResponseParser();


### PR DESCRIPTION
## Summary

- Increased `N_PREDICT` token budget from 500 to 1500 in `ReasoningBudgetTest`
- Updated comment to document that slow/contended CI runners (e.g., 2-thread GitHub-hosted x86_64) can cause Qwen3-0.6B to exceed 500 tokens while still inside the `<think>` block
- This prevents flaky test failures on resource-constrained CI environments while maintaining sufficient headroom for thinking + short answer across all platforms

## Test plan

- [x] Affected unit tests pass locally
- [x] CI is green on this branch (the increased budget resolves intermittent failures in `testThinkingDefault_reasoningContentAndAnswerPresent`)

## Related issues / PRs

<!-- Resolves flaky test failures on slow CI runners -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01HM3ZGeHgy5SF8SqJ9aN9iX