### PR TITLE
docs: Add similar projects section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,3 +450,8 @@ rm /usr/lib/jvm/java-21/bin/msvcp140.dll
 ```
 
 The system's updated C++ runtime will be used instead, resolving the crash.
+
+## Similar Projects / Usage
+
+- [LLaMAndroid](https://github.com/Rattlyy/LLaMAndroid/tree/main/app) — Android app demonstrating usage of llama.cpp bindings.
+- [llama-stack-client-kotlin](https://github.com/ogx-ai/llama-stack-client-kotlin) — Kotlin client for the Llama Stack API.


### PR DESCRIPTION
## Summary

- Added a new "Similar Projects / Usage" section to the README documenting related projects that use llama.cpp bindings
- Included references to LLaMAndroid (Android app) and llama-stack-client-kotlin (Kotlin client) as examples of llama.cpp integration

## Test plan

- [x] No testing needed — documentation-only change

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01Dik5tqksUvPofkBmTxiRmW