### PR TITLE
Downgrade jqwik to 1.9.3 and document QuickTheories replacement plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -702,9 +702,11 @@ interim measure until that work lands.
 
 ## Open TODOs
 
-- **[URGENT] Replace jqwik.** Upstream is openly hostile to the AI-assisted workflow this project uses (jqwik 1.10.0 added a deliberate prompt-injection string to test stdout; jqwik 1.10.1 release notes added: *"This project is not meant to be used by any 'AI' coding agents at all."*). See the "jqwik prompt-injection in test output" section above for context and links. Replace the one jqwik test class in this repo (`LlamaParameterProperties`) with one of:
-  - **junit-quickcheck** (`com.pholser:junit-quickcheck-core` + `-generators`) — closest API match; uses JUnit Vintage runner, well-maintained, no anti-AI behaviour.
-  - A minimal hand-rolled `@ParameterizedTest` + `@MethodSource`/`@ArgumentsSource` approach using JUnit Jupiter that is already on the classpath. Lower dependency count; some shrinking / generator features lost.
+- **[URGENT] Replace jqwik with QuickTheories.** Upstream is openly hostile to the AI-assisted workflow this project uses (jqwik 1.10.0 added a deliberate prompt-injection string to test stdout; jqwik 1.10.1 release notes added: *"This project is not meant to be used by any 'AI' coding agents at all."*). See the "jqwik prompt-injection in test output" section above for context and links. Replace the one jqwik test class in this repo (`LlamaParameterProperties`) with one of (in order of preference):
+  - **QuickTheories** (`org.quicktheories:quicktheories`, MIT) — preferred. Native JUnit Jupiter (5/6); plain `@Test` methods with `qt().forAll(...).check(...)` bodies. No `@RunWith`, no JUnit Vintage engine. Property-based generation with shrinking preserved; the fluent DSL (`integers().between(...)`, `floats().between(...)`, `strings().basicLatinAlphabet().ofLengthBetween(...)`) covers every constraint the current jqwik tests use.
+  - **junit-quickcheck** (`com.pholser:junit-quickcheck-core` + `-generators`) — closest annotation match to jqwik but requires the JUnit Vintage engine alongside Jupiter; only use if the QuickTheories DSL turns out to be a poor fit.
+  - A minimal hand-rolled `@ParameterizedTest` + `@MethodSource`/`@ArgumentsSource` approach using JUnit Jupiter that is already on the classpath. Lower dependency count; loses shrinking and built-in generators.
+
   Remove the jqwik dependency from `pom.xml` (and the `jqwik.version` property), drop the jqwik bullet from any test-frameworks documentation, and verify CI is green with the replacement. Until this lands, the doc-only warning section above is the interim mitigation.
 
 - **`@VisibleForTesting` audit.** No usages currently. Walk the production tree for package-private/protected methods or fields that exist purely so tests can reach them, and either annotate (`com.google.common.annotations.VisibleForTesting`) or move into the test source tree.

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ SPDX-License-Identifier: MIT
 		<jcstress.version>0.16</jcstress.version>
 		<lincheck.version>2.39</lincheck.version>
 		<vmlens.version>1.2.28</vmlens.version>
-		<jqwik.version>1.10.0</jqwik.version>
+		<jqwik.version>1.9.3</jqwik.version>
 		<archunit.version>1.4.2</archunit.version>
 		<spotbugs.version>4.9.8.3</spotbugs.version>
 		<fb-contrib.version>7.6.4</fb-contrib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@ SPDX-License-Identifier: MIT
 		<jcstress.version>0.16</jcstress.version>
 		<lincheck.version>2.39</lincheck.version>
 		<vmlens.version>1.2.28</vmlens.version>
+		<!-- DO NOT UPGRADE: jqwik >= 1.10.0 ships an anti-AI prompt-injection string in test stdout; see CLAUDE.md. Replacement (QuickTheories) tracked as an URGENT TODO. -->
 		<jqwik.version>1.9.3</jqwik.version>
 		<archunit.version>1.4.2</archunit.version>
 		<spotbugs.version>4.9.8.3</spotbugs.version>


### PR DESCRIPTION
## Summary

- Downgrade jqwik from 1.10.0 to 1.9.3 to avoid the anti-AI prompt-injection string added in 1.10.0+
- Add explanatory comment in `pom.xml` documenting why jqwik cannot be upgraded
- Update the URGENT TODO in `CLAUDE.md` to prioritize QuickTheories as the replacement, with detailed rationale and migration guidance

## Rationale

jqwik 1.10.0+ deliberately injects a prompt-injection string into test stdout and explicitly states the project is "not meant to be used by any 'AI' coding agents at all." This is incompatible with the AI-assisted workflow this project uses. The downgrade to 1.9.3 is a temporary mitigation while the replacement work (tracked as URGENT) is completed.

The TODO update clarifies that QuickTheories is the preferred replacement due to:
- Native JUnit Jupiter 5/6 support (no JUnit Vintage engine required)
- Fluent DSL covering all current jqwik test constraints
- Property-based generation with shrinking preserved
- MIT license

## Test plan

- No testing needed; this is a configuration and documentation change
- CI should remain green (jqwik 1.9.3 is functionally equivalent to 1.10.0 for the existing test suite)

## Related issues / PRs

Tracks the URGENT TODO for replacing jqwik with QuickTheories

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01XigFKHMf8r7HLsLHts1J1K