### PR TITLE
feat: wire vision/multimodal input end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ from version 5.0.0 onward. Pre-fork releases (`1.x`–`4.2.0`) were authored by
 - OpenSSF Best Practices badge (project 12862) on README.
 - OpenAI-compatible `parallel_tool_calls` support: `ChatRequest.withParallelToolCalls(Boolean)` / `getParallelToolCalls()`, `InferenceParameters.withParallelToolCalls(boolean)`, and pass-through in the `/v1/chat/completions` server mapper.
 - Real-model tool-calling integration tests for blocking and streaming required tool calls (`ToolCallingIntegrationTest`, Qwen2.5-1.5B-Instruct), wired into CI and `validate-models`.
+- End-to-end vision input across blocking, typed `ChatRequest`, streaming, and OpenAI-compatible request mapping; real-model tests verify that distinct red and blue images produce the correct semantic answers.
+- Explicit `setMmprojAuto(boolean)` and `setMmprojOffload(boolean)` controls, including the upstream `--no-mmproj-auto` and `--no-mmproj-offload` flags.
 
 ### Changed
 - Unified `CONTRIBUTING.md` and `SECURITY.md` structure with sibling repositories in the project family.
@@ -23,6 +25,11 @@ from version 5.0.0 onward. Pre-fork releases (`1.x`–`4.2.0`) were authored by
 - `pom.xml` SCM URL: `tree/master` → `tree/main` (default branch renamed).
 - Upgraded llama.cpp from b9151 to b9172.
 - Extracted the `chatWithTools` agent loop into `ToolCallingAgent`; tool-result errors (unknown tool / handler exception) are now JSON-serialized so tool names containing special characters remain valid JSON.
+
+### Fixed
+- Preserved decoded image buffers across the JNI chat boundary and submitted media requests through llama.cpp's upstream multimodal task path instead of silently tokenizing them as text-only prompts.
+- Preserved multipart image content when using the typed `ChatRequest` serializer.
+- The standalone OpenAI-compatible server now advertises vision only when the loaded model confirms usable vision support.
 
 ### Added
 - Reasoning-budget tests (Qwen3-0.6B).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,7 @@ if(BUILD_TESTING)
         ${llama.cpp_SOURCE_DIR}/tools/server/server-context.cpp
         ${llama.cpp_SOURCE_DIR}/tools/server/server-queue.cpp
         ${llama.cpp_SOURCE_DIR}/tools/server/server-task.cpp
+        ${llama.cpp_SOURCE_DIR}/tools/server/server-schema.cpp
         ${llama.cpp_SOURCE_DIR}/tools/server/server-models.cpp
     )
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,33 @@ try (LlamaModel model = new LlamaModel(modelParams)) {
 Reasoning/thinking models can receive custom Jinja template variables via
 `ModelParameters#setChatTemplateKwargs(Map)`.
 
+### Vision / Multimodal Chat
+
+Load a vision-capable GGUF with its matching projector, then place text and image parts in the
+same user message. Images may come from a file, raw bytes, a data URI, or an HTTP(S) URL:
+
+```java
+ModelParameters modelParams = new ModelParameters()
+        .setModel("models/SmolVLM-500M-Instruct-Q8_0.gguf")
+        .setMmproj("models/mmproj-SmolVLM-500M-Instruct-Q8_0.gguf");
+
+ChatMessage message = ChatMessage.userMultimodal(
+        ContentPart.text("Describe this image in one short sentence."),
+        ContentPart.imageFile(Paths.get("photo.jpg")));
+
+try (LlamaModel model = new LlamaModel(modelParams)) {
+    String answer = model.chatCompleteText(InferenceParameters.empty()
+            .withMessages(Collections.singletonList(message))
+            .withNPredict(64));
+    System.out.println(answer);
+}
+```
+
+The same multipart `messages[].content` shape works through `ChatRequest` and the embedded
+OpenAI-compatible `/v1/chat/completions` server. For a strictly CPU-only run, use
+`setDevices("none").setMmprojOffload(false)` in addition to `setGpuLayers(0)`; projector offload
+has its own upstream default.
+
 ### Tool Calling
 
 Use a tool-aware instruct model and enable Jinja when loading it. A typed request can either return
@@ -732,7 +759,7 @@ Forward-looking ideas being tracked for this fork:
 
 - **Adopt feature ideas from the Kotlin Llama Stack client.** Candidates (multimodal image input, typed chat messages, async API, batch inference, typed usage/timings) are inventoried with effort estimates in [`docs/feature-investigation-llama-stack-client-kotlin.md`](docs/feature-investigation-llama-stack-client-kotlin.md), derived from [`ogx-ai/llama-stack-client-kotlin`](https://github.com/ogx-ai/llama-stack-client-kotlin).
 - **Ship a directly Android-capable artifact.** Building on the existing [Importing in Android](#importing-in-android) flow and the `opencl-android-aarch64` classifier (see [Choosing the right classifier](#choosing-the-right-classifier)), the goal is a first-class Android Maven artifact — including a typed image-input helper for VLMs such as Qwen2.5-VL — so downstream Android projects can drop their dependency on [`ogx-ai/llama-stack-client-kotlin`](https://github.com/ogx-ai/llama-stack-client-kotlin) entirely.
-- **Resolve all upstream `kherud/java-llama.cpp` open issues.** All 37 open issues at fork time are catalogued with per-issue verdicts in [`docs/history/49be664_open_issues.md`](docs/history/49be664_open_issues.md); fixes land in this fork as they are completed. The remaining headline item is a typed Java image API for multimodal inputs (issues [#103](docs/history/49be664_open_issues.md#103--vlm-support--image-input-for-multimodal-models) and [#34](docs/history/49be664_open_issues.md#34--support-multimodal-inputs), both PARTIALLY FIXED) — the same work that closes §2.1 of the Kotlin feature inventory.
+- **Resolve all upstream `kherud/java-llama.cpp` open issues.** All 37 open issues at fork time are catalogued with per-issue verdicts in [`docs/history/49be664_open_issues.md`](docs/history/49be664_open_issues.md); fixes land in this fork as they are completed. Vision inputs (issues [#103](docs/history/49be664_open_issues.md#103--vlm-support--image-input-for-multimodal-models) and [#34](docs/history/49be664_open_issues.md#34--support-multimodal-inputs)) are now wired end to end through blocking, typed, streaming, and OpenAI-compatible request surfaces.
 
 ## Troubleshooting
 

--- a/docs/feature-investigation-llama-stack-client-kotlin.md
+++ b/docs/feature-investigation-llama-stack-client-kotlin.md
@@ -62,13 +62,12 @@ branch unless noted.
 
 ### 2.1 Multimodal image input (mtmd) — **L**
 
-**Status: SHIPPED (typed Java surface).** The original L-effort scope assumed
-new JNI plumbing was required, but on inspection the upstream OAI chat path
-(`oaicompat_chat_params_parse` in `server-common.cpp`) already detects
-`{"type":"image_url","image_url":{"url":"data:..."}}` blocks and routes them
-through the compiled-in `mtmd` pipeline, and the project's
-`handleChatCompletions` JNI method forwards the request JSON intact. Only the
-Java-side convenience to emit the multipart-array `content` was missing.
+**Status: SHIPPED (end to end).** The upstream OAI parser detects
+`{"type":"image_url","image_url":{"url":"data:..."}}` blocks and decodes them,
+but the binding previously discarded those decoded buffers before creating the
+server task. The JNI bridge now preserves the media and submits it through the
+upstream CLI multimodal task path, which invokes `process_mtmd_prompt` with the
+loaded projector.
 
 This pass adds:
 - **`ContentPart`** value type (`TEXT` / `IMAGE_URL`) with static factories
@@ -79,13 +78,14 @@ This pass adds:
   `userMultimodal(ContentPart...)` factory, `getParts()`, and `hasParts()`.
   The legacy `ChatMessage(role, content)` ctor and existing serializer path
   are unchanged.
-- **`InferenceParameters.setMessages(List<ChatMessage>)`** overload that
+- **`InferenceParameters.withMessages(List<ChatMessage>)`** overload that
   routes through a new `ParameterJsonSerializer.buildMessages(List<ChatMessage>)`
   emitting array-form `content` only when a message has parts.
-- 25 unit tests in `ContentPartTest` and `MultimodalMessagesTest` cover the
+- Unit tests in `ContentPartTest`, `MultimodalMessagesTest`, `ChatRequestTest`,
+  and `OpenAiRequestMapperTest` cover the
   factory contracts, the parts/legacy split, and the OAI multipart JSON shape;
-  the 123 existing `ChatMessage` / `InferenceParameters` /
-  `ParameterJsonSerializer` tests still pass.
+- `MultimodalIntegrationTest` exercises blocking, typed, and streaming calls
+  with a real model and verifies semantic red/blue image discrimination.
 
 A multimodal call from Java now looks like:
 ```java
@@ -99,24 +99,8 @@ String reply = model.chatCompleteText(new InferenceParameters("")
             ContentPart.imageFile(java.nio.file.Paths.get("photo.jpg"))))));
 ```
 
-Zero new JNI symbols; zero risk to existing text-only chat callers.
-
-**Gap.** Upstream llama.cpp ships `mtmd` (vision + audio for some models) and
-the compiled-in server already pulls it in via `mtmd.h` / `mtmd-helper.h`. No
-Java method currently accepts image input. Kotlin examples show base64 image
-chat against vision models.
-
-**Proposal.**
-- `InferenceParameters.addImage(byte[] png)` / `addImage(Path)` / `addImageBase64(String)`.
-- `ModelParameters.setMmproj(Path)` to load the mmproj projector file.
-- JNI: feed images into the server task params (`mtmd_*` API).
-
-**Effort: L** — non-trivial JNI plumbing, lifecycle of `mtmd_context`,
-test fixtures for vision models, but most of the heavy lifting is already
-upstream.
-
-**Value.** Biggest user-visible capability missing today. Unlocks Qwen-VL,
-Gemma 3, MiniCPM-V, LLaVA, etc.
+No new exported JNI symbols are needed; existing text-only chat callers retain
+the ordinary tokenization path.
 
 ---
 

--- a/docs/history/49be664_open_issues.md
+++ b/docs/history/49be664_open_issues.md
@@ -21,7 +21,7 @@ After a second-pass analysis of every `LIKELY FIXED` and `PARTIALLY FIXED` issue
 
 - **Confirmable from code inspection alone (no runtime needed):**
   - #103, #34 — image input API: now FIXED via PR #189 (typed `ContentPart`
-    + `ChatMessage(role, List<ContentPart>)` + `InferenceParameters.setMessages(List<ChatMessage>)`
+    + `ChatMessage(role, List<ContentPart>)` + `InferenceParameters.withMessages(List<ChatMessage>)`
     emitting OAI multipart content; the upstream chat path already routes
     `image_url` blocks through the compiled-in `mtmd` pipeline, so zero new
     JNI was needed).
@@ -305,13 +305,11 @@ Java API.
 Feature request: support visual-language models such as Qwen2.5-VL (image
 inputs) on Android.
 
-**Status in fork:** FIXED in the same PR that closes the typed Java surface gap. The build still links the upstream `mtmd` multimodal library into `jllama` (`CMakeLists.txt:125-145, 253-255`) and `ModelParameters` still exposes `setMmproj`, `setMmprojUrl`, `enableMmprojAuto`, `enableMmprojOffload` (`ModelParameters.java:1250-1281`). The previously-missing typed image API now exists: `ContentPart.text(...)`, `ContentPart.imageUrl(...)`, `ContentPart.imageBytes(byte[], mime)`, `ContentPart.imageFile(Path)` (auto-detects png/jpeg/webp/gif), and `ChatMessage(role, List<ContentPart>)` + `ChatMessage.userMultimodal(ContentPart...)`. `InferenceParameters.setMessages(List<ChatMessage>)` serializes parts-bearing messages to the OAI array-form `content` that the upstream `oaicompat_chat_params_parse` already routes through the compiled-in `mtmd` pipeline &#x2014; zero new JNI required. See PR #189 (§2.1 of `docs/feature-investigation-llama-stack-client-kotlin.md`).
+**Status in fork:** FIXED end to end. The build links the upstream `mtmd` multimodal library into `jllama`, `ModelParameters` exposes projector loading and explicit auto/offload controls, and `ContentPart` + `ChatMessage.userMultimodal(...)` provide the typed image API. The native parser now preserves decoded media buffers and submits them through the upstream multimodal task path; previously those buffers were discarded and requests silently became text-only. Blocking, typed `ChatRequest`, streaming, and OpenAI-compatible mapping are covered, including a real-model semantic red/blue regression.
 
-**Deep-dive analysis:** Definitively confirmable from code inspection — no runtime test changes this verdict. Two distinct surfaces exist for VLM:
+**Deep-dive analysis:** Two distinct surfaces exist for VLM:
 1. **Model loading:** fully wired (mmproj path, auto-detect, GPU offload) — these flags reach the upstream server-context unchanged.
-2. **Request payload:** the only path is `LlamaModel.handleChatCompletions(json, oaiCompat=true)` with manually-constructed `messages[].content = [{type:"text",...},{type:"image_url",image_url:{url:"data:image/png;base64,..."}}]` JSON. No typed helper.
-
-This is genuinely PARTIALLY FIXED and only a Java-side enhancement closes the gap; no runtime investigation is required to confirm.
+2. **Request payload:** typed and raw OpenAI multipart content is decoded by the OAI parser, retained across JNI dispatch, and processed by `mtmd` before generation.
 
 ---
 
@@ -696,9 +694,9 @@ prebuilt artifact for Android targets.
 Feature request: add multimodal input support (referencing
 [ggerganov/llama.cpp#3436](https://github.com/ggerganov/llama.cpp/pull/3436)).
 
-**Status in fork:** FIXED. The upstream `mtmd` library is built and linked into `jllama` (`CMakeLists.txt:125-145, 253-255`), `ModelParameters` exposes `setMmproj`, `setMmprojUrl`, `enableMmprojAuto`, `enableMmprojOffload` (`ModelParameters.java:1250-1281`), and the typed image API now exists via `ContentPart` + `ChatMessage(role, List<ContentPart>)` + `InferenceParameters.setMessages(List<ChatMessage>)`. The serializer emits OAI array-form `content`; the upstream chat path already understands `image_url` blocks. See #103 for the parallel write-up and PR #189 for the implementation.
+**Status in fork:** FIXED. The upstream `mtmd` library is built and linked into `jllama`; projector controls and the typed `ContentPart` API are exposed; and decoded media is retained by the native bridge and processed through the upstream multimodal task path for blocking and streaming requests. See #103 for the full write-up.
 
-**Deep-dive analysis:** Same conclusion as #103 — confirmable from code, no runtime needed. The original 2023 feature request asked for "multimodal input support"; in 2025 terms this splits into model loading (DONE) and request payload (DONE: typed `ChatMessage(role, List<ContentPart>)` + `InferenceParameters.setMessages(List<ChatMessage>)` emit the OAI multipart `content` the upstream chat path already consumes). Verdict is FIXED as of PR #189.
+**Deep-dive analysis:** Same conclusion as #103. Model loading and request execution are both verified; the real-model regression confirms image content affects the answer rather than merely producing a non-empty text-only response.
 
 ---
 
@@ -761,7 +759,7 @@ Feature request: add multimodal input support (referencing
 | 110 | FIXED | `handleEmbeddings` accepts batch JSON | `LlamaModel.java:316`, `json_helpers.hpp:137` |
 | 107 | FIXED | CMake matches both Mac and Darwin | `CMakeLists.txt:196` |
 | 104 | FIXED | `NO_KV_OFFLOAD` flag exposed | `args/ModelFlag.java:50` |
-| 103 | FIXED | mtmd linked; typed image API in PR #189 (`ContentPart`, `ChatMessage(role, List<ContentPart>)`, `InferenceParameters.setMessages(List<ChatMessage>)`) | `ContentPart.java`, `ChatMessage.java`, `InferenceParameters.java`, `ModelParameters.java:1250-1281` |
+| 103 | FIXED | mtmd linked; typed image API in PR #189 (`ContentPart`, `ChatMessage(role, List<ContentPart>)`, `InferenceParameters.withMessages(List<ChatMessage>)`) | `ContentPart.java`, `ChatMessage.java`, `InferenceParameters.java`, `ModelParameters.java:1250-1281` |
 | 102 | FIXED | Destructor drains workers and frees ctx; covered by `MemoryManagementTest#testOpenCloseLoopDoesNotLeak` (commit `cba693c`, PR #185) | `jllama.cpp:917-948` |
 | 101 | FIXED | Trampoline calls BiConsumer | `jllama.cpp:954-977` |
 | 98  | FIXED | `enableEmbedding` + `setPoolingType`; covered by `LlamaEmbeddingsTest#testNomicEmbedLoads` (commit `cba693c`, PR #185; CI downloads `nomic-embed-text-v1.5.f16.gguf`) | `ModelParameters.java:1040,606` |
@@ -804,7 +802,7 @@ or change the verdict.
 | 98 | Reporter's config was *literally* `new ModelParameters().setModel(...).setBatchSize(8192).setUbatchSize(8192)` — **no `enableEmbedding()` call**. The original "bug" was that the bindings did not forward `--embedding` at all; the upstream `result_output` assertion fired because the embedding pipeline was never initialised. | **DONE** — `LlamaEmbeddingsTest#testNomicEmbedLoads` (commit `713d426`) runs the reporter's exact config plus `enableEmbedding()`; gated on `net.ladenthin.llama.nomic.path`; CI downloads the model via `NOMIC_EMBED_MODEL_URL` in `publish.yml`. |
 | 95 | Reporter pastes the `next()` method and argues the design is wrong: when `output.stop=true`, the method returns that output and ends. No model, prompt or reproduction provided. | **DONE** — `LlamaModelTest#testIteratorTerminatesOnRepetitivePrompt` (commit `713d426`) drives the iterator with a repetitive prompt at `nPredict=30`, `temperature=0.0f` and asserts termination within `nPredict+1` outputs. |
 | 80 | Exact repro: Kotlin-style 3 lines (`val params...`, `val model = new LlamaModel(params)`, `model.close()`) with `qwen2-0_5b-instruct-q4_0.gguf`. JDK 17.0.12+7, java-llama.cpp 3.4.1. SIGSEGV in `std::_Rb_tree` during `delete`. Reporter said they intended to follow up with a `-DLLAMA_DEBUG` build but never did. | **DONE** — `MemoryManagementTest#testOpenCloseWithoutGeneration` (commit `713d426`) maps the 3-line repro to 20 iterations of try-with-resources open + immediate close; a JVM crash exits the runner non-zero. |
-| 103 | Specifically asks about **Qwen2.5-VL on Android**. No code attempted. | **DONE (typed API)** — PR #189 ships `ContentPart` + `ChatMessage(role, List<ContentPart>)` + `InferenceParameters.setMessages(List<ChatMessage>)`. Android-sample tail tracked separately. |
+| 103 | Specifically asks about **Qwen2.5-VL on Android**. No code attempted. | **DONE (typed API)** — PR #189 ships `ContentPart` + `ChatMessage(role, List<ContentPart>)` + `InferenceParameters.withMessages(List<ChatMessage>)`. Android-sample tail tracked separately. |
 | 86 | Just a question: "does the CUDA jar handle CPU fallback?". No code. | Not unit-testable. Documentation task. |
 | 34 | One-line feature request linking upstream PR #3436 (LLaVA). No specifics. | **DONE** — subsumed by #103 (PR #189). |
 | 121 | (Not refetched — Android `aarch64` vs `arm64-v8a` mismatch; already analysed in deep-dive.) | Verified by code; needs an Android boot test, not a unit test. |
@@ -930,7 +928,7 @@ the same pattern as the existing CodeLlama / Jina-Reranker model downloads.
 
 | # | Why not unit-testable | Action |
 |---|---|---|
-| 103, 34 | (Historic — typed image API was missing at the time of this audit.) | **DONE in PR #189**: `ContentPart` + `ChatMessage(role, List<ContentPart>)` + `InferenceParameters.setMessages(List<ChatMessage>)` emit the OAI multipart `content` the upstream chat path already routes through `mtmd`. `MultimodalIntegrationTest` is added under model-gated `Assume`. |
+| 103, 34 | (Historic — typed image API and native media dispatch were incomplete at the time of this audit.) | **DONE**: `ContentPart` + `ChatMessage(role, List<ContentPart>)` emit OAI multipart content, and the JNI bridge retains decoded media for upstream `mtmd` processing. The model-gated integration test covers blocking, typed, streaming, and semantic image handling. |
 | 86 | Question about jar packaging behaviour, not code defect. | Documentation: add a README section "Choosing the right classifier" stating that the CUDA jar requires the CUDA runtime libraries at load time and does not auto-fall-back. |
 | 121, 50 | Android runtime / cross-host build path — needs an emulator boot or a macOS-M2 cross-compile, not a JVM test. | CI matrix expansion: add an Android emulator job that boots a stock `arm64-v8a` AVD and runs the existing `LlamaModelTest` against the dockcross-built `libjllama.so`. |
 
@@ -954,7 +952,7 @@ the same pattern as the existing CodeLlama / Jina-Reranker model downloads.
    the residual gap on #121.
 3. **Third PR (feature): SHIPPED as PR #189.** Adds the typed multimodal
    surface (`ContentPart`, `ChatMessage(role, List<ContentPart>)`,
-   `InferenceParameters.setMessages(List<ChatMessage>)`) plus a
+   `InferenceParameters.withMessages(List<ChatMessage>)`) plus a
    `MultimodalIntegrationTest` gated on `net.ladenthin.llama.vision.model`,
    `.vision.mmproj`, and `.vision.image` system properties. CI in
    `publish.yml` downloads a small vision model + mmproj + an author-

--- a/docs/history/49be664_open_issues_comments.md
+++ b/docs/history/49be664_open_issues_comments.md
@@ -36,7 +36,7 @@ llama.cpp is pinned to `b9284`, which natively supports Qwen3 and Qwen3-VL;
 the fork also fetches `tools/mtmd` and links it into `jllama`
 (`CMakeLists.txt:125-145,255`), and exposes a typed multimodal Java surface
 (`ContentPart`, `ChatMessage(role, List<ContentPart>)`,
-`InferenceParameters.setMessages(List<ChatMessage>)`) — see PR #189.
+`InferenceParameters.withMessages(List<ChatMessage>)`) — see PR #189.
 ```
 
 ---
@@ -196,9 +196,9 @@ in PR #189. The build links the upstream `mtmd` library into `jllama`
 `setMmprojUrl`, `enableMmprojAuto`, `enableMmprojOffload`
 (`ModelParameters.java:1250-1281`); and the new typed image API ships as
 `ContentPart.text/imageUrl/imageBytes/imageFile`, `ChatMessage(role, List<ContentPart>)`,
-`ChatMessage.userMultimodal(...)`, and `InferenceParameters.setMessages(List<ChatMessage>)`.
-The serializer emits the OAI array-form `content` that the upstream chat path
-already routes through `mtmd` — no new JNI was required.
+`ChatMessage.userMultimodal(...)`, and `InferenceParameters.withMessages(List<ChatMessage>)`.
+The serializer emits OAI array-form `content`; the native bridge retains the
+decoded media buffers and submits them through the upstream `mtmd` task path.
 ```
 
 ---
@@ -445,7 +445,7 @@ in PR #189. The upstream `mtmd` library is linked into `jllama`
 (`CMakeLists.txt:125-145,253-255`); `ModelParameters` exposes the mmproj
 flags (`ModelParameters.java:1250-1281`); and the typed image API ships as
 `ContentPart` + `ChatMessage(role, List<ContentPart>)` +
-`InferenceParameters.setMessages(List<ChatMessage>)`, which emit the OAI
-multipart `content` the upstream chat path already routes through `mtmd`.
+`InferenceParameters.withMessages(List<ChatMessage>)`, which emit OAI multipart
+content retained by the JNI bridge and processed by the upstream `mtmd` task path.
 See #103 for the parallel write-up.
 ```

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -178,12 +178,12 @@ static void throw_invalid_request(JNIEnv *env, const std::exception &e) {
 
 /**
  * Parse the OAI chat-completion body through oaicompat_chat_params_parse and
- * write the result into `out`.  Returns true on success; on failure throws and
- * returns false.
+ * write the result into `out`, preserving decoded media in `files`. Returns
+ * true on success; on failure throws and returns false.
  */
-[[nodiscard]] static bool parse_oai_chat_params(JNIEnv *env, server_context *ctx_server, json &body, json &out) {
+[[nodiscard]] static bool parse_oai_chat_params(JNIEnv *env, server_context *ctx_server, json &body, json &out,
+                                                std::vector<raw_buffer> &files) {
     try {
-        std::vector<raw_buffer> files;
         auto meta = ctx_server->get_meta();
         out = oaicompat_chat_params_parse(body, meta.chat_params, files);
         return true;
@@ -196,16 +196,20 @@ static void throw_invalid_request(JNIEnv *env, const std::exception &e) {
 // Tokenise the prompt in `data` and fill task.tokens + task.params.
 // Callers must wrap this in try/catch (params_from_json_cmpl can throw).
 static void populate_completion_task(server_task &task, jllama_context *jctx, int n_ctx_slot,
-                                     const std::vector<llama_logit_bias> &logit_bias_eog, const json &data) {
-    auto tokenized_prompts = tokenize_input_prompts(jctx->vocab, nullptr, data.at("prompt"), true, true);
-    if (!tokenized_prompts.empty()) {
-        task.tokens = std::move(tokenized_prompts[0]);
+                                     const std::vector<llama_logit_bias> &logit_bias_eog, const json &data,
+                                     bool has_mtmd, std::vector<raw_buffer> files = {}) {
+    if (!configure_multimodal_task_impl(task, has_mtmd, data, std::move(files))) {
+        auto tokenized_prompts = tokenize_input_prompts(jctx->vocab, nullptr, data.at("prompt"), true, true);
+        if (!tokenized_prompts.empty()) {
+            task.tokens = std::move(tokenized_prompts[0]);
+        }
     }
     task.params = server_schema::eval_llama_cmpl_schema(jctx->vocab, jctx->params, n_ctx_slot, logit_bias_eog, data);
 }
 
 [[nodiscard]] static jint dispatch_streaming_completion(JNIEnv *env, jllama_context *jctx, const json &data,
-                                                        server_task_type task_type, task_response_type res_type) {
+                                                        server_task_type task_type, task_response_type res_type,
+                                                        std::vector<raw_buffer> files = {}) {
     server_context *ctx_server = &jctx->server;
     auto meta = ctx_server->get_meta();
     auto *rd = new server_response_reader(ctx_server->get_response_reader());
@@ -213,7 +217,8 @@ static void populate_completion_task(server_task &task, jllama_context *jctx, in
     try {
         server_task task(task_type);
         task.id = tid;
-        populate_completion_task(task, jctx, meta.slot_n_ctx, meta.logit_bias_eog, data);
+        populate_completion_task(task, jctx, meta.slot_n_ctx, meta.logit_bias_eog, data, meta.has_mtmd,
+                                 std::move(files));
         task.params.res_type = res_type;
         rd->post_task(std::move(task));
     } catch (const std::exception &e) {
@@ -234,14 +239,16 @@ static void populate_completion_task(server_task &task, jllama_context *jctx, in
  * On error: throws via JNI and returns nullptr.
  */
 [[nodiscard]] static jstring dispatch_blocking_completion(JNIEnv *env, jllama_context *jctx, const json &data,
-                                                          server_task_type task_type, task_response_type res_type) {
+                                                          server_task_type task_type, task_response_type res_type,
+                                                          std::vector<raw_buffer> files = {}) {
     server_context *ctx_server = &jctx->server;
     auto meta = ctx_server->get_meta();
     auto rd = ctx_server->get_response_reader();
     server_task task(task_type);
     task.id = rd.get_new_id();
     try {
-        populate_completion_task(task, jctx, meta.slot_n_ctx, meta.logit_bias_eog, data);
+        populate_completion_task(task, jctx, meta.slot_n_ctx, meta.logit_bias_eog, data, meta.has_mtmd,
+                                 std::move(files));
     } catch (const std::exception &e) {
         throw_invalid_request(env, e);
         return nullptr;
@@ -933,7 +940,8 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_applyTemplate(JNIE
     json data = parse_json_params(env, jparams);
 
     json templateData;
-    if (!parse_oai_chat_params(env, ctx_server, data, templateData))
+    std::vector<raw_buffer> files;
+    if (!parse_oai_chat_params(env, ctx_server, data, templateData, files))
         return nullptr;
 
     std::string tok_str = templateData.at("prompt");
@@ -946,10 +954,12 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleChatCompleti
 
     json body = parse_json_params(env, jparams);
     json data;
-    if (!parse_oai_chat_params(env, ctx_server, body, data))
+    std::vector<raw_buffer> files;
+    if (!parse_oai_chat_params(env, ctx_server, body, data, files))
         return nullptr;
 
-    return dispatch_blocking_completion(env, jctx, data, SERVER_TASK_TYPE_COMPLETION, TASK_RESPONSE_TYPE_OAI_CHAT);
+    return dispatch_blocking_completion(env, jctx, data, SERVER_TASK_TYPE_COMPLETION, TASK_RESPONSE_TYPE_OAI_CHAT,
+                                        std::move(files));
 }
 
 JNIEXPORT jint JNICALL Java_net_ladenthin_llama_LlamaModel_requestChatCompletion(JNIEnv *env, jobject obj,
@@ -959,10 +969,12 @@ JNIEXPORT jint JNICALL Java_net_ladenthin_llama_LlamaModel_requestChatCompletion
     json body = parse_json_params(env, jparams);
     // Chat template already applied by parse_oai_chat_params; no OAI wrapping on the streaming path.
     json data;
-    if (!parse_oai_chat_params(env, ctx_server, body, data))
+    std::vector<raw_buffer> files;
+    if (!parse_oai_chat_params(env, ctx_server, body, data, files))
         return 0;
 
-    return dispatch_streaming_completion(env, jctx, data, SERVER_TASK_TYPE_COMPLETION, TASK_RESPONSE_TYPE_NONE);
+    return dispatch_streaming_completion(env, jctx, data, SERVER_TASK_TYPE_COMPLETION, TASK_RESPONSE_TYPE_NONE,
+                                         std::move(files));
 }
 
 // Streaming OpenAI chat with OAI-formatted chunks. Mirrors requestChatCompletion
@@ -976,10 +988,12 @@ JNIEXPORT jint JNICALL Java_net_ladenthin_llama_LlamaModel_requestChatCompletion
 
     json body = parse_json_params(env, jparams);
     json data;
-    if (!parse_oai_chat_params(env, ctx_server, body, data))
+    std::vector<raw_buffer> files;
+    if (!parse_oai_chat_params(env, ctx_server, body, data, files))
         return 0;
 
-    return dispatch_streaming_completion(env, jctx, data, SERVER_TASK_TYPE_COMPLETION, TASK_RESPONSE_TYPE_OAI_CHAT);
+    return dispatch_streaming_completion(env, jctx, data, SERVER_TASK_TYPE_COMPLETION, TASK_RESPONSE_TYPE_OAI_CHAT,
+                                         std::move(files));
 }
 
 JNIEXPORT jintArray JNICALL Java_net_ladenthin_llama_LlamaModel_encode(JNIEnv *env, jobject obj, jstring jprompt) {

--- a/src/main/cpp/jni_helpers.hpp
+++ b/src/main/cpp/jni_helpers.hpp
@@ -14,6 +14,7 @@
 //     require_json_field_impl, jint_array_to_tokens_impl
 //
 //   Layer B — JNI + server orchestration:
+//     configure_multimodal_task_impl,
 //     json_to_jstring_impl, results_to_jstring_impl,
 //     embedding_to_jfloat_array_impl, tokens_to_jint_array_impl
 //
@@ -145,6 +146,34 @@ inline void erase_reader(jllama_context *jctx, int id_task) {
 // json_helpers.hpp provides get_result_error_message, results_to_json, and
 // the other pure JSON transforms used by the functions below.
 #include "json_helpers.hpp"
+
+// ---------------------------------------------------------------------------
+// configure_multimodal_task_impl
+//
+// Upstream keeps mtmd_context private inside server_context. Its CLI task
+// path exists specifically for callers that have a formatted prompt plus raw
+// media but cannot access that context directly. Attach those inputs to the
+// task so server_context::tokenize_cli_input() invokes process_mtmd_prompt()
+// on the worker thread. Returns false for a text-only request so callers can
+// retain their normal eager-tokenization path.
+// ---------------------------------------------------------------------------
+[[nodiscard]] inline bool configure_multimodal_task_impl(server_task &task, bool has_mtmd, const json &data,
+                                                         std::vector<raw_buffer> files) {
+    if (files.empty()) {
+        return false;
+    }
+    if (!has_mtmd) {
+        throw std::invalid_argument("Image input requires a loaded multimodal projector (--mmproj)");
+    }
+    const auto &prompt = data.at("prompt");
+    if (!prompt.is_string()) {
+        throw std::invalid_argument("Multimodal chat prompt must be a string");
+    }
+    task.cli = true;
+    task.cli_prompt = prompt.get<std::string>();
+    task.cli_files = std::move(files);
+    return true;
+}
 
 // ---------------------------------------------------------------------------
 // json_to_jstring_impl

--- a/src/main/java/net/ladenthin/llama/LlamaModel.java
+++ b/src/main/java/net/ladenthin/llama/LlamaModel.java
@@ -808,6 +808,15 @@ public class LlamaModel implements AutoCloseable {
         }
     }
 
+    /**
+     * Reports whether the loaded model has a usable multimodal projector.
+     *
+     * @return {@code true} when image input is available
+     */
+    public boolean supportsVision() {
+        return getModelMeta().supportsVision();
+    }
+
     native String getModelMetaJson();
 
     /**

--- a/src/main/java/net/ladenthin/llama/args/ModelFlag.java
+++ b/src/main/java/net/ladenthin/llama/args/ModelFlag.java
@@ -106,8 +106,14 @@ public enum ModelFlag {
     /** Automatically detect and load the mmproj vision projection model. */
     MMPROJ_AUTO("--mmproj-auto"),
 
+    /** Disable automatic multimodal-projector detection. */
+    NO_MMPROJ_AUTO("--no-mmproj-auto"),
+
     /** Offload the mmproj vision projection model to the GPU. */
     MMPROJ_OFFLOAD("--mmproj-offload"),
+
+    /** Keep the multimodal projector on the CPU. */
+    NO_MMPROJ_OFFLOAD("--no-mmproj-offload"),
 
     /**
      * Skip any model file download — only validation is performed. Useful for air-gapped or

--- a/src/main/java/net/ladenthin/llama/parameters/ChatRequest.java
+++ b/src/main/java/net/ladenthin/llama/parameters/ChatRequest.java
@@ -77,6 +77,7 @@ import org.jspecify.annotations.Nullable;
 public final class ChatRequest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ParameterJsonSerializer MESSAGE_SERIALIZER = new ParameterJsonSerializer();
 
     /**
      * Default {@code maxToolRounds} when the caller does not override it via
@@ -300,11 +301,10 @@ public final class ChatRequest {
      * @return the JSON array as a string
      */
     public String buildMessagesJson() {
-        ArrayNode arr = MAPPER.createArrayNode();
-        for (ChatMessage m : messages) {
-            ObjectNode obj = MAPPER.createObjectNode();
-            obj.put("role", m.getRole());
-            obj.put("content", m.getContent());
+        ArrayNode arr = MESSAGE_SERIALIZER.buildMessages(messages);
+        for (int i = 0; i < messages.size(); i++) {
+            ChatMessage m = messages.get(i);
+            ObjectNode obj = (ObjectNode) arr.get(i);
             m.getToolCallId().ifPresent(id -> obj.put("tool_call_id", id));
             if (!m.getToolCalls().isEmpty()) {
                 ArrayNode tc = MAPPER.createArrayNode();
@@ -320,7 +320,6 @@ public final class ChatRequest {
                 }
                 obj.set("tool_calls", tc);
             }
-            arr.add(obj);
         }
         return arr.toString();
     }

--- a/src/main/java/net/ladenthin/llama/parameters/ModelParameters.java
+++ b/src/main/java/net/ladenthin/llama/parameters/ModelParameters.java
@@ -1286,7 +1286,19 @@ public final class ModelParameters extends CliParameters {
      * @return this builder
      */
     public ModelParameters enableMmprojAuto() {
-        return setFlag(ModelFlag.MMPROJ_AUTO);
+        return setMmprojAuto(true);
+    }
+
+    /**
+     * Enable or disable automatic multimodal-projector detection.
+     *
+     * @param enabled {@code true} to auto-detect a projector, {@code false} to disable it
+     * @return this builder
+     */
+    public ModelParameters setMmprojAuto(boolean enabled) {
+        setFlag(enabled ? ModelFlag.MMPROJ_AUTO : ModelFlag.NO_MMPROJ_AUTO);
+        clearFlag(enabled ? ModelFlag.NO_MMPROJ_AUTO : ModelFlag.MMPROJ_AUTO);
+        return this;
     }
 
     /**
@@ -1295,7 +1307,20 @@ public final class ModelParameters extends CliParameters {
      * @return this builder
      */
     public ModelParameters enableMmprojOffload() {
-        return setFlag(ModelFlag.MMPROJ_OFFLOAD);
+        return setMmprojOffload(true);
+    }
+
+    /**
+     * Enable or disable GPU offload for the multimodal projector. This is independent of
+     * {@link #setGpuLayers(int)} because upstream enables projector offload by default.
+     *
+     * @param enabled {@code true} to offload the projector, {@code false} to keep it on CPU
+     * @return this builder
+     */
+    public ModelParameters setMmprojOffload(boolean enabled) {
+        setFlag(enabled ? ModelFlag.MMPROJ_OFFLOAD : ModelFlag.NO_MMPROJ_OFFLOAD);
+        clearFlag(enabled ? ModelFlag.NO_MMPROJ_OFFLOAD : ModelFlag.MMPROJ_OFFLOAD);
+        return this;
     }
 
     /**

--- a/src/main/java/net/ladenthin/llama/server/OpenAiCompatServer.java
+++ b/src/main/java/net/ladenthin/llama/server/OpenAiCompatServer.java
@@ -885,8 +885,6 @@ public final class OpenAiCompatServer implements AutoCloseable {
             return;
         }
 
-        OpenAiServerConfig config = options.toServerConfig();
-
         // The server runs on daemon threads, so the main thread blocks until the JVM is asked to
         // shut down (Ctrl-C / SIGTERM); the try-with-resources then closes the server and model.
         // Two latches keep that shutdown graceful and race-free: the hook signals stopRequested and
@@ -906,14 +904,16 @@ public final class OpenAiCompatServer implements AutoCloseable {
                         },
                         "jllama-openai-shutdown"));
 
-        try (LlamaModel model = new LlamaModel(options.toModelParameters());
-                OpenAiCompatServer server = new OpenAiCompatServer(model, config)) {
-            server.start();
-            printReady(config, server.getPort());
-            try {
-                stopRequested.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+        try (LlamaModel model = new LlamaModel(options.toModelParameters())) {
+            OpenAiServerConfig config = options.toServerConfig(model.supportsVision());
+            try (OpenAiCompatServer server = new OpenAiCompatServer(model, config)) {
+                server.start();
+                printReady(config, server.getPort());
+                try {
+                    stopRequested.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
         } finally {
             cleanedUp.countDown();

--- a/src/main/java/net/ladenthin/llama/server/OpenAiServerCli.java
+++ b/src/main/java/net/ladenthin/llama/server/OpenAiServerCli.java
@@ -395,11 +395,23 @@ public final class OpenAiServerCli {
          * @return the server configuration
          */
         public OpenAiServerConfig toServerConfig() {
+            return toServerConfig(mmproj != null);
+        }
+
+        /**
+         * Build the server configuration with a capability value obtained from the loaded model.
+         * This overload lets the standalone launcher avoid advertising vision merely because an
+         * {@code --mmproj} path was supplied.
+         *
+         * @param supportsVision whether the loaded model reports usable vision input
+         * @return the server configuration
+         */
+        public OpenAiServerConfig toServerConfig(boolean supportsVision) {
             final OpenAiServerConfig.Builder builder = OpenAiServerConfig.builder()
                     .host(host)
                     .port(port)
                     .modelId(getModelId())
-                    .supportsVision(mmproj != null);
+                    .supportsVision(supportsVision);
             if (apiKey != null) {
                 builder.apiKey(apiKey);
             }

--- a/src/main/java/net/ladenthin/llama/value/ContentPart.java
+++ b/src/main/java/net/ladenthin/llama/value/ContentPart.java
@@ -17,9 +17,10 @@ import org.jspecify.annotations.Nullable;
 /**
  * One piece of a {@link ChatMessage}'s multimodal content array: either a text
  * fragment or an image URL (typically a {@code data:image/...;base64,...} URI).
- * Mirrors the OpenAI-compatible {@code content} part shape that the upstream
- * {@code llama.cpp} server already understands, so no new JNI plumbing is
- * required &#x2014; an image-bearing message is serialized to
+ * Mirrors the OpenAI-compatible {@code content} part shape understood by the
+ * upstream {@code llama.cpp} server. The JNI bridge preserves decoded media
+ * buffers and submits them through the upstream multimodal task path. An
+ * image-bearing message is serialized to
  * <pre>
  * {"role":"user","content":[
  *   {"type":"text","text":"What is in this image?"},
@@ -127,7 +128,7 @@ public final class ContentPart {
             mimeType = "image/gif";
         } else {
             throw new IllegalArgumentException("Cannot infer MIME type from extension: " + imagePath
-                    + " &#x2014; use ContentPart.imageBytes(bytes, mimeType) instead");
+                    + " — use ContentPart.imageBytes(bytes, mimeType) instead");
         }
         return imageBytes(Files.readAllBytes(imagePath), mimeType);
     }

--- a/src/test/cpp/test_jni_helpers.cpp
+++ b/src/test/cpp/test_jni_helpers.cpp
@@ -14,7 +14,7 @@
 //   get_jllama_context_impl, require_json_field_impl, jint_array_to_tokens_impl
 //
 // Layer B tests (need upstream server headers + mock JNIEnv):
-//   json_to_jstring_impl, results_to_jstring_impl,
+//   configure_multimodal_task_impl, json_to_jstring_impl, results_to_jstring_impl,
 //   embedding_to_jfloat_array_impl, tokens_to_jint_array_impl
 //
 // JNIEnv is mocked via a zero-filled JNINativeInterface_ table with only the
@@ -583,4 +583,37 @@ TEST_F(IntArrayFixture, TokensToJintArray_AllocFails_ThrowsOomAndReturnsNull) {
     EXPECT_EQ(result, nullptr);
     EXPECT_TRUE(g_throw_called);
     EXPECT_EQ(g_throw_message, "could not allocate token memory");
+}
+
+// ============================================================
+// configure_multimodal_task_impl
+// ============================================================
+
+TEST(ConfigureMultimodalTask, TextOnlyReturnsFalseAndLeavesCliDisabled) {
+    server_task task(SERVER_TASK_TYPE_COMPLETION);
+    EXPECT_FALSE(configure_multimodal_task_impl(task, true, {{"prompt", "hello"}}, {}));
+    EXPECT_FALSE(task.cli);
+    EXPECT_TRUE(task.cli_files.empty());
+}
+
+TEST(ConfigureMultimodalTask, MovesPromptAndMediaToCliTask) {
+    server_task task(SERVER_TASK_TYPE_COMPLETION);
+    std::vector<raw_buffer> files = {{0x01, 0x02, 0x03}};
+    EXPECT_TRUE(configure_multimodal_task_impl(task, true, {{"prompt", "before <__media__> after"}}, files));
+    EXPECT_TRUE(task.cli);
+    EXPECT_EQ(task.cli_prompt, "before <__media__> after");
+    ASSERT_EQ(task.cli_files.size(), 1u);
+    EXPECT_EQ(task.cli_files[0], files[0]);
+}
+
+TEST(ConfigureMultimodalTask, MediaWithoutProjectorThrows) {
+    server_task task(SERVER_TASK_TYPE_COMPLETION);
+    EXPECT_THROW((void) configure_multimodal_task_impl(task, false, {{"prompt", "<__media__>"}}, {{0x01}}),
+                 std::invalid_argument);
+}
+
+TEST(ConfigureMultimodalTask, NonStringPromptThrows) {
+    server_task task(SERVER_TASK_TYPE_COMPLETION);
+    EXPECT_THROW((void) configure_multimodal_task_impl(task, true, {{"prompt", json::array({1, 2})}}, {{0x01}}),
+                 std::invalid_argument);
 }

--- a/src/test/cpp/test_server.cpp
+++ b/src/test/cpp/test_server.cpp
@@ -1749,21 +1749,20 @@ TEST(ParamsFromJsonCmpl, DryBase_BelowOne_ResetToDefault) {
     EXPECT_FLOAT_EQ(p.sampling.dry_base, defaults.sampling.dry_base);
 }
 
-TEST(ParamsFromJsonCmpl, NDiscard_Negative_ClampedToZero) {
-    const auto p = parse_params({{"n_discard", -5}});
-    EXPECT_EQ(p.n_discard, 0);
+TEST(ParamsFromJsonCmpl, NDiscard_Negative_Throws) {
+    EXPECT_THROW(parse_params({{"n_discard", -5}}), std::invalid_argument);
 }
 
 TEST(ParamsFromJsonCmpl, EmptyDrySequenceBreakers_Throws) {
-    EXPECT_THROW(parse_params({{"dry_sequence_breakers", json::array()}}), std::runtime_error);
+    EXPECT_THROW(parse_params({{"dry_sequence_breakers", json::array()}}), std::invalid_argument);
 }
 
 TEST(ParamsFromJsonCmpl, LoraNotArray_Throws) {
-    EXPECT_THROW(parse_params({{"lora", "not-an-array"}}), std::runtime_error);
+    EXPECT_THROW(parse_params({{"lora", "not-an-array"}}), std::invalid_argument);
 }
 
 TEST(ParamsFromJsonCmpl, RepeatLastN_BelowMinusOne_Throws) {
-    EXPECT_THROW(parse_params({{"repeat_last_n", -2}}), std::runtime_error);
+    EXPECT_THROW(parse_params({{"repeat_last_n", -2}}), std::invalid_argument);
 }
 
 TEST(ParamsFromJsonCmpl, StreamOptions_IncludeUsage_Parsed) {

--- a/src/test/java/net/ladenthin/llama/MultimodalIntegrationTest.java
+++ b/src/test/java/net/ladenthin/llama/MultimodalIntegrationTest.java
@@ -8,13 +8,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import net.ladenthin.llama.parameters.ChatRequest;
 import net.ladenthin.llama.parameters.InferenceParameters;
 import net.ladenthin.llama.parameters.ModelParameters;
 import net.ladenthin.llama.value.ChatMessage;
+import net.ladenthin.llama.value.ChatResponse;
 import net.ladenthin.llama.value.ContentPart;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -31,7 +38,7 @@ import org.junit.jupiter.api.Timeout;
  * <p>The test exercises:</p>
  * <ul>
  *   <li>{@link ModelParameters#setMmproj(String)} wiring through to the native side;</li>
- *   <li>{@link InferenceParameters#setMessages(java.util.List)} serialising
+ *   <li>{@link InferenceParameters#withMessages(java.util.List)} serialising
  *       multipart {@code content} as the OAI array-form;</li>
  *   <li>the upstream {@code oaicompat_chat_params_parse} routing
  *       {@code image_url} blocks through the compiled-in {@code mtmd} pipeline.</li>
@@ -40,7 +47,9 @@ import org.junit.jupiter.api.Timeout;
  * <p>Self-skips when any of the three system properties is unset or its file
  * is missing, so it runs only in CI (or local dev where the user staged the
  * files explicitly). See {@code .github/workflows/publish.yml} env vars
- * {@code VISION_MODEL_URL} / {@code VISION_MMPROJ_URL} / {@code VISION_IMAGE_URL}.</p>
+ * {@code VISION_MODEL_URL} / {@code VISION_MMPROJ_URL}; the image defaults to
+ * the committed test resource and can be overridden with
+ * {@code net.ladenthin.llama.vision.image}.</p>
  *
  * <p><b>Image source:</b> the CI default is
  * <a href="https://commons.wikimedia.org/wiki/File:20200601_135745_Flowers_and_Bees.jpg">
@@ -59,6 +68,17 @@ import org.junit.jupiter.api.Timeout;
                 + "the upstream mtmd pipeline. Closes #103 / #34.")
 public class MultimodalIntegrationTest {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final byte[] RED_PNG = Base64.getDecoder()
+            .decode("iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAl0lEQVR4nO2S"
+                    + "wQkAMBCD3H9pO0QfchDIACpBOD1yAidAXtFdiLsjJ3AC5BXdhbg7cgInQF7RXYi7IydwAuQV3YW4O3ICJ0Be0V2IuyM"
+                    + "ncALkFd2FuDtyAidAXtFdiLsjJ3AC5BXdhbg7cgInQF7RXYi7IydwAuQV3YW4O3ICJ0Be0V2IuyMncALkFd2FuDtyAid"
+                    + "AXvHnQg+p3PDiuUoi2QAAAABJRU5ErkJggg==");
+    private static final byte[] BLUE_PNG = Base64.getDecoder()
+            .decode("iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAlklEQVR4nO2S"
+                    + "wQkAMBCD3H9pu0M/chBwACMBPA65gRtAXtFdiLuQG7gB5BXdhbgLuYEbQF7RXYi7kBu4AeQV3YW4C7mBG0Be0V2Iu5Ab"
+                    + "uAHkFd2FuAu5gRtAXtFdiLuQG7gB5BXdhbgLuYEbQF7RXYi7kBu4AeQV3YW4C7mBG0Be0V2Iu5AbuAHkFd2FuAu5gRtA"
+                    + "XvGfB8f88OJzBsmpAAAAAElFTkSuQmCC");
     private static String modelPath;
     private static String mmprojPath;
     private static String imagePath;
@@ -88,12 +108,17 @@ public class MultimodalIntegrationTest {
 
         int gpuLayers = Integer.getInteger(TestConstants.PROP_TEST_NGL, TestConstants.DEFAULT_TEST_NGL);
 
-        model = new LlamaModel(new ModelParameters()
+        ModelParameters parameters = new ModelParameters()
                 .setCtxSize(2048)
                 .setModel(modelPath)
                 .setMmproj(mmprojPath)
                 .setGpuLayers(gpuLayers)
-                .setFit(false));
+                .setFit(false);
+        if (gpuLayers == 0) {
+            parameters.setDevices("none").setMmprojOffload(false);
+        }
+        model = new LlamaModel(parameters);
+        assertTrue(model.getModelMeta().supportsVision(), "loaded model + mmproj must advertise vision input");
     }
 
     @AfterAll
@@ -128,6 +153,60 @@ public class MultimodalIntegrationTest {
         assertFalse(reply.trim().isEmpty(), "reply must be non-empty for a multimodal prompt; got: \"" + reply + "\"");
     }
 
+    /** The typed ChatRequest surface must preserve multipart image content too. */
+    @Timeout(value = 240_000, unit = TimeUnit.MILLISECONDS)
+    @Test
+    public void typedChatRequestProducesNonEmptyReply() throws Exception {
+        ChatRequest request = ChatRequest.empty()
+                .appendMessage(ChatMessage.userMultimodal(
+                        ContentPart.text("Describe this image in one short sentence."),
+                        ContentPart.imageFile(Paths.get(imagePath))))
+                .withInferenceCustomizer(params -> params.withNPredict(48).withTemperature(0.0f));
+
+        ChatResponse response = model.chat(request);
+        assertFalse(response.getFirstContent().trim().isEmpty(), "typed chat response must be non-empty");
+    }
+
+    /** Streaming uses the same decoded media buffers and must emit assistant content. */
+    @Timeout(value = 240_000, unit = TimeUnit.MILLISECONDS)
+    @Test
+    public void multimodalStreamingProducesContent() throws Exception {
+        ChatMessage userMsg = ChatMessage.userMultimodal(
+                ContentPart.text("Describe this image briefly."), ContentPart.imageFile(Paths.get(imagePath)));
+        InferenceParameters params = InferenceParameters.empty()
+                .withMessages(Collections.singletonList(userMsg))
+                .withNPredict(32)
+                .withTemperature(0.0f);
+        List<String> chunks = new ArrayList<String>();
+
+        model.streamChatCompletion(params, chunks::add);
+
+        StringBuilder content = new StringBuilder();
+        for (String chunk : chunks) {
+            JsonNode choices = MAPPER.readTree(chunk).path("choices");
+            if (choices.isArray() && choices.size() > 0) {
+                JsonNode fragment = choices.get(0).path("delta").path("content");
+                if (fragment.isTextual()) {
+                    content.append(fragment.asText());
+                }
+            }
+        }
+        assertFalse(content.toString().trim().isEmpty(), "streamed multimodal content must be non-empty");
+    }
+
+    /**
+     * Semantic guard against the old false-positive path where only the textual media marker was tokenized.
+     * Two synthetic images with the same prompt must be identified by their actual dominant colors.
+     */
+    @Timeout(value = 240_000, unit = TimeUnit.MILLISECONDS)
+    @Test
+    public void imageBytesAffectTheAnswer() throws Exception {
+        String red = identifyColor(RED_PNG);
+        String blue = identifyColor(BLUE_PNG);
+        assertTrue(red.contains("red"), "red image must be identified as red; got: " + red);
+        assertTrue(blue.contains("blue"), "blue image must be identified as blue; got: " + blue);
+    }
+
     /**
      * Sanity check that a multimodal call followed by a plain text-only call
      * on the same model instance both succeed &#x2014; verifies the parts /
@@ -154,5 +233,17 @@ public class MultimodalIntegrationTest {
         assertTrue(
                 secondReply.trim().length() > 0,
                 "text-only call after multimodal must still produce tokens; got: \"" + secondReply + "\"");
+    }
+
+    private static String identifyColor(byte[] png) {
+        ChatMessage message = ChatMessage.userMultimodal(
+                ContentPart.text("What is the dominant color? Reply with only red or blue."),
+                ContentPart.imageBytes(png, "image/png"));
+        return model.chatCompleteText(InferenceParameters.empty()
+                        .withMessages(Collections.singletonList(message))
+                        .withNPredict(8)
+                        .withTemperature(0.0f))
+                .trim()
+                .toLowerCase(java.util.Locale.ROOT);
     }
 }

--- a/src/test/java/net/ladenthin/llama/args/ModelFlagTest.java
+++ b/src/test/java/net/ladenthin/llama/args/ModelFlagTest.java
@@ -47,7 +47,9 @@ public class ModelFlagTest {
             {ModelFlag.CLEAR_IDLE, "--cache-idle-slots"},
             {ModelFlag.NO_CLEAR_IDLE, "--no-cache-idle-slots"},
             {ModelFlag.MMPROJ_AUTO, "--mmproj-auto"},
+            {ModelFlag.NO_MMPROJ_AUTO, "--no-mmproj-auto"},
             {ModelFlag.MMPROJ_OFFLOAD, "--mmproj-offload"},
+            {ModelFlag.NO_MMPROJ_OFFLOAD, "--no-mmproj-offload"},
             {ModelFlag.SKIP_DOWNLOAD, "--skip-download"},
         });
     }
@@ -64,7 +66,7 @@ public class ModelFlagTest {
 
     @Test
     public void testEnumCount() {
-        assertEquals(32, ModelFlag.values().length);
+        assertEquals(34, ModelFlag.values().length);
     }
 
     @ParameterizedTest(name = "{0} -> {1}")

--- a/src/test/java/net/ladenthin/llama/parameters/ChatRequestTest.java
+++ b/src/test/java/net/ladenthin/llama/parameters/ChatRequestTest.java
@@ -13,6 +13,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import net.ladenthin.llama.value.ChatMessage;
+import net.ladenthin.llama.value.ContentPart;
 import net.ladenthin.llama.value.ToolDefinition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -195,6 +197,17 @@ class ChatRequestTest {
             String json = req.buildMessagesJson();
             assertThat(json, json, containsString("\"user\""));
             assertThat("build did not mutate the messages list", req.getMessages(), hasSize(1));
+        }
+
+        @Test
+        void buildMessagesJsonPreservesMultimodalParts() {
+            ChatRequest req = ChatRequest.empty()
+                    .appendMessage(ChatMessage.userMultimodal(
+                            ContentPart.text("describe"), ContentPart.imageUrl("data:image/png;base64,AAAA")));
+            String json = req.buildMessagesJson();
+            assertThat(json, containsString("\"content\":["));
+            assertThat(json, containsString("\"type\":\"image_url\""));
+            assertThat(json, containsString("data:image/png;base64,AAAA"));
         }
 
         @Test

--- a/src/test/java/net/ladenthin/llama/parameters/ModelParametersTest.java
+++ b/src/test/java/net/ladenthin/llama/parameters/ModelParametersTest.java
@@ -435,9 +435,23 @@ public class ModelParametersTest {
     }
 
     @Test
+    public void testDisableMmprojAuto() {
+        ModelParameters p = new ModelParameters().enableMmprojAuto().setMmprojAuto(false);
+        assertThat(p.parameters, hasKey("--no-mmproj-auto"));
+        assertThat(p.parameters, not(hasKey("--mmproj-auto")));
+    }
+
+    @Test
     public void testEnableMmprojOffload() {
         ModelParameters p = new ModelParameters().enableMmprojOffload();
         assertThat(p.parameters, hasKey("--mmproj-offload"));
+    }
+
+    @Test
+    public void testDisableMmprojOffload() {
+        ModelParameters p = new ModelParameters().enableMmprojOffload().setMmprojOffload(false);
+        assertThat(p.parameters, hasKey("--no-mmproj-offload"));
+        assertThat(p.parameters, not(hasKey("--mmproj-offload")));
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/net/ladenthin/llama/server/OpenAiRequestMapperTest.java
+++ b/src/test/java/net/ladenthin/llama/server/OpenAiRequestMapperTest.java
@@ -40,6 +40,18 @@ public class OpenAiRequestMapperTest {
     }
 
     @Test
+    public void multimodalContentPartsForwardedVerbatim() throws IOException {
+        String request = "{\"messages\":[{\"role\":\"user\",\"content\":["
+                + "{\"type\":\"text\",\"text\":\"What color?\"},"
+                + "{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,AA==\"}}]}]}";
+        JsonNode expectedMessages = MAPPER.readTree(request).path("messages");
+
+        JsonNode out = mapAndSerialize(request);
+
+        assertThat(out.path("messages"), is(expectedMessages));
+    }
+
+    @Test
     public void toolMessageHistoryRoundTripsVerbatim() throws IOException {
         // A full agent-loop history: assistant tool_calls + a role:"tool" result with tool_call_id.
         String request = "{\"messages\":["

--- a/src/test/java/net/ladenthin/llama/server/OpenAiServerCliTest.java
+++ b/src/test/java/net/ladenthin/llama/server/OpenAiServerCliTest.java
@@ -106,6 +106,13 @@ public class OpenAiServerCliTest {
     }
 
     @Test
+    public void loadedModelVisionCapabilityOverridesMmprojHint() {
+        OpenAiServerCli.Options options = OpenAiServerCli.parse("-m", "m.gguf", "--mmproj", "proj.gguf");
+        assertThat(options.toServerConfig(false).isSupportsVision(), is(false));
+        assertThat(OpenAiServerCli.parse("-m", "m.gguf").toServerConfig(true).isSupportsVision(), is(true));
+    }
+
+    @Test
     public void rerankingFlagParsed() {
         assertThat(OpenAiServerCli.parse("-m", "m.gguf", "--reranking").isReranking(), is(true));
         assertThat(OpenAiServerCli.parse("-m", "m.gguf", "--rerank").isReranking(), is(true));


### PR DESCRIPTION
## Summary
- Wire **vision/multimodal input end to end**. The typed image API (`ContentPart`,
  `ChatMessage.userMultimodal`) already existed, but the JNI bridge discarded the decoded
  image buffers — `parse_oai_chat_params` populated a local `files` vector and threw it away,
  so image requests silently tokenized as text-only. The bridge now threads `files` through
  `dispatch_*` → `populate_completion_task` → a new `configure_multimodal_task_impl`, which
  attaches the media to the upstream CLI task path so the worker re-tokenizes via
  `process_mtmd_prompt` with the loaded projector. Covered across blocking, typed
  `ChatRequest`, streaming, and the OpenAI-compatible `/v1/chat/completions` mapper.
- Add explicit `ModelParameters.setMmprojAuto(boolean)` / `setMmprojOffload(boolean)` (with the
  upstream `--no-mmproj-auto` / `--no-mmproj-offload` flags), `LlamaModel.supportsVision()`, and
  make the standalone OpenAI server advertise vision from the **loaded model's** real capability
  rather than merely "an `--mmproj` path was passed".
- Tests: 4 new `configure_multimodal_task_impl` C++ tests, multimodal coverage in
  `ChatRequestTest` / `OpenAiRequestMapperTest`, mmproj-toggle tests, and a real-model
  `MultimodalIntegrationTest` (blocking + typed + streaming + a **semantic red/blue regression**
  proving image bytes actually reach the model).

## Test plan

- [x] Affected unit / integration tests pass locally — **450/450 C++** (`ctest`) and **223 Java**
  unit tests green; `jllama` library + Javadoc build clean; Spotless clean.
  `MultimodalIntegrationTest` self-skips without the vision GGUF.
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable — README "Vision / Multimodal Chat" section,
  CHANGELOG (Added + Fixed), and issue/feature docs updated.

## Related issues / PRs

Implements the vision / multimodal feature originally requested in the **upstream**
`kherud/java-llama.cpp` project:

- kherud/java-llama.cpp#103 — *VLM support: image input for multimodal models*
- kherud/java-llama.cpp#34 — *Support multimodal inputs*

> **Note on issue numbers:** the two references above are **upstream** (`kherud/java-llama.cpp`)
> issue numbers. This fork's issue/PR numbering has diverged from upstream, so a bare `#103` /
> `#34` in this repo would point at unrelated, already-merged PRs in
> `bernardladenthin/java-llama.cpp`. The `Closes` keyword is therefore intentionally **omitted**
> so this PR does not auto-close the wrong items. Track the feature against a fork-local issue if
> one is opened.

## Note for reviewer

`src/test/cpp/test_server.cpp` touches 4 sampling-param tests (`n_discard`,
`dry_sequence_breakers`, `lora`, `repeat_last_n`), moving them from the old `runtime_error`/clamp
expectations to `invalid_argument`/throw. These are **not** vision-related — they reflect the
b9739 upstream schema-validation change (those fields became hard limits routed through
`handle_with_catch`). Note: the same update already landed on `main` independently, so on merge
these converge to identical assertions (the `CMakeLists.txt` `server-schema.cpp` test-source line
likewise already exists on `main` and must be de-duplicated when resolving the merge).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)