### PR TITLE
Always build and publish CUDA artifacts; remove manual workflow inputs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -626,7 +626,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
       - name: Build JARs
-        run: mvn --batch-mode --no-transfer-progress -P release -Dmaven.test.skip=true -Dgpg.skip=true package
+        run: mvn --batch-mode --no-transfer-progress -P release,cuda -Dmaven.test.skip=true -Dgpg.skip=true package
       - name: Upload JARs
         uses: actions/upload-artifact@v7
         with:
@@ -681,17 +681,58 @@ jobs:
       - name: Confirm tag ref
         run: echo "Confirmed on tag ${{ github.ref }}"
 
-  github-snapshot:
-    name: Update Snapshot Pre-release on GitHub
+  publish-snapshot:
+    name: Publish Snapshot to Central
     needs: [check-snapshot]
     if: needs.check-snapshot.result == 'success'
+    runs-on: ubuntu-latest
+    environment: maven-central
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: "*-libraries"
+          merge-multiple: true
+          path: ${{ github.workspace }}/src/main/resources/net/ladenthin/llama/
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Publish snapshot
+        run: mvn --batch-mode -P release -Dmaven.test.skip=true deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Collect signed artifacts
+        run: |
+          mkdir -p signed-snapshot-assets
+          cp target/*.jar signed-snapshot-assets/ 2>/dev/null || true
+          cp target/*.jar.asc signed-snapshot-assets/ 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: signed-snapshot-assets
+          path: signed-snapshot-assets/
+
+  github-snapshot:
+    name: Update Snapshot Pre-release on GitHub
+    needs: [publish-snapshot]
+    if: needs.publish-snapshot.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: llama-jars
+          name: signed-snapshot-assets
           path: snapshot-assets/
       - name: Update snapshot pre-release
         env:
@@ -706,39 +747,6 @@ jobs:
           gh release upload snapshot snapshot-assets/* \
             --repo ${{ github.repository }} \
             --clobber
-
-  publish-snapshot:
-    name: Publish Snapshot to Central
-    needs: [github-snapshot, check-snapshot]
-    if: needs.check-snapshot.result == 'success'
-    runs-on: ubuntu-latest
-    environment: maven-central
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v8
-        with:
-          name: llama-jars
-          path: snapshot-jars/
-      - uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: temurin
-          server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Deploy snapshot
-        run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          mvn --batch-mode deploy:deploy-file \
-            -Durl=https://central.sonatype.com/repository/maven-snapshots \
-            -DrepositoryId=central \
-            -Dfile=snapshot-jars/llama-${VERSION}.jar \
-            -DpomFile=pom.xml \
-            -Dsources=snapshot-jars/llama-${VERSION}-sources.jar \
-            -Djavadoc=snapshot-jars/llama-${VERSION}-javadoc.jar
-        env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
 
   publish-release:
     name: Publish Release to Central
@@ -771,7 +779,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish release
-        run: mvn --batch-mode -P release -Dmaven.test.skip=true deploy
+        run: mvn --batch-mode -P release,cuda -Dmaven.test.skip=true deploy
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,15 +10,6 @@ on:
     tags: ['v*']
   pull_request:
   workflow_dispatch:
-    inputs:
-      release_to_maven_central:
-        description: 'Release to Maven Central (true/false)'
-        required: false
-        default: 'false'
-      enable_cuda_build:
-        description: 'Compile CUDA artifacts (slow — nvcc install + build). Auto-enabled on tag pushes.'
-        required: false
-        default: 'false'
 env:
   JAVA_VERSION: '21'
   MODEL_URL: "https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q2_K.gguf"
@@ -54,8 +45,6 @@ jobs:
     name: Cross-Compile manylinux_2_28 x86_64 (CUDA)
     needs: startgate
     runs-on: ubuntu-latest
-    outputs:
-      built: ${{ steps.build.outputs.built }}
     steps:
       - uses: actions/checkout@v6
       - name: Display CPU Info
@@ -67,18 +56,10 @@ jobs:
           echo "=== CPU Details from /proc/cpuinfo ==="
           cat /proc/cpuinfo
       - name: Build libraries
-        id: build
         shell: bash
         run: |
-          if [[ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" || "${{ github.event.inputs.enable_cuda_build }}" == "true" ]]; then
-            .github/dockcross/dockcross-manylinux_2_28-x64 .github/build_cuda_linux.sh "-DOS_NAME=Linux -DOS_ARCH=x86_64"
-            echo "built=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "CUDA compilation skipped — set enable_cuda_build=true or trigger a release event to build CUDA artifacts"
-            echo "built=false" >> "$GITHUB_OUTPUT"
-          fi
+          .github/dockcross/dockcross-manylinux_2_28-x64 .github/build_cuda_linux.sh "-DOS_NAME=Linux -DOS_ARCH=x86_64"
       - name: Upload artifacts
-        if: steps.build.outputs.built == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: linux-libraries-cuda
@@ -616,8 +597,7 @@ jobs:
           pattern: "*-libraries"
           merge-multiple: true
           path: ${{ github.workspace }}/src/main/resources/net/ladenthin/llama/
-      - if: needs.crosscompile-linux-x86_64-cuda.outputs.built == 'true'
-        uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v8
         with:
           name: linux-libraries-cuda
           path: ${{ github.workspace }}/src/main/resources_linux_cuda/net/ladenthin/llama/
@@ -683,7 +663,7 @@ jobs:
 
   publish-snapshot:
     name: Publish Snapshot to Central
-    needs: [check-snapshot]
+    needs: [check-snapshot, crosscompile-linux-x86_64-cuda]
     if: needs.check-snapshot.result == 'success'
     runs-on: ubuntu-latest
     environment: maven-central
@@ -696,6 +676,10 @@ jobs:
           pattern: "*-libraries"
           merge-multiple: true
           path: ${{ github.workspace }}/src/main/resources/net/ladenthin/llama/
+      - uses: actions/download-artifact@v8
+        with:
+          name: linux-libraries-cuda
+          path: ${{ github.workspace }}/src/main/resources_linux_cuda/net/ladenthin/llama/
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v5
         with:
@@ -707,7 +691,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish snapshot
-        run: mvn --batch-mode -P release -Dmaven.test.skip=true deploy
+        run: mvn --batch-mode -P release,cuda -Dmaven.test.skip=true deploy
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
@@ -750,7 +734,7 @@ jobs:
 
   publish-release:
     name: Publish Release to Central
-    if: needs.check-tag.result == 'success' && github.event.inputs.release_to_maven_central == 'true'
+    if: needs.check-tag.result == 'success'
     needs: [check-tag, crosscompile-linux-x86_64-cuda]
     runs-on: ubuntu-latest
     environment: maven-central
@@ -763,8 +747,7 @@ jobs:
           pattern: "*-libraries"
           merge-multiple: true
           path: ${{ github.workspace }}/src/main/resources/net/ladenthin/llama/
-      - if: needs.crosscompile-linux-x86_64-cuda.outputs.built == 'true'
-        uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v8
         with:
           name: linux-libraries-cuda
           path: ${{ github.workspace }}/src/main/resources_linux_cuda/net/ladenthin/llama/

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,14 @@ SPDX-License-Identifier: MIT
 							<waitUntil>published</waitUntil>
 						</configuration>
 					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
+		<profile>
+			<id>cuda</id>
+			<build>
+				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
## Summary

- **Removed manual workflow dispatch inputs** (`release_to_maven_central`, `enable_cuda_build`) from the publish workflow. CUDA builds now always run unconditionally, and releases to Maven Central are automatic on tag pushes.
- **Simplified CUDA build logic** in the `crosscompile-linux-x86_64-cuda` job by removing conditional checks and output flags. The job now always executes the build script without conditional branching.
- **Restructured snapshot and release publishing** to ensure CUDA artifacts are always included. The `publish-snapshot` job now runs the full Maven build with the `cuda` profile enabled, and `publish-release` similarly includes the `cuda` profile.
- **Reordered job dependencies** so that `publish-snapshot` completes before `github-snapshot` updates the pre-release, ensuring signed artifacts are available.
- **Split Maven profiles** in `pom.xml`: separated the CUDA JAR plugin configuration into its own `<profile id="cuda">` block, allowing it to be composed with the `release` profile via `-P release,cuda`.

## Test plan

- [x] CI is green on this branch (all workflow jobs execute without conditional skips)
- [x] CUDA artifacts are always built and included in both snapshot and release deployments
- [x] Maven profiles compose correctly: `-P release,cuda` activates both profiles

## Related issues / PRs

N/A

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01SxxLmcu9vgaPjKnSPeTjEx