### PR TITLE
Upgrade actions/checkout from v6 to v7

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,7 +18,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with: { java-version: '21', distribution: temurin }
       - uses: github/codeql-action/init@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
     needs: startgate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           java-version: '21'
@@ -99,7 +99,7 @@ jobs:
     needs: startgate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Resolve pinned llama.cpp tag from CMakeLists.txt
         id: tag
         shell: bash
@@ -112,7 +112,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Pinned llama.cpp WebUI tag: $TAG"
       - name: Checkout llama.cpp tools/ui at the pinned tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ggml-org/llama.cpp
           ref: ${{ steps.tag.outputs.tag }}
@@ -196,7 +196,7 @@ jobs:
       CUDA_ARCH: '120'
       DOCKCROSS_ARGS: "-e SCCACHE_WEBDAV_ENDPOINT -e SCCACHE_WEBDAV_TOKEN -e USE_CACHE -e SCCACHE_LOG -e SCCACHE_ERROR_LOG -e RUST_BACKTRACE -e CUDA_FAST_BUILD -e CUDA_ARCH"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -236,7 +236,7 @@ jobs:
       SCCACHE_WEBDAV_TOKEN: ${{ secrets.DEPOT_TOKEN }}
       DOCKCROSS_ARGS: "-e SCCACHE_WEBDAV_ENDPOINT -e SCCACHE_WEBDAV_TOKEN -e USE_CACHE"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -273,7 +273,7 @@ jobs:
       SCCACHE_WEBDAV_TOKEN: ${{ secrets.DEPOT_TOKEN }}
       DOCKCROSS_ARGS: "-e SCCACHE_WEBDAV_ENDPOINT -e SCCACHE_WEBDAV_TOKEN -e USE_CACHE"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -310,7 +310,7 @@ jobs:
       SCCACHE_WEBDAV_TOKEN: ${{ secrets.DEPOT_TOKEN }}
       DOCKCROSS_ARGS: "-e SCCACHE_WEBDAV_ENDPOINT -e SCCACHE_WEBDAV_TOKEN -e USE_CACHE"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -348,7 +348,7 @@ jobs:
       SCCACHE_WEBDAV_TOKEN: ${{ secrets.DEPOT_TOKEN }}
       DOCKCROSS_ARGS: "-e SCCACHE_WEBDAV_ENDPOINT -e SCCACHE_WEBDAV_TOKEN -e USE_CACHE"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -378,7 +378,7 @@ jobs:
       SCCACHE_WEBDAV_ENDPOINT: https://cache.depot.dev
       SCCACHE_WEBDAV_TOKEN: ${{ secrets.DEPOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -423,7 +423,7 @@ jobs:
       SCCACHE_WEBDAV_ENDPOINT: https://cache.depot.dev
       SCCACHE_WEBDAV_TOKEN: ${{ secrets.DEPOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -463,7 +463,7 @@ jobs:
     needs: [startgate, build-webui]
     runs-on: windows-2025-vs2026
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -497,7 +497,7 @@ jobs:
     needs: [startgate, build-webui]
     runs-on: windows-2025-vs2026
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -535,7 +535,7 @@ jobs:
     needs: startgate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -564,7 +564,7 @@ jobs:
       SCCACHE_WEBDAV_ENDPOINT: https://cache.depot.dev
       SCCACHE_WEBDAV_TOKEN: ${{ secrets.DEPOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Download shared WebUI assets
         uses: actions/download-artifact@v8
         with:
@@ -608,7 +608,7 @@ jobs:
     needs: crosscompile-linux-x86_64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Display CPU Info
         shell: bash
         run: |
@@ -720,7 +720,7 @@ jobs:
     needs: startgate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -745,7 +745,7 @@ jobs:
     needs: build-macos-arm64-metal
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Display CPU Info
         shell: bash
         run: |
@@ -825,7 +825,7 @@ jobs:
     needs: build-macos-arm64-no-metal
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Display CPU Info
         shell: bash
         run: |
@@ -905,7 +905,7 @@ jobs:
     needs: build-macos-arm64-metal-15
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Display CPU Info
         shell: bash
         run: |
@@ -985,7 +985,7 @@ jobs:
     needs: build-windows-x86_64
     runs-on: windows-2025-vs2026
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Display CPU Info
         shell: pwsh
         run: |
@@ -1090,7 +1090,7 @@ jobs:
       - test-java-windows-x86_64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           pattern: "*-libraries"
@@ -1128,7 +1128,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with: { java-version: '${{ env.JAVA_VERSION }}', distribution: temurin }
       - uses: actions/download-artifact@v8
@@ -1178,7 +1178,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           pattern: "*-libraries"
@@ -1262,7 +1262,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           pattern: "*-libraries"

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -13,5 +13,5 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: fsfe/reuse-action@v6

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` action from v6 to v7 across all GitHub workflows
- This update applies to 8 workflow files: `publish.yml`, `clang-format.yml`, `claude-code-review.yml`, `claude.yml`, `codeql.yml`, `reuse.yml`, `scorecard.yml`, and `sonarqube.yml`
- v7 includes performance improvements and bug fixes from the upstream action

## Test plan

- [x] CI is green on this branch (all workflows will use the updated action)

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01XmsmwGc5o9YSPmzPTMCs4s