### PR TITLE
Fix fork PR sccache failures with token-gated install and build retry

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -104,10 +104,37 @@ else
 fi
 
 cmake -Bbuild $LAUNCH $@ || exit 1
-cmake --build build --config Release -j"${JOBS}" || exit 1
+
+# Build. The pre-build probe only proves the cache was reachable at one instant; it cannot
+# foresee a cache outage that strikes *during* the build. When sccache is the launcher and its
+# backend fails mid-build — e.g. an intermittent Depot 403 on the server-startup .sccache_check,
+# or the tokenless 403 a fork PR hits because secrets are withheld — sccache makes every TU fatal
+# and reds the whole build. sccache exposes no "ignore backend errors" switch for that startup
+# check, so recover by retrying the build once WITHOUT the launcher: a from-scratch uncached -O3
+# build is content-identical and release-safe, so the cache can never red the build. The retry is
+# gated on the failure output actually showing an sccache cache error, so a genuine compile error
+# still fails fast (and is reported) instead of triggering a wasteful uncached rebuild.
+build_log="$(mktemp 2>/dev/null || echo "/tmp/jllama-build.$$.log")"
+cmake --build build --config Release -j"${JOBS}" 2>&1 | tee "$build_log"
+build_rc=${PIPESTATUS[0]}
+if [ "$build_rc" -ne 0 ]; then
+  if [ -n "$LAUNCH" ] && grep -qiE 'sccache: error|Server startup failed|cache storage failed' "$build_log"; then
+    echo "build.sh: build failed via an sccache cache error — retrying WITHOUT cache (clean reconfigure)."
+    rm -f "$build_log"
+    rm -rf build && mkdir -p build
+    cmake -Bbuild $@ || exit 1
+    cmake --build build --config Release -j"${JOBS}" || exit 1
+    LAUNCH=""  # cache disabled for this run; skip the stats query below
+  else
+    rm -f "$build_log"
+    exit 1
+  fi
+fi
+rm -f "$build_log"
 
 # Only query stats when sccache was actually used as the launcher; if the probe rejected a
-# crashing sccache, re-invoking it here would just repeat the crash output (harmless but noisy).
+# crashing sccache (or the mid-build retry disabled it), re-invoking it here would just repeat
+# the crash output (harmless but noisy).
 if [ -n "$LAUNCH" ] && command -v sccache >/dev/null 2>&1; then
   sccache --show-stats || true
 fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -415,7 +415,7 @@ jobs:
           echo "=== Processor Details ==="
           system_profiler SPHardwareDataType
       - name: Install sccache (shared compiler cache)
-        if: env.USE_CACHE == 'true'
+        if: env.USE_CACHE == 'true' && env.SCCACHE_WEBDAV_TOKEN != ''
         continue-on-error: true
         run: brew install sccache
       - name: Build libraries
@@ -460,7 +460,7 @@ jobs:
           echo "=== Processor Details ==="
           system_profiler SPHardwareDataType
       - name: Install sccache (shared compiler cache)
-        if: env.USE_CACHE == 'true'
+        if: env.USE_CACHE == 'true' && env.SCCACHE_WEBDAV_TOKEN != ''
         continue-on-error: true
         run: brew install sccache
       - name: Build libraries
@@ -578,7 +578,7 @@ jobs:
         with:
           arch: x64
       - name: Install sccache (shared compiler cache)
-        if: env.USE_CACHE == 'true'
+        if: env.USE_CACHE == 'true' && env.SCCACHE_WEBDAV_TOKEN != ''
         continue-on-error: true
         shell: pwsh
         run: |
@@ -632,7 +632,7 @@ jobs:
         with:
           arch: x86
       - name: Install sccache (shared compiler cache)
-        if: env.USE_CACHE == 'true'
+        if: env.USE_CACHE == 'true' && env.SCCACHE_WEBDAV_TOKEN != ''
         continue-on-error: true
         shell: pwsh
         run: |
@@ -723,7 +723,7 @@ jobs:
           echo "=== Processor Details ==="
           system_profiler SPHardwareDataType
       - name: Install sccache (shared compiler cache)
-        if: env.USE_CACHE == 'true'
+        if: env.USE_CACHE == 'true' && env.SCCACHE_WEBDAV_TOKEN != ''
         continue-on-error: true
         run: brew install sccache
       - name: Build libraries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,25 @@ sccache as the launcher: it compiles a trivial TU *through* sccache, and only se
 when a job sets one) for diagnosis but never reds the build. This closes the gap the original
 absent-only guard left.
 
+**The fork-PR `.sccache_check` 403 (mac-only symptom) and its two guards.** A fork PR (e.g.
+`vaiju1981/java-llama.cpp` → upstream) runs with secrets withheld, so `SCCACHE_WEBDAV_TOKEN`
+(`= secrets.DEPOT_TOKEN`) is **empty**. Depot rejects the unauthenticated server-startup
+`.sccache_check` with **403 Forbidden** (`PermissionDenied (temporary) … Forbidden`), and
+because sccache treats a failed startup check as fatal, *every* TU dies. The symptom looked
+**mac-only** purely because of an asymmetry in how sccache reaches `PATH`: the macOS jobs ran
+`brew install sccache` **unconditionally** (`if: USE_CACHE == 'true'`), whereas the
+Linux/dockcross/aarch64 jobs only **fetch** sccache when a token is present (the `[ -n
+"$SCCACHE_WEBDAV_TOKEN…" ]` guard in `build.sh`'s fetch block) — so on a tokenless fork PR
+mac was the only platform with sccache on `PATH` to misfire. Two independent guards now prevent
+it: **(1)** every `Install sccache` step is gated `if: env.USE_CACHE == 'true' && env.SCCACHE_WEBDAV_TOKEN
+!= ''`, so a tokenless fork PR never even installs sccache (mac now matches Linux); and **(2)**
+`build.sh`'s build step **retries once without the launcher** when the build fails *and* the
+output shows an sccache cache error (`sccache: error` / `Server startup failed` / `cache storage
+failed`) — a clean uncached `-O3` rebuild that is content-identical and release-safe. The retry
+is gated on that error signature so a genuine compile error still fails fast and is reported
+(no wasteful uncached rebuild). Guard (2) also covers an *intermittent* 403 that strikes a
+valid-token job mid-build, which the one-shot probe cannot foresee.
+
 **Rollout.** **Phase 1 — DONE & proven: the 3 macOS build jobs** (slowest + OOM-prone) —
 `brew install sccache` + the env above + `BUILD_JOBS: 2`. macOS build dropped **~40 min → ~6 min**
 with a warm cache. **Phase 2 — DONE: all 5 dockcross cross-compile jobs** now have the same


### PR DESCRIPTION
## Summary

- **Gate sccache installation on token presence** in all macOS and Windows jobs (`if: env.USE_CACHE == 'true' && env.SCCACHE_WEBDAV_TOKEN != ''`), preventing fork PRs (which run with secrets withheld) from installing sccache and hitting 403 errors during the startup check.
- **Add build retry logic in `build.sh`** that detects sccache cache errors and retries the build once without the launcher, ensuring transient cache failures don't red the entire build.
- **Document the fork-PR 403 issue and both guards** in `CLAUDE.md` to explain the root cause, symptom asymmetry (mac-only), and how the two independent guards prevent it.

## Motivation

Fork PRs run with `SCCACHE_WEBDAV_TOKEN` empty (secrets withheld), causing Depot to reject the unauthenticated `.sccache_check` with 403 Forbidden. sccache treats this as fatal, killing every TU. The symptom appeared mac-only because macOS jobs unconditionally installed sccache, while Linux jobs only fetched it when a token was present. Additionally, even valid-token jobs can hit intermittent 403s mid-build that the one-shot probe cannot foresee.

## Changes

1. **`.github/workflows/publish.yml`**: Added `&& env.SCCACHE_WEBDAV_TOKEN != ''` condition to all five "Install sccache" steps (macOS and Windows jobs), so tokenless fork PRs never install sccache.

2. **`.github/build.sh`**: 
   - Capture build output to a temp log file and check the exit code.
   - On build failure, grep for sccache-specific error signatures (`sccache: error`, `Server startup failed`, `cache storage failed`).
   - If an sccache error is detected and the launcher was active, clean reconfigure and rebuild without the launcher (uncached `-O3` build, content-identical and release-safe).
   - Retry is gated on the error signature so genuine compile errors still fail fast.
   - Skip the sccache stats query if the retry disabled the launcher.

3. **`CLAUDE.md`**: Added detailed section explaining the fork-PR 403 issue, the asymmetry in how sccache reaches `PATH`, and how both guards (token-gated install + build retry) prevent it.

## Test plan

- CI is green on this branch (all jobs, including fork PR simulation if available)
- The retry logic is only triggered on actual sccache cache errors, so genuine compile errors are unaffected
- Uncached rebuild is content-identical to cached build, so release safety is preserved

## Related issues / PRs

Fixes fork PR build failures on macOS due to sccache 403 errors.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01V9ZHtf3xz9pB5L9KWgWdWG