### PR TITLE
Upgrade llama.cpp from b9219 to b9222

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Java bindings for [llama.cpp](https://github.com/ggerganov/llama.cpp) via JNI, providing a high-level API for LLM inference in Java. The Java layer communicates with a native C++ library through JNI.
 
-Current llama.cpp pinned version: **b9219**
+Current llama.cpp pinned version: **b9222**
 
 ## Upgrading CUDA Version
 
@@ -301,6 +301,8 @@ Also review the project `CMakeLists.txt` for build-system-level breaks (e.g. ren
 | ~b9198–b9219 | upstream `CMakeLists.txt` | Backward-compat shim widened: `if(DEFINED LLAMA_BUILD_WEBUI AND NOT DEFINED LLAMA_BUILD_UI)` → `if(DEFINED LLAMA_BUILD_WEBUI)` — setting the old name now always forwards to the new one (and emits the existing `DEPRECATION` message). Project sets only `LLAMA_BUILD_WEBUI OFF CACHE BOOL "" FORCE` (`CMakeLists.txt:107`), behaviour unchanged |
 | ~b9198–b9219 | `ggml/src/ggml-cuda/ssm-conv.cu` + `top-k.cu` | Added kernel size 15 to SSM-conv launcher (now supports 3/4/5/9/15); `top-k.cu` includes `<cuda/iterator>` for CCCL ≥ 3.1; internal CUDA backend, no project changes |
 | ~b9198–b9219 | `ggml/src/ggml-sycl/ggml-sycl.cpp` + `vecdotq.hpp` | SYCL GEMM now falls back to direct MKL for small problems (gemm_flops < 256³); Q6_K dot product refactored to a single scalar fast-path helper `vec_dot_q6_K_q8_1_impl_mmvq_scalar`; internal SYCL backend, no project changes |
+| ~b9219–b9222 | `ggml/src/ggml-hexagon/` + `htp/pad-ops.c` (new) + `htp/unary-ops.c` | Hexagon HTP backend gains `GGML_OP_PAD` (HVX + optional VTCM/DMA double-buffered, both zero-pad and circular-pad variants) and `GGML_OP_TRI` (HVX-vectorised triangular masking) support; new `HTP_OP_PAD` / `HTP_OP_TRI` opcodes; internal Qualcomm DSP backend, no project changes |
+| ~b9219–b9222 | `.devops/*.Dockerfile` + `.github/workflows/docker.yml` | OCI image labels (`org.opencontainers.image.*`) added via `BUILD_DATE`/`APP_VERSION`/`APP_REVISION` build args; new `skip_s390x` workflow_dispatch input; manifest annotations on `docker buildx imagetools create`; upstream packaging/CI only, no project changes |
 
 ## Build Commands
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ set(LLAMA_BUILD_WEBUI OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b9219
+	GIT_TAG        b9222
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **Build:**  
 ![Java 11+](https://img.shields.io/badge/Java-11%2B-informational)  
 ![JUnit](https://img.shields.io/badge/tested%20with-JUnit4-yellow)  
-[![llama.cpp b9219](https://img.shields.io/badge/llama.cpp-%23b9219-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9219)  
+[![llama.cpp b9222](https://img.shields.io/badge/llama.cpp-%23b9222-informational)](https://github.com/ggml-org/llama.cpp/releases/tag/b9222)  
 [![Publish](https://github.com/bernardladenthin/java-llama.cpp/actions/workflows/publish.yml/badge.svg)](https://github.com/bernardladenthin/java-llama.cpp/actions/workflows/publish.yml)  
 [![CodeQL](https://github.com/bernardladenthin/java-llama.cpp/actions/workflows/codeql.yml/badge.svg)](https://github.com/bernardladenthin/java-llama.cpp/actions/workflows/codeql.yml)  
 


### PR DESCRIPTION
## Summary

- Upgrade llama.cpp dependency from b9219 to b9222
- Update documentation to reflect new pinned version
- No breaking API changes detected in this version range

## Test plan

- [x] CI is green on this branch
- [x] Docs updated (CLAUDE.md, README.md, CMakeLists.txt)

## Related issues / PRs

None

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_012E3kENGEVkcQEuDba7pwzz