### PR TITLE
Skip reranking tests when model file is unavailable

### DIFF
--- a/src/test/java/net/ladenthin/llama/RerankingModelTest.java
+++ b/src/test/java/net/ladenthin/llama/RerankingModelTest.java
@@ -7,12 +7,14 @@ package net.ladenthin.llama;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 import net.ladenthin.llama.parameters.ModelParameters;
 import net.ladenthin.llama.value.LlamaOutput;
 import net.ladenthin.llama.value.Pair;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +32,9 @@ public class RerankingModelTest {
 
     @BeforeAll
     public static void setup() {
+        Assumptions.assumeTrue(
+                new File("models/jina-reranker-v1-tiny-en-Q4_0.gguf").exists(),
+                "Reranking model not available, skipping tests");
         int gpuLayers = Integer.getInteger(TestConstants.PROP_TEST_NGL, TestConstants.DEFAULT_TEST_NGL);
         model = new LlamaModel(new ModelParameters()
                 .setCtxSize(128)


### PR DESCRIPTION
## Summary

- Add conditional test execution to `RerankingModelTest` using JUnit 5's `Assumptions` API
- Skip tests gracefully when the required reranking model file (`models/jina-reranker-v1-tiny-en-Q4_0.gguf`) is not available
- Prevents test failures in environments where the model file has not been downloaded

## Test plan

- [x] Affected unit tests pass locally (tests skip when model unavailable, run when present)
- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01VhZPQjHAWvrq7Hd3mDz57C