### PR TITLE
Upgrade palantir-java-format from 2.91.0 to 2.92.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ SPDX-License-Identifier: MIT
 		<fb-contrib.version>7.7.4</fb-contrib.version>
 		<findsecbugs.version>1.14.0</findsecbugs.version>
 		<spotless.version>3.6.0</spotless.version>
-		<palantir-java-format.version>2.91.0</palantir-java-format.version>
+		<palantir-java-format.version>2.92.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
 	</properties>


### PR DESCRIPTION
## Summary

- Bumps `palantir-java-format` dependency from version 2.91.0 to 2.92.0
- This is a minor version update to the Java code formatter used by Spotless

## Test plan

- [x] CI is green on this branch (dependency update only, no code changes)

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_014yVpSSsdKVEjrYwLek3tTK