### PR TITLE
docs: Add llama.cpp-android-tutorial to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,3 +518,4 @@ The system's updated C++ runtime will be used instead, resolving the crash.
 
 - [LLaMAndroid](https://github.com/Rattlyy/LLaMAndroid/tree/main/app) — Android app demonstrating usage of llama.cpp bindings.
 - [llama-stack-client-kotlin](https://github.com/ogx-ai/llama-stack-client-kotlin) — Kotlin client for the Llama Stack API.
+- [llama.cpp-android-tutorial](https://github.com/JackZeng0208/llama.cpp-android-tutorial) — Step-by-step tutorial for running llama.cpp on Android.


### PR DESCRIPTION
## Summary

- Added [llama.cpp-android-tutorial](https://github.com/JackZeng0208/llama.cpp-android-tutorial) to the list of related Android projects in README.md
- This tutorial provides step-by-step guidance for running llama.cpp on Android, complementing the existing LLaMAndroid and llama-stack-client-kotlin examples

## Test plan

- [x] CI is green on this branch
- [x] Docs updated (README.md)

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01WW5Ki2GroqBce6Bsav4UhN