### PR TITLE
Upgrade spotbugs and pitest-maven to latest patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Anti-AI policy: jqwik >=1.10 injects prompts targeting AI agents in test
+    # stdout. Pinned at 1.9.3; block ALL net.jqwik updates. See README.
+    ignore:
+      - dependency-name: "net.jqwik:*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ The system's updated C++ runtime will be used instead, resolving the crash.
 
 ### Contributors: do not upgrade jqwik past 1.9.3
 
-> ⚠️ **DO NOT UPGRADE jqwik past 1.9.3.** jqwik 1.10.0 added an anti-AI prompt-injection string to test stdout; the 1.10.1 user guide states the library "is not meant to be used by any 'AI' coding agents at all." 1.9.3 is the last pre-disclosure release and is the pinned version. See `CLAUDE.md` section "jqwik prompt-injection in test output" for the full context.
+> ⚠️ **DO NOT UPGRADE jqwik past 1.9.3.** jqwik 1.10.0 added an anti-AI prompt-injection string to test stdout; the 1.10.1 user guide states the library "is not meant to be used by any 'AI' coding agents at all." 1.9.3 is the last pre-disclosure release and is the pinned version. See `CLAUDE.md` section "jqwik prompt-injection in test output" for the full context. Dependabot is configured to ignore **all** `net.jqwik` updates (every version, including patches) — see the `ignore` rule in [`.github/dependabot.yml`](./.github/dependabot.yml).
 
 ## Similar Projects / Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ SPDX-License-Identifier: MIT
 		     section "jqwik prompt-injection in test output" for full context. -->
 		<jqwik.version>1.9.3</jqwik.version>
 		<archunit.version>1.4.2</archunit.version>
-		<spotbugs.version>4.9.8.3</spotbugs.version>
+		<spotbugs.version>4.9.8.4</spotbugs.version>
 		<fb-contrib.version>7.7.4</fb-contrib.version>
 		<findsecbugs.version>1.14.0</findsecbugs.version>
 		<spotless.version>3.6.0</spotless.version>
@@ -296,7 +296,7 @@ SPDX-License-Identifier: MIT
 				<plugin>
 					<groupId>org.pitest</groupId>
 					<artifactId>pitest-maven</artifactId>
-					<version>1.25.3</version>
+					<version>1.25.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.sonatype.central</groupId>
@@ -643,7 +643,7 @@ SPDX-License-Identifier: MIT
 					  mutation parity, gated at a 100% threshold on every CI build. Expand
 					  the targetClasses globs as further packages reach parity (see README
 					  TODO). The value/ and exception/ trees are at 100% (verified with
-					  pitest-maven 1.25.3); their unit tests are pure-Java (no native
+					  pitest-maven 1.25.4); their unit tests are pure-Java (no native
 					  libjllama / model file needed).
 				-->
 				<groupId>org.pitest</groupId>


### PR DESCRIPTION
## Summary

- Upgrade `spotbugs` from 4.9.8.3 to 4.9.8.4
- Upgrade `pitest-maven` from 1.25.3 to 1.25.4
- Update documentation and Dependabot configuration to enforce jqwik version pinning

## Test plan

- [x] CI is green on this branch
- [x] Docs updated where applicable

## Related issues / PRs

None

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

## Notes

The spotbugs and pitest-maven upgrades are routine patch version bumps with no breaking changes. The Dependabot configuration change adds an `ignore` rule to block all `net.jqwik` updates (every version, including patches) due to the anti-AI prompt-injection policy documented in the README. This prevents accidental upgrades past jqwik 1.9.3, which is the last pre-disclosure release before the library added prompt-injection strings targeting AI agents in test output.

https://claude.ai/code/session_01XEjgThAas1gQV65HK6kSqM