### PR TITLE
Upgrade Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,14 @@ SPDX-License-Identifier: MIT
 	</distributionManagement>
 
 	<properties>
-		<jna.version>5.18.1</jna.version>
+		<jna.version>5.19.0</jna.version>
 		<jspecify.version>1.0.0</jspecify.version>
 		<lombok.version>1.18.46</lombok.version>
 		<errorprone.version>2.49.0</errorprone.version>
-		<nullaway.version>0.13.4</nullaway.version>
+		<nullaway.version>0.13.6</nullaway.version>
 		<checker.version>4.2.0</checker.version>
 		<jackson.version>2.22.0</jackson.version>
-		<reactor.version>3.6.11</reactor.version>
+		<reactor.version>3.8.5</reactor.version>
 		<slf4j.version>2.0.18</slf4j.version>
 		<logback.version>1.5.34</logback.version>
 		<animal-sniffer.version>1.27</animal-sniffer.version>
@@ -64,7 +64,7 @@ SPDX-License-Identifier: MIT
 		<jmh.version>1.37</jmh.version>
 		<jcstress.version>0.16</jcstress.version>
 		<lincheck.version>3.6</lincheck.version>
-		<logcaptor.version>2.10.1</logcaptor.version>
+		<logcaptor.version>2.12.6</logcaptor.version>
 		<vmlens.version>1.2.28</vmlens.version>
 		<!-- DO NOT UPGRADE jqwik past 1.9.3. jqwik 1.10.0 added a deliberate
 		     anti-AI prompt-injection string to test stdout; the 1.10.1 user
@@ -284,7 +284,7 @@ SPDX-License-Identifier: MIT
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.14</version>
+					<version>0.8.15</version>
 				</plugin>
 				<plugin>
 					<groupId>org.pitest</groupId>


### PR DESCRIPTION
## Summary

- Upgrade JNA from 5.18.1 to 5.19.0
- Upgrade NullAway from 0.13.4 to 0.13.6
- Upgrade Reactor from 3.6.11 to 3.8.5
- Upgrade LogCaptor from 2.10.1 to 2.12.6
- Upgrade JaCoCo from 0.8.14 to 0.8.15

These are routine dependency updates to pull in the latest bug fixes and improvements from upstream projects.

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01Dd2pKJ9sid6Dh4v1AnYGmV