### PR TITLE
Replace synchronized method with private lock object in LlamaLoader

### DIFF
--- a/src/main/java/net/ladenthin/llama/loader/LlamaLoader.java
+++ b/src/main/java/net/ladenthin/llama/loader/LlamaLoader.java
@@ -44,6 +44,16 @@ import org.jspecify.annotations.Nullable;
 @ToString
 public class LlamaLoader {
 
+    /**
+     * Private monitor guarding {@link #initialize()}. Synchronizing on this
+     * dedicated object instead of {@code LlamaLoader.class} keeps the lock
+     * private to this class, so untrusted code that can reach the public
+     * {@code LlamaLoader} type cannot acquire the same intrinsic lock and
+     * interfere with library initialization (SpotBugs
+     * {@code USO_UNSAFE_STATIC_METHOD_SYNCHRONIZATION}).
+     */
+    private static final Object INITIALIZE_LOCK = new Object();
+
     private static boolean extracted = false;
     private static final LlamaSystemProperties systemProperties = new LlamaSystemProperties();
     private static final NativeLibraryPermissionSetter permissionSetter = new NativeLibraryPermissionSetter(System.err);
@@ -63,22 +73,24 @@ public class LlamaLoader {
     /**
      * Loads the llama and jllama shared libraries
      */
-    public static synchronized void initialize() {
-        // only cleanup before the first extract
-        if (!extracted) {
-            cleanup();
-        }
-        if ("Mac".equals(OSInfo.getOSName())) {
-            String nativeDirName = getNativeResourcePath();
-            String tempFolder = getTempDir().getAbsolutePath();
-            System.out.println(nativeDirName);
-            Path metalFilePath = extractFile(nativeDirName, "ggml-metal.metal", tempFolder);
-            if (metalFilePath == null) {
-                System.err.println("'ggml-metal.metal' not found");
+    public static void initialize() {
+        synchronized (INITIALIZE_LOCK) {
+            // only cleanup before the first extract
+            if (!extracted) {
+                cleanup();
             }
+            if ("Mac".equals(OSInfo.getOSName())) {
+                String nativeDirName = getNativeResourcePath();
+                String tempFolder = getTempDir().getAbsolutePath();
+                System.out.println(nativeDirName);
+                Path metalFilePath = extractFile(nativeDirName, "ggml-metal.metal", tempFolder);
+                if (metalFilePath == null) {
+                    System.err.println("'ggml-metal.metal' not found");
+                }
+            }
+            loadNativeLibrary("jllama");
+            extracted = true;
         }
-        loadNativeLibrary("jllama");
-        extracted = true;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Refactored `LlamaLoader.initialize()` from a synchronized method to use a private lock object (`INITIALIZE_LOCK`) for synchronization
- This change addresses SpotBugs warning `USO_UNSAFE_STATIC_METHOD_SYNCHRONIZATION` by preventing untrusted code from acquiring the same intrinsic lock on the public class
- Keeps the lock private to the class, improving security and encapsulation

## Test plan

- Affected unit / integration tests pass locally
- CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01W9s19iveUACGzehJs33Cm9