### PR TITLE
Add Spotless formatting policy documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -750,6 +750,11 @@ See [`../workspace/policies/javadoc-conventions.md`](../workspace/policies/javad
 
 See [`../workspace/policies/spotbugs-suppressions.md`](../workspace/policies/spotbugs-suppressions.md).
 
+## Spotless Formatting
+
+See [`../workspace/policies/spotless-formatting.md`](../workspace/policies/spotless-formatting.md).
+Run `mvn spotless:apply` before every commit that touches `.java` files.
+
 ## jqwik Policy
 
 See [`../workspace/policies/jqwik-prompt-injection.md`](../workspace/policies/jqwik-prompt-injection.md).


### PR DESCRIPTION
## Summary

- Added documentation section for Spotless code formatting conventions
- References the new `spotless-formatting.md` policy file
- Includes reminder to run `mvn spotless:apply` before committing changes to `.java` files

## Test plan

- [x] No testing needed — documentation-only change

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01Au4VSkHrWmx3FJDYcLSNJo