### PR TITLE
Upgrade Android minimum API level from 24 to 28

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,6 @@ jobs:
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }
       - name: Build with Maven
-        run: mvn --batch-mode compile
+        run: mvn --batch-mode --no-transfer-progress compile
       - uses: github/codeql-action/analyze@v4
         with: { category: "/language:java" }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Build libraries
         shell: bash
         run: |
-          .github/dockcross/dockcross-android-arm64 .github/build.sh "-DANDROID_PLATFORM=android-24 -DOS_NAME=Linux-Android -DOS_ARCH=aarch64"
+          .github/dockcross/dockcross-android-arm64 .github/build.sh "-DANDROID_PLATFORM=android-28 -DOS_NAME=Linux-Android -DOS_ARCH=aarch64"
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -180,7 +180,7 @@ jobs:
       - name: Build libraries
         shell: bash
         run: |
-          .github/dockcross/dockcross-android-arm64 .github/build_opencl_android.sh "-DANDROID_PLATFORM=android-24 -DOS_NAME=Linux-Android -DOS_ARCH=aarch64 -DGGML_OPENCL=ON -DGGML_OPENCL_EMBED_KERNELS=ON -DGGML_OPENCL_USE_ADRENO_KERNELS=ON"
+          .github/dockcross/dockcross-android-arm64 .github/build_opencl_android.sh "-DANDROID_PLATFORM=android-28 -DOS_NAME=Linux-Android -DOS_ARCH=aarch64 -DGGML_OPENCL=ON -DGGML_OPENCL_EMBED_KERNELS=ON -DGGML_OPENCL_USE_ADRENO_KERNELS=ON"
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -212,7 +212,7 @@ jobs:
       - name: Build libraries
         shell: bash
         run: |
-          mvn compile
+          mvn --no-transfer-progress compile
           .github/build.sh -DLLAMA_METAL=OFF -DGGML_NATIVE=OFF -DBUILD_TESTING=ON
       - name: Run C++ unit tests
         run: ctest --test-dir build --output-on-failure
@@ -243,7 +243,7 @@ jobs:
       - name: Build libraries
         shell: bash
         run: |
-          mvn compile
+          mvn --no-transfer-progress compile
           .github/build.sh -DLLAMA_METAL_EMBED_LIBRARY=ON -DBUILD_TESTING=ON
       - name: Run C++ unit tests
         run: ctest --test-dir build --output-on-failure
@@ -334,7 +334,7 @@ jobs:
           cat /proc/cpuinfo
       - name: Build libraries
         run: |
-          mvn -q compile
+          mvn -q --no-transfer-progress compile
           .github/build.sh -DBUILD_TESTING=ON
       - name: Run C++ unit tests
         run: ctest --test-dir build --output-on-failure
@@ -360,7 +360,7 @@ jobs:
       - name: Build libraries
         shell: bash
         run: |
-          mvn compile
+          mvn --no-transfer-progress compile
           .github/build.sh -DLLAMA_METAL_EMBED_LIBRARY=ON -DGGML_NATIVE=OFF -DBUILD_TESTING=ON
       - name: Run C++ unit tests
         run: ctest --test-dir build --output-on-failure
@@ -873,7 +873,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish snapshot
-        run: mvn --batch-mode -P release,cuda,opencl-android -Dmaven.test.skip=true deploy
+        run: mvn --batch-mode --no-transfer-progress -P release,cuda,opencl-android -Dmaven.test.skip=true deploy
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
@@ -948,7 +948,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish release
-        run: mvn --batch-mode -P release,cuda,opencl-android -Dmaven.test.skip=true deploy
+        run: mvn --batch-mode --no-transfer-progress -P release,cuda,opencl-android -Dmaven.test.skip=true deploy
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=bernardladenthin_java-llama.cpp
+        run: mvn -B --no-transfer-progress verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=bernardladenthin_java-llama.cpp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Three places wire it together (mirrors the CUDA classifier pattern):
 Local sanity build:
 ```bash
 .github/dockcross/dockcross-android-arm64 .github/build_opencl_android.sh \
-  "-DANDROID_PLATFORM=android-24 -DOS_NAME=Linux-Android -DOS_ARCH=aarch64 \
+  "-DANDROID_PLATFORM=android-28 -DOS_NAME=Linux-Android -DOS_ARCH=aarch64 \
    -DGGML_OPENCL=ON -DGGML_OPENCL_EMBED_KERNELS=ON \
    -DGGML_OPENCL_USE_ADRENO_KERNELS=ON"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,20 @@ git add .github/build_cuda_linux.sh pom.xml CLAUDE.md
 git commit -m "Upgrade CUDA from 13.2 to 13.3"
 ```
 
+## Android minimum API level
+
+Current Android minimum API level: **28** (Android 9.0 Pie)
+
+To change the minimum API level, update the following **three** places:
+
+1. **`CMakeLists.txt`** — the `add_compile_definitions(__ANDROID_API__=28)` line (controls which NDK header symbols are exposed).
+2. **`.github/workflows/publish.yml`** — `-DANDROID_PLATFORM=android-28` in both the `crosscompile-android-aarch64` and `crosscompile-android-aarch64-opencl` job steps.
+3. **`CLAUDE.md`** (this file) — the "Current Android minimum API level" line above and the `-DANDROID_PLATFORM` values in the local sanity-build examples.
+
+Also update the minimum-API note in **`README.md`** (the `[!NOTE]` block near the Android classifier entries and the "Importing in Android" section).
+
+**Why API 28?** `mtmd-helper.cpp` (part of the upstream llama.cpp `mtmd` multimodal library) includes `vendor/sheredom/subprocess.h`, which calls `posix_spawn`, `posix_spawnp`, and `posix_spawn_file_actions_*`. The Android NDK headers only expose those declarations when `__ANDROID_API__ >= 28`. The symbols exist in `libc.so` at all API levels; the define only gates their header visibility.
+
 ## OpenCL / Adreno backend on Android
 
 A second Android arm64 artifact is built with the OpenCL backend enabled and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_L
     link_libraries(stdc++fs)
 endif()
 
-# Android standalone toolchains default to API level 21, but cpp-httplib uses
-# getifaddrs/freeifaddrs which are only declared in <ifaddrs.h> when
-# __ANDROID_API__ >= 24. NDK unified sysroots (r14b+) include the symbol in
-# libc regardless of level; this exposes the declaration for all targets.
+# Android NDK headers gate symbols on __ANDROID_API__:
+#   >= 24: getifaddrs/freeifaddrs (<ifaddrs.h>), needed by cpp-httplib.
+#   >= 28: posix_spawn / posix_spawnp / posix_spawn_file_actions_* (<spawn.h>),
+#          needed by mtmd-helper.cpp (vendor/sheredom/subprocess.h).
+# NDK unified sysroots (r14b+) include all these symbols in libc regardless of
+# level; the define only controls which declarations are visible in the headers.
 if(ANDROID_ABI)
-    add_compile_definitions(__ANDROID_API__=24)
+    add_compile_definitions(__ANDROID_API__=28)
 endif()
 
 set(LLAMA_BUILD_COMMON ON)

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Pick at most one — they are mutually exclusive.
 > by the released artifacts; building from source via the
 > `.github/dockcross/dockcross-android-arm` toolchain is possible but not
 > wired into CI.
+>
+> The minimum required Android version is **API 28 (Android 9.0 Pie)**.
+> Devices running Android 8.1 (API 27) or earlier are not supported.
 
 ### Setup required
 
@@ -505,6 +508,10 @@ The `LogLevel` enum values passed to the callback correspond to the native llama
 | `ERROR` | Errors that may affect inference results |
 
 ## Importing in Android
+
+> [!IMPORTANT]
+> **Minimum Android version: API 28 (Android 9.0 Pie).** Devices running
+> Android 8.1 (API 27) or earlier are not supported.
 
 You can use this library in Android project.
 1. Add java-llama.cpp as a submodule in your an droid `app` project directory


### PR DESCRIPTION
## Summary

- Upgrade Android minimum API level from 24 to 28 (Android 9.0 Pie) to support `posix_spawn` functions required by `mtmd-helper.cpp`
- Add `--no-transfer-progress` flag to all Maven invocations in CI workflows for cleaner logs
- Document the Android API level requirement in README and CLAUDE.md with rationale

## Details

**Android API Level Change:**
The minimum required Android API level is increased from 24 to 28 because `mtmd-helper.cpp` (part of the upstream llama.cpp multimodal library) includes `vendor/sheredom/subprocess.h`, which calls `posix_spawn`, `posix_spawnp`, and `posix_spawn_file_actions_*`. These symbols are only declared in Android NDK headers when `__ANDROID_API__ >= 28`, though the symbols exist in `libc.so` at all API levels.

Changes made:
1. **CMakeLists.txt**: Updated `add_compile_definitions(__ANDROID_API__=28)` (was 24)
2. **`.github/workflows/publish.yml`**: Updated `-DANDROID_PLATFORM=android-28` in both Android build jobs (was android-24)
3. **README.md**: Added minimum API level notes in two locations (Android classifier section and "Importing in Android" section)
4. **CLAUDE.md**: Added new "Android minimum API level" section documenting the three places to update and the rationale

**Maven Output Cleanup:**
Added `--no-transfer-progress` flag to Maven commands across all CI workflows (publish.yml, codeql.yml, sonarqube.yml) to suppress verbose dependency download progress output and improve log readability.

## Test plan

- CI is green on this branch
- Docs updated in README.md and CLAUDE.md with clear guidance for future API level changes

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01RcJfwgM2cfjd3n5A8JrGqe