### PR TITLE
Refactor CliArg enum tests into shared base class

### DIFF
--- a/src/test/java/net/ladenthin/llama/args/AbstractCliArgEnumTest.java
+++ b/src/test/java/net/ladenthin/llama/args/AbstractCliArgEnumTest.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+// SPDX-FileCopyrightText: 2023-2025 Konstantin Herud
+//
+// SPDX-License-Identifier: MIT
+
+package net.ladenthin.llama.args;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Shared parameterized assertions for enums implementing {@link CliArg}.
+ *
+ * <p>Subclasses declare {@code @RunWith(Parameterized.class)} and provide a
+ * {@code @Parameterized.Parameters} data method returning
+ * {@code (enumConstant, expectedArgValue, expectedEnumCount)} rows.
+ */
+public abstract class AbstractCliArgEnumTest<E extends Enum<E> & CliArg> {
+
+    private final E value;
+    private final String expectedArgValue;
+    private final int expectedEnumCount;
+
+    protected AbstractCliArgEnumTest(E value, String expectedArgValue, int expectedEnumCount) {
+        this.value = value;
+        this.expectedArgValue = expectedArgValue;
+        this.expectedEnumCount = expectedEnumCount;
+    }
+
+    @Test
+    public void testGetArgValue() {
+        assertEquals(expectedArgValue, value.getArgValue());
+    }
+
+    @Test
+    public void testEnumCount() {
+        assertEquals(expectedEnumCount, value.getDeclaringClass().getEnumConstants().length);
+    }
+
+    @Test
+    public void testImplementsCliArg() {
+        assertTrue(value instanceof CliArg);
+    }
+
+    @Test
+    public void testArgValueNonEmpty() {
+        assertNotNull(value.getArgValue());
+        assertFalse(value.getArgValue().isEmpty());
+    }
+}

--- a/src/test/java/net/ladenthin/llama/args/GpuSplitModeTest.java
+++ b/src/test/java/net/ladenthin/llama/args/GpuSplitModeTest.java
@@ -5,57 +5,25 @@
 
 package net.ladenthin.llama.args;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.*;
-
 @RunWith(Parameterized.class)
-public class GpuSplitModeTest {
+public class GpuSplitModeTest extends AbstractCliArgEnumTest<GpuSplitMode> {
 
     @Parameterized.Parameters(name = "{0} -> {1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {GpuSplitMode.NONE,  "none"},
-            {GpuSplitMode.LAYER, "layer"},
-            {GpuSplitMode.ROW,   "row"},
+            {GpuSplitMode.NONE,  "none",  3},
+            {GpuSplitMode.LAYER, "layer", 3},
+            {GpuSplitMode.ROW,   "row",   3},
         });
     }
 
-    private final GpuSplitMode gpuSplitMode;
-    private final String expectedArgValue;
-
-    public GpuSplitModeTest(GpuSplitMode gpuSplitMode, String expectedArgValue) {
-        this.gpuSplitMode = gpuSplitMode;
-        this.expectedArgValue = expectedArgValue;
-    }
-
-    @Test
-    public void testGetArgValue() {
-        assertEquals(expectedArgValue, gpuSplitMode.getArgValue());
-    }
-
-    // ------------------------------------------------------------------
-    // Structural invariants
-    // ------------------------------------------------------------------
-
-    @Test
-    public void testEnumCount() {
-        assertEquals(3, GpuSplitMode.values().length);
-    }
-
-    @Test
-    public void testImplementsCliArg() {
-        assertTrue(gpuSplitMode instanceof CliArg);
-    }
-
-    @Test
-    public void testArgValueNonEmpty() {
-        assertNotNull(gpuSplitMode.getArgValue());
-        assertFalse(gpuSplitMode.getArgValue().isEmpty());
+    public GpuSplitModeTest(GpuSplitMode value, String expectedArgValue, int expectedEnumCount) {
+        super(value, expectedArgValue, expectedEnumCount);
     }
 }

--- a/src/test/java/net/ladenthin/llama/args/MiroStatTest.java
+++ b/src/test/java/net/ladenthin/llama/args/MiroStatTest.java
@@ -5,57 +5,25 @@
 
 package net.ladenthin.llama.args;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.*;
-
 @RunWith(Parameterized.class)
-public class MiroStatTest {
+public class MiroStatTest extends AbstractCliArgEnumTest<MiroStat> {
 
     @Parameterized.Parameters(name = "{0} -> {1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {MiroStat.DISABLED, "0"},
-            {MiroStat.V1,       "1"},
-            {MiroStat.V2,       "2"},
+            {MiroStat.DISABLED, "0", 3},
+            {MiroStat.V1,       "1", 3},
+            {MiroStat.V2,       "2", 3},
         });
     }
 
-    private final MiroStat miroStat;
-    private final String expectedArgValue;
-
-    public MiroStatTest(MiroStat miroStat, String expectedArgValue) {
-        this.miroStat = miroStat;
-        this.expectedArgValue = expectedArgValue;
-    }
-
-    @Test
-    public void testGetArgValue() {
-        assertEquals(expectedArgValue, miroStat.getArgValue());
-    }
-
-    // ------------------------------------------------------------------
-    // Structural invariants
-    // ------------------------------------------------------------------
-
-    @Test
-    public void testEnumCount() {
-        assertEquals(3, MiroStat.values().length);
-    }
-
-    @Test
-    public void testImplementsCliArg() {
-        assertTrue(miroStat instanceof CliArg);
-    }
-
-    @Test
-    public void testArgValueNonEmpty() {
-        assertNotNull(miroStat.getArgValue());
-        assertFalse(miroStat.getArgValue().isEmpty());
+    public MiroStatTest(MiroStat value, String expectedArgValue, int expectedEnumCount) {
+        super(value, expectedArgValue, expectedEnumCount);
     }
 }

--- a/src/test/java/net/ladenthin/llama/args/NumaStrategyTest.java
+++ b/src/test/java/net/ladenthin/llama/args/NumaStrategyTest.java
@@ -5,57 +5,25 @@
 
 package net.ladenthin.llama.args;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.*;
-
 @RunWith(Parameterized.class)
-public class NumaStrategyTest {
+public class NumaStrategyTest extends AbstractCliArgEnumTest<NumaStrategy> {
 
     @Parameterized.Parameters(name = "{0} -> {1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {NumaStrategy.DISTRIBUTE, "distribute"},
-            {NumaStrategy.ISOLATE,    "isolate"},
-            {NumaStrategy.NUMACTL,    "numactl"},
+            {NumaStrategy.DISTRIBUTE, "distribute", 3},
+            {NumaStrategy.ISOLATE,    "isolate",    3},
+            {NumaStrategy.NUMACTL,    "numactl",    3},
         });
     }
 
-    private final NumaStrategy numaStrategy;
-    private final String expectedArgValue;
-
-    public NumaStrategyTest(NumaStrategy numaStrategy, String expectedArgValue) {
-        this.numaStrategy = numaStrategy;
-        this.expectedArgValue = expectedArgValue;
-    }
-
-    @Test
-    public void testGetArgValue() {
-        assertEquals(expectedArgValue, numaStrategy.getArgValue());
-    }
-
-    // ------------------------------------------------------------------
-    // Structural invariants
-    // ------------------------------------------------------------------
-
-    @Test
-    public void testEnumCount() {
-        assertEquals(3, NumaStrategy.values().length);
-    }
-
-    @Test
-    public void testImplementsCliArg() {
-        assertTrue(numaStrategy instanceof CliArg);
-    }
-
-    @Test
-    public void testArgValueNonEmpty() {
-        assertNotNull(numaStrategy.getArgValue());
-        assertFalse(numaStrategy.getArgValue().isEmpty());
+    public NumaStrategyTest(NumaStrategy value, String expectedArgValue, int expectedEnumCount) {
+        super(value, expectedArgValue, expectedEnumCount);
     }
 }

--- a/src/test/java/net/ladenthin/llama/args/PoolingTypeTest.java
+++ b/src/test/java/net/ladenthin/llama/args/PoolingTypeTest.java
@@ -5,60 +5,28 @@
 
 package net.ladenthin.llama.args;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.*;
-
 @RunWith(Parameterized.class)
-public class PoolingTypeTest {
+public class PoolingTypeTest extends AbstractCliArgEnumTest<PoolingType> {
 
     @Parameterized.Parameters(name = "{0} -> {1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {PoolingType.UNSPECIFIED, "unspecified"},
-            {PoolingType.NONE,        "none"},
-            {PoolingType.MEAN,        "mean"},
-            {PoolingType.CLS,         "cls"},
-            {PoolingType.LAST,        "last"},
-            {PoolingType.RANK,        "rank"},
+            {PoolingType.UNSPECIFIED, "unspecified", 6},
+            {PoolingType.NONE,        "none",        6},
+            {PoolingType.MEAN,        "mean",        6},
+            {PoolingType.CLS,         "cls",         6},
+            {PoolingType.LAST,        "last",        6},
+            {PoolingType.RANK,        "rank",        6},
         });
     }
 
-    private final PoolingType poolingType;
-    private final String expectedArgValue;
-
-    public PoolingTypeTest(PoolingType poolingType, String expectedArgValue) {
-        this.poolingType = poolingType;
-        this.expectedArgValue = expectedArgValue;
-    }
-
-    @Test
-    public void testGetArgValue() {
-        assertEquals(expectedArgValue, poolingType.getArgValue());
-    }
-
-    // ------------------------------------------------------------------
-    // Structural invariants
-    // ------------------------------------------------------------------
-
-    @Test
-    public void testEnumCount() {
-        assertEquals(6, PoolingType.values().length);
-    }
-
-    @Test
-    public void testImplementsCliArg() {
-        assertTrue(poolingType instanceof CliArg);
-    }
-
-    @Test
-    public void testArgValueNonEmpty() {
-        assertNotNull(poolingType.getArgValue());
-        assertFalse(poolingType.getArgValue().isEmpty());
+    public PoolingTypeTest(PoolingType value, String expectedArgValue, int expectedEnumCount) {
+        super(value, expectedArgValue, expectedEnumCount);
     }
 }

--- a/src/test/java/net/ladenthin/llama/args/ReasoningFormatTest.java
+++ b/src/test/java/net/ladenthin/llama/args/ReasoningFormatTest.java
@@ -12,24 +12,19 @@ import java.util.Arrays;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
-public class CacheTypeTest extends AbstractCliArgEnumTest<CacheType> {
+public class ReasoningFormatTest extends AbstractCliArgEnumTest<ReasoningFormat> {
 
     @Parameterized.Parameters(name = "{0} -> {1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {CacheType.F32,    "f32",    9},
-            {CacheType.F16,    "f16",    9},
-            {CacheType.BF16,   "bf16",   9},
-            {CacheType.Q8_0,   "q8_0",   9},
-            {CacheType.Q4_0,   "q4_0",   9},
-            {CacheType.Q4_1,   "q4_1",   9},
-            {CacheType.IQ4_NL, "iq4_nl", 9},
-            {CacheType.Q5_0,   "q5_0",   9},
-            {CacheType.Q5_1,   "q5_1",   9},
+            {ReasoningFormat.NONE,            "none",            4},
+            {ReasoningFormat.AUTO,            "auto",            4},
+            {ReasoningFormat.DEEPSEEK,        "deepseek",        4},
+            {ReasoningFormat.DEEPSEEK_LEGACY, "deepseek-legacy", 4},
         });
     }
 
-    public CacheTypeTest(CacheType value, String expectedArgValue, int expectedEnumCount) {
+    public ReasoningFormatTest(ReasoningFormat value, String expectedArgValue, int expectedEnumCount) {
         super(value, expectedArgValue, expectedEnumCount);
     }
 }

--- a/src/test/java/net/ladenthin/llama/args/RopeScalingTypeTest.java
+++ b/src/test/java/net/ladenthin/llama/args/RopeScalingTypeTest.java
@@ -5,60 +5,28 @@
 
 package net.ladenthin.llama.args;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.*;
-
 @RunWith(Parameterized.class)
-public class RopeScalingTypeTest {
+public class RopeScalingTypeTest extends AbstractCliArgEnumTest<RopeScalingType> {
 
     @Parameterized.Parameters(name = "{0} -> {1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {RopeScalingType.UNSPECIFIED, "unspecified"},
-            {RopeScalingType.NONE,        "none"},
-            {RopeScalingType.LINEAR,      "linear"},
-            {RopeScalingType.YARN2,       "yarn"},
-            {RopeScalingType.LONGROPE,    "longrope"},
-            {RopeScalingType.MAX_VALUE,   "maxvalue"},
+            {RopeScalingType.UNSPECIFIED, "unspecified", 6},
+            {RopeScalingType.NONE,        "none",        6},
+            {RopeScalingType.LINEAR,      "linear",      6},
+            {RopeScalingType.YARN2,       "yarn",        6},
+            {RopeScalingType.LONGROPE,    "longrope",    6},
+            {RopeScalingType.MAX_VALUE,   "maxvalue",    6},
         });
     }
 
-    private final RopeScalingType ropeScalingType;
-    private final String expectedArgValue;
-
-    public RopeScalingTypeTest(RopeScalingType ropeScalingType, String expectedArgValue) {
-        this.ropeScalingType = ropeScalingType;
-        this.expectedArgValue = expectedArgValue;
-    }
-
-    @Test
-    public void testGetArgValue() {
-        assertEquals(expectedArgValue, ropeScalingType.getArgValue());
-    }
-
-    // ------------------------------------------------------------------
-    // Structural invariants
-    // ------------------------------------------------------------------
-
-    @Test
-    public void testEnumCount() {
-        assertEquals(6, RopeScalingType.values().length);
-    }
-
-    @Test
-    public void testImplementsCliArg() {
-        assertTrue(ropeScalingType instanceof CliArg);
-    }
-
-    @Test
-    public void testArgValueNonEmpty() {
-        assertNotNull(ropeScalingType.getArgValue());
-        assertFalse(ropeScalingType.getArgValue().isEmpty());
+    public RopeScalingTypeTest(RopeScalingType value, String expectedArgValue, int expectedEnumCount) {
+        super(value, expectedArgValue, expectedEnumCount);
     }
 }

--- a/src/test/java/net/ladenthin/llama/args/SamplerTest.java
+++ b/src/test/java/net/ladenthin/llama/args/SamplerTest.java
@@ -5,63 +5,31 @@
 
 package net.ladenthin.llama.args;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.*;
-
 @RunWith(Parameterized.class)
-public class SamplerTest {
+public class SamplerTest extends AbstractCliArgEnumTest<Sampler> {
 
     @Parameterized.Parameters(name = "{0} -> {1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {Sampler.DRY,         "dry"},
-            {Sampler.TOP_K,       "top_k"},
-            {Sampler.TOP_P,       "top_p"},
-            {Sampler.TYP_P,       "typ_p"},
-            {Sampler.MIN_P,       "min_p"},
-            {Sampler.TEMPERATURE, "temperature"},
-            {Sampler.XTC,         "xtc"},
-            {Sampler.INFILL,      "infill"},
-            {Sampler.PENALTIES,   "penalties"},
+            {Sampler.DRY,         "dry",         9},
+            {Sampler.TOP_K,       "top_k",       9},
+            {Sampler.TOP_P,       "top_p",       9},
+            {Sampler.TYP_P,       "typ_p",       9},
+            {Sampler.MIN_P,       "min_p",       9},
+            {Sampler.TEMPERATURE, "temperature", 9},
+            {Sampler.XTC,         "xtc",         9},
+            {Sampler.INFILL,      "infill",      9},
+            {Sampler.PENALTIES,   "penalties",   9},
         });
     }
 
-    private final Sampler sampler;
-    private final String expectedArgValue;
-
-    public SamplerTest(Sampler sampler, String expectedArgValue) {
-        this.sampler = sampler;
-        this.expectedArgValue = expectedArgValue;
-    }
-
-    @Test
-    public void testGetArgValue() {
-        assertEquals(expectedArgValue, sampler.getArgValue());
-    }
-
-    // ------------------------------------------------------------------
-    // Structural invariants
-    // ------------------------------------------------------------------
-
-    @Test
-    public void testEnumCount() {
-        assertEquals(9, Sampler.values().length);
-    }
-
-    @Test
-    public void testImplementsCliArg() {
-        assertTrue(sampler instanceof CliArg);
-    }
-
-    @Test
-    public void testArgValueNonEmpty() {
-        assertNotNull(sampler.getArgValue());
-        assertFalse(sampler.getArgValue().isEmpty());
+    public SamplerTest(Sampler value, String expectedArgValue, int expectedEnumCount) {
+        super(value, expectedArgValue, expectedEnumCount);
     }
 }


### PR DESCRIPTION
## Summary

- Extract common test logic from 8 parameterized enum test classes into a new `AbstractCliArgEnumTest<E>` base class
- Reduce code duplication by ~60% across enum tests (CacheType, Sampler, PoolingType, RopeScalingType, GpuSplitMode, MiroStat, NumaStrategy)
- Add test coverage for `ReasoningFormat` enum using the new base class

## Test plan

- [x] Affected unit tests pass locally (all 8 refactored enum tests + new ReasoningFormat test)
- [x] CI is green on this branch
- [x] No docs/CHANGELOG updates needed (internal test refactoring)

## Related issues / PRs

None

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01LCtDfZEtDv3wsJwerCybiN