### PR TITLE
Add ContinuationMode enum for channel-specific message continuation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b9198**
+Current llama.cpp pinned version: **b9219**
 
 ## Upgrading CUDA Version
 
@@ -293,6 +293,14 @@ Also review the project `CMakeLists.txt` for build-system-level breaks (e.g. ren
 | ~b9172–b9198 | `vendor/cpp-httplib/httplib.{h,cpp}` | Bumped to v0.45.0: RFC 9112 §6 message-body framing — requests without `Content-Length` / `Transfer-Encoding` no longer scan for stray body bytes on persistent connections (fixes #2450 keep-alive misframing); X-Forwarded-For parser falls back to the connection remote address when the header is empty/malformed; compiled automatically, no project changes |
 | ~b9172–b9198 | `ggml/CMakeLists.txt` | GGML version bumped 0.11.1 → 0.12.0; no project changes |
 | ~b9172–b9198 | `ggml/src/ggml.c` + `ggml-cuda/gated_delta_net.cu` + `ggml-metal/ggml-metal.metal` + `ggml-vulkan/vulkan-shaders/gated_delta_net.comp` | `ggml_gated_delta_net` state tensor reshaped from 2D `(S_v*S_v*H, n_seqs)` to 3D `(S_v*S_v*H, K, n_seqs)` where `K` is the snapshot slot count (`K=1` is final-state-only, `K>1` keeps last `min(n_tokens, K)` per-token snapshots); internal Qwen3.5 / Qwen3-Next recurrent-attention kernel, no project changes |
+| ~b9198–b9219 | `common/chat.{h,cpp}` | New `common_chat_continuation` enum (`NONE`/`AUTO`/`REASONING`/`CONTENT`); new `common_chat_msg::render_content(delimiter)` method; new `continue_final_message` field on `common_chat_templates_inputs`; new `common_chat_continuation_parse()` accepts both `bool` and `"reasoning_content"`/`"content"` strings; `common_chat_template_generation_prompt()` extracted; `oaicompat_chat_params_parse` refactored to route the prefill-assistant heuristic through the new continuation enum. Existing `bool` wire-format unchanged; the new string variants are exposed via `InferenceParameters.setContinueFinalMessage(ContinuationMode)` |
+| ~b9198–b9219 | `common/hf-cache.{h,cpp}` + `common/arg.cpp` | `hf_cache::migrate_old_cache_to_hf_cache()` and `hf_file::size` field removed; the migration call in `common_params_parse_ex` was dropped. Internal to `arg.cpp`, no project impact |
+| ~b9198–b9219 | `common/speculative.{h,cpp}` + `src/llama-ext.h` + `src/llama-context.{h,cpp}` + `src/llama-cparams.h` | `llama_set_embeddings_pre_norm(ctx, value)` → `llama_set_embeddings_pre_norm(ctx, value, masked)` (3rd `bool` arg distinguishes "embeddings for outputs only" from "embeddings for every token"); new `cparams.embeddings_pre_norm_masked`; new `common_speculative_need_embd_pre_norm()` API; MTP draft path now uses pre-norm extraction. Project does not call any of these APIs (speculative decoding is configured via `ModelParameters` only), no source changes required |
+| ~b9198–b9219 | `tools/server/server-task.{h,cpp}` | `task_result_state` ctor moved from header into `.cpp` — now seeds `chat_msg` via `common_chat_parse("", true, …)` when `!echo` so the assistant prefill is not echoed back as a delta; new `bool echo` field on `chat_parser_params` (default `false`, populated from request body via `json_value(data, "echo", false)`). Project compiles `server-task.cpp` from upstream and does not instantiate `task_result_state` directly, no source changes required |
+| ~b9198–b9219 | `tools/server/server-context.cpp` + `server-models.cpp` | New `cors_proxy_enabled` boolean field added to `/props` and `/v1/models` JSON responses (set from `params.ui_mcp_proxy \|\| params.webui_mcp_proxy`). Additive, no Java consumer in this project |
+| ~b9198–b9219 | upstream `CMakeLists.txt` | Backward-compat shim widened: `if(DEFINED LLAMA_BUILD_WEBUI AND NOT DEFINED LLAMA_BUILD_UI)` → `if(DEFINED LLAMA_BUILD_WEBUI)` — setting the old name now always forwards to the new one (and emits the existing `DEPRECATION` message). Project sets only `LLAMA_BUILD_WEBUI OFF CACHE BOOL "" FORCE` (`CMakeLists.txt:107`), behaviour unchanged |
+| ~b9198–b9219 | `ggml/src/ggml-cuda/ssm-conv.cu` + `top-k.cu` | Added kernel size 15 to SSM-conv launcher (now supports 3/4/5/9/15); `top-k.cu` includes `<cuda/iterator>` for CCCL ≥ 3.1; internal CUDA backend, no project changes |
+| ~b9198–b9219 | `ggml/src/ggml-sycl/ggml-sycl.cpp` + `vecdotq.hpp` | SYCL GEMM now falls back to direct MKL for small problems (gemm_flops < 256³); Q6_K dot product refactored to a single scalar fast-path helper `vec_dot_q6_K_q8_1_impl_mmvq_scalar`; internal SYCL backend, no project changes |
 
 ## Build Commands
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ set(LLAMA_BUILD_WEBUI OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b9198
+	GIT_TAG        b9219
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **Build:**  
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)  
 ![JUnit](https://img.shields.io/badge/tested%20with-JUnit4-yellow)  
-[![llama.cpp b9198](https://img.shields.io/badge/llama.cpp-%23b9198-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9198)  
+[![llama.cpp b9219](https://img.shields.io/badge/llama.cpp-%23b9219-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9219)  
 [![Publish](https://github.com/bernardladenthin/java-llama.cpp/actions/workflows/publish.yml/badge.svg)](https://github.com/bernardladenthin/java-llama.cpp/actions/workflows/publish.yml)  
 [![CodeQL](https://github.com/bernardladenthin/java-llama.cpp/actions/workflows/codeql.yml/badge.svg)](https://github.com/bernardladenthin/java-llama.cpp/actions/workflows/codeql.yml)  
 

--- a/src/main/java/net/ladenthin/llama/InferenceParameters.java
+++ b/src/main/java/net/ladenthin/llama/InferenceParameters.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import net.ladenthin.llama.args.ContinuationMode;
 import net.ladenthin.llama.args.MiroStat;
 import net.ladenthin.llama.args.ReasoningFormat;
 import net.ladenthin.llama.args.Sampler;
@@ -610,6 +611,21 @@ public final class InferenceParameters extends JsonParameters {
 	 */
 	public InferenceParameters setContinueFinalMessage(boolean continueFinalMessage) {
 		parameters.put(PARAM_CONTINUE_FINAL_MESSAGE, String.valueOf(continueFinalMessage));
+		return this;
+	}
+
+	/**
+	 * Continue the final assistant message and pin the continuation to a specific channel.
+	 * Selects the reasoning or content portion of the last assistant message to extend from,
+	 * matching llama.cpp's string-valued {@code continue_final_message}
+	 * ({@code "reasoning_content"} or {@code "content"}). Mutually exclusive with
+	 * {@code add_generation_prompt=true}.
+	 *
+	 * @param mode the channel to continue from
+	 * @return this builder
+	 */
+	public InferenceParameters setContinueFinalMessage(ContinuationMode mode) {
+		parameters.put(PARAM_CONTINUE_FINAL_MESSAGE, toJsonString(mode.getValue()));
 		return this;
 	}
 

--- a/src/main/java/net/ladenthin/llama/args/ContinuationMode.java
+++ b/src/main/java/net/ladenthin/llama/args/ContinuationMode.java
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+package net.ladenthin.llama.args;
+
+/**
+ * Channel of a prefilled assistant message that the model continues from
+ * when {@code continue_final_message} is used on the chat completions endpoint.
+ *
+ * <p>Maps to the string-valued branch of llama.cpp's
+ * {@code common_chat_continuation_parse}. The boolean form
+ * ({@code true}/{@code false}) is exposed separately via
+ * {@code InferenceParameters.setContinueFinalMessage(boolean)}.
+ */
+public enum ContinuationMode {
+
+    /** Continue inside the reasoning channel of the last assistant message. */
+    REASONING_CONTENT("reasoning_content"),
+
+    /** Continue inside the content channel of the last assistant message. */
+    CONTENT("content");
+
+    private final String value;
+
+    ContinuationMode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/test/java/net/ladenthin/llama/InferenceParametersTest.java
+++ b/src/test/java/net/ladenthin/llama/InferenceParametersTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.ladenthin.llama.args.ContinuationMode;
 import net.ladenthin.llama.args.MiroStat;
 import net.ladenthin.llama.args.ReasoningFormat;
 import net.ladenthin.llama.args.Sampler;
@@ -307,6 +308,20 @@ public class InferenceParametersTest {
 	public void testSetContinueFinalMessageFalse() {
 		InferenceParameters params = new InferenceParameters("").setContinueFinalMessage(false);
 		assertEquals("false", params.parameters.get("continue_final_message"));
+	}
+
+	@Test
+	public void testSetContinueFinalMessageReasoningContent() {
+		InferenceParameters params = new InferenceParameters("")
+				.setContinueFinalMessage(ContinuationMode.REASONING_CONTENT);
+		assertEquals("\"reasoning_content\"", params.parameters.get("continue_final_message"));
+	}
+
+	@Test
+	public void testSetContinueFinalMessageContent() {
+		InferenceParameters params = new InferenceParameters("")
+				.setContinueFinalMessage(ContinuationMode.CONTENT);
+		assertEquals("\"content\"", params.parameters.get("continue_final_message"));
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add new `ContinuationMode` enum to support llama.cpp's string-valued `continue_final_message` parameter (`"reasoning_content"` and `"content"`)
- Add overloaded `InferenceParameters.setContinueFinalMessage(ContinuationMode)` method to allow pinning continuation to a specific channel
- Upgrade llama.cpp from b9198 to b9219 to support the new continuation modes in `common/chat.h`

## Test plan

- [x] Added unit tests for both `ContinuationMode` enum values (`testSetContinueFinalMessageReasoningContent`, `testSetContinueFinalMessageContent`)
- [x] Existing boolean-form test (`testSetContinueFinalMessageTrue/False`) remains unchanged and passing
- [x] CI passes on this branch

## Related issues / PRs

Closes llama.cpp b9198 → b9219 upgrade tracking

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_011KGddirMTGSyJeCqgpnTUS