### PR TITLE
Update copyright attribution for Konstantin Herud

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/build.bat
+++ b/.github/build.bat
@@ -1,5 +1,5 @@
 REM SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-REM SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+REM SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 REM
 REM SPDX-License-Identifier: MIT
 

--- a/.github/build.sh
+++ b/.github/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/build_cuda_linux.sh
+++ b/.github/build_cuda_linux.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/dockcross/update.sh
+++ b/.github/dockcross/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/validate-models.bat
+++ b/.github/validate-models.bat
@@ -1,5 +1,5 @@
 REM SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-REM SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+REM SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 REM
 REM SPDX-License-Identifier: MIT
 

--- a/.github/validate-models.sh
+++ b/.github/validate-models.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-# SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+# SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 #
 # SPDX-License-Identifier: MIT
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -22,7 +22,7 @@ path = [
     ".claude/commands/find-cpp-duplication.md",
 ]
 SPDX-FileCopyrightText = [
-    "2023-2025 Konstantin Heurer",
+    "2023-2025 Konstantin Herud",
     "2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>",
 ]
 SPDX-License-Identifier = "MIT"
@@ -31,7 +31,7 @@ SPDX-License-Identifier = "MIT"
 [[annotations]]
 path = "CITATION.cff"
 SPDX-FileCopyrightText = [
-    "2023-2025 Konstantin Heurer",
+    "2023-2025 Konstantin Herud",
     "2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>",
 ]
 SPDX-License-Identifier = "MIT"
@@ -40,7 +40,7 @@ SPDX-License-Identifier = "MIT"
 [[annotations]]
 path = "CMakeLists.txt"
 SPDX-FileCopyrightText = [
-    "2023-2025 Konstantin Heurer",
+    "2023-2025 Konstantin Herud",
     "2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>",
 ]
 SPDX-License-Identifier = "MIT"
@@ -55,7 +55,7 @@ path = [
     ".github/dockcross/dockcross-manylinux_2_28-x64",
 ]
 SPDX-FileCopyrightText = [
-    "2023-2025 Konstantin Heurer",
+    "2023-2025 Konstantin Herud",
     "2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>",
 ]
 SPDX-License-Identifier = "MIT"
@@ -65,7 +65,7 @@ SPDX-License-Identifier = "MIT"
 [[annotations]]
 path = ".github/CODEOWNERS"
 SPDX-FileCopyrightText = [
-    "2023-2025 Konstantin Heurer",
+    "2023-2025 Konstantin Herud",
     "2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>",
 ]
 SPDX-License-Identifier = "MIT"

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 
 SPDX-License-Identifier: MIT
 -->

--- a/src/main/cpp/compat/ggml_x86_compat.c
+++ b/src/main/cpp/compat/ggml_x86_compat.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
- * SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+ * SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
  *
  * SPDX-License-Identifier: MIT
  */

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/cpp/jllama.h
+++ b/src/main/cpp/jllama.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
- * SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+ * SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
  *
  * SPDX-License-Identifier: MIT
  */

--- a/src/main/cpp/jni_helpers.hpp
+++ b/src/main/cpp/jni_helpers.hpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/cpp/json_helpers.hpp
+++ b/src/main/cpp/json_helpers.hpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/cpp/utils.hpp
+++ b/src/main/cpp/utils.hpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/CliParameters.java
+++ b/src/main/java/net/ladenthin/llama/CliParameters.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/InferenceParameters.java
+++ b/src/main/java/net/ladenthin/llama/InferenceParameters.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/JsonParameters.java
+++ b/src/main/java/net/ladenthin/llama/JsonParameters.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/LlamaException.java
+++ b/src/main/java/net/ladenthin/llama/LlamaException.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/LlamaIterable.java
+++ b/src/main/java/net/ladenthin/llama/LlamaIterable.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/LlamaIterator.java
+++ b/src/main/java/net/ladenthin/llama/LlamaIterator.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/LlamaLoader.java
+++ b/src/main/java/net/ladenthin/llama/LlamaLoader.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/LlamaModel.java
+++ b/src/main/java/net/ladenthin/llama/LlamaModel.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/LlamaOutput.java
+++ b/src/main/java/net/ladenthin/llama/LlamaOutput.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/LlamaSystemProperties.java
+++ b/src/main/java/net/ladenthin/llama/LlamaSystemProperties.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/LogLevel.java
+++ b/src/main/java/net/ladenthin/llama/LogLevel.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/ModelMeta.java
+++ b/src/main/java/net/ladenthin/llama/ModelMeta.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/ModelParameters.java
+++ b/src/main/java/net/ladenthin/llama/ModelParameters.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/OSInfo.java
+++ b/src/main/java/net/ladenthin/llama/OSInfo.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/Pair.java
+++ b/src/main/java/net/ladenthin/llama/Pair.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/ProcessRunner.java
+++ b/src/main/java/net/ladenthin/llama/ProcessRunner.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/StopReason.java
+++ b/src/main/java/net/ladenthin/llama/StopReason.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/CacheType.java
+++ b/src/main/java/net/ladenthin/llama/args/CacheType.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/CliArg.java
+++ b/src/main/java/net/ladenthin/llama/args/CliArg.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/GpuSplitMode.java
+++ b/src/main/java/net/ladenthin/llama/args/GpuSplitMode.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/LogFormat.java
+++ b/src/main/java/net/ladenthin/llama/args/LogFormat.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/MiroStat.java
+++ b/src/main/java/net/ladenthin/llama/args/MiroStat.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/ModelFlag.java
+++ b/src/main/java/net/ladenthin/llama/args/ModelFlag.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/NumaStrategy.java
+++ b/src/main/java/net/ladenthin/llama/args/NumaStrategy.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/PoolingType.java
+++ b/src/main/java/net/ladenthin/llama/args/PoolingType.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/ReasoningFormat.java
+++ b/src/main/java/net/ladenthin/llama/args/ReasoningFormat.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/RopeScalingType.java
+++ b/src/main/java/net/ladenthin/llama/args/RopeScalingType.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/args/Sampler.java
+++ b/src/main/java/net/ladenthin/llama/args/Sampler.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/json/ChatResponseParser.java
+++ b/src/main/java/net/ladenthin/llama/json/ChatResponseParser.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/json/CompletionResponseParser.java
+++ b/src/main/java/net/ladenthin/llama/json/CompletionResponseParser.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/json/ParameterJsonSerializer.java
+++ b/src/main/java/net/ladenthin/llama/json/ParameterJsonSerializer.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/main/java/net/ladenthin/llama/json/RerankResponseParser.java
+++ b/src/main/java/net/ladenthin/llama/json/RerankResponseParser.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/cpp/test_jni_helpers.cpp
+++ b/src/test/cpp/test_jni_helpers.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/cpp/test_json_helpers.cpp
+++ b/src/test/cpp/test_json_helpers.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/cpp/test_server.cpp
+++ b/src/test/cpp/test_server.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/cpp/test_utils.cpp
+++ b/src/test/cpp/test_utils.cpp
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/examples/ChatExample.java
+++ b/src/test/java/examples/ChatExample.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/examples/GrammarExample.java
+++ b/src/test/java/examples/GrammarExample.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/examples/InfillExample.java
+++ b/src/test/java/examples/InfillExample.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/examples/MainExample.java
+++ b/src/test/java/examples/MainExample.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ChatAdvancedTest.java
+++ b/src/test/java/net/ladenthin/llama/ChatAdvancedTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ChatScenarioTest.java
+++ b/src/test/java/net/ladenthin/llama/ChatScenarioTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ClaudeGenerated.java
+++ b/src/test/java/net/ladenthin/llama/ClaudeGenerated.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ConfigureParallelInferenceTest.java
+++ b/src/test/java/net/ladenthin/llama/ConfigureParallelInferenceTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ErrorHandlingTest.java
+++ b/src/test/java/net/ladenthin/llama/ErrorHandlingTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/InferenceParametersTest.java
+++ b/src/test/java/net/ladenthin/llama/InferenceParametersTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/JsonEndpointParametersTest.java
+++ b/src/test/java/net/ladenthin/llama/JsonEndpointParametersTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/LlamaEmbeddingsTest.java
+++ b/src/test/java/net/ladenthin/llama/LlamaEmbeddingsTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/LlamaExceptionTest.java
+++ b/src/test/java/net/ladenthin/llama/LlamaExceptionTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/LlamaLoaderTest.java
+++ b/src/test/java/net/ladenthin/llama/LlamaLoaderTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/LlamaModelTest.java
+++ b/src/test/java/net/ladenthin/llama/LlamaModelTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/LlamaOutputTest.java
+++ b/src/test/java/net/ladenthin/llama/LlamaOutputTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/LogLevelTest.java
+++ b/src/test/java/net/ladenthin/llama/LogLevelTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/MemoryManagementTest.java
+++ b/src/test/java/net/ladenthin/llama/MemoryManagementTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ModelMetaTest.java
+++ b/src/test/java/net/ladenthin/llama/ModelMetaTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ModelParametersExtendedTest.java
+++ b/src/test/java/net/ladenthin/llama/ModelParametersExtendedTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ModelParametersTest.java
+++ b/src/test/java/net/ladenthin/llama/ModelParametersTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/OSInfoTest.java
+++ b/src/test/java/net/ladenthin/llama/OSInfoTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/PairTest.java
+++ b/src/test/java/net/ladenthin/llama/PairTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ReasoningBudgetTest.java
+++ b/src/test/java/net/ladenthin/llama/ReasoningBudgetTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/RerankingModelTest.java
+++ b/src/test/java/net/ladenthin/llama/RerankingModelTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/ResponseJsonStructureTest.java
+++ b/src/test/java/net/ladenthin/llama/ResponseJsonStructureTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/StopReasonTest.java
+++ b/src/test/java/net/ladenthin/llama/StopReasonTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/TestConstants.java
+++ b/src/test/java/net/ladenthin/llama/TestConstants.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/CacheTypeTest.java
+++ b/src/test/java/net/ladenthin/llama/args/CacheTypeTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/GpuSplitModeTest.java
+++ b/src/test/java/net/ladenthin/llama/args/GpuSplitModeTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/LogFormatTest.java
+++ b/src/test/java/net/ladenthin/llama/args/LogFormatTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/MiroStatTest.java
+++ b/src/test/java/net/ladenthin/llama/args/MiroStatTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/ModelFlagTest.java
+++ b/src/test/java/net/ladenthin/llama/args/ModelFlagTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/NumaStrategyTest.java
+++ b/src/test/java/net/ladenthin/llama/args/NumaStrategyTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/PoolingTypeTest.java
+++ b/src/test/java/net/ladenthin/llama/args/PoolingTypeTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/RopeScalingTypeTest.java
+++ b/src/test/java/net/ladenthin/llama/args/RopeScalingTypeTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/args/SamplerTest.java
+++ b/src/test/java/net/ladenthin/llama/args/SamplerTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/json/ChatResponseParserTest.java
+++ b/src/test/java/net/ladenthin/llama/json/ChatResponseParserTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/json/CompletionResponseParserTest.java
+++ b/src/test/java/net/ladenthin/llama/json/CompletionResponseParserTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/json/ParameterJsonSerializerTest.java
+++ b/src/test/java/net/ladenthin/llama/json/ParameterJsonSerializerTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/test/java/net/ladenthin/llama/json/RerankResponseParserTest.java
+++ b/src/test/java/net/ladenthin/llama/json/RerankResponseParserTest.java
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
-// SPDX-FileCopyrightText: 2023-2025 Konstantin Heurer
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
 //
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
## Summary

- Corrects the spelling of a copyright holder's name from "Heurer" to "Herud" across all project files
- Updates SPDX-FileCopyrightText headers in configuration files, source code, and build scripts
- Adds missing copyright attribution to `.gitattributes`

## Test plan

- [ ] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01AgCnWF7K52sanDcL5rvJcN