### PR TITLE
Feature/todo fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,9 +21,17 @@ session PRs) surfaced the items below. None are regressions from recent work. Th
 Items marked **✓ verified** were re-confirmed by reading the cited code directly; the rest were
 read-confirmed by the audit but warrant a quick re-check before the fix.
 
-**Progress (`feature/todo_fixes`):** Tier 1 (N1, N2, J1, P1) **DONE** and Tier 2 (N3, N4, S1, J3, J5)
-**DONE** — verified (452/452 C++ tests, affected Java tests + new regressions, Javadoc + Spotless +
-clang-format 22.1.5 clean). Remaining: all of Tier 3.
+**Progress (`feature/todo_fixes`):** Tier 1 (N1, N2, J1, P1), Tier 2 (N3, N4, S1, J3, J5) and Tier 3
+(S2, S3, P3, NaN/Inf JSON, OSInfo `exec`, discovery-route auth doc, `completeBatch` leak, probabilities
+doc) **DONE** — verified (452/452 C++ tests, affected Java tests + new regressions, Javadoc + Spotless +
+clang-format 22.1.5 clean).
+
+**Deferred — `LlamaLoader` native-lib extraction temp-path race (open).** Fixing it (per-process temp
+dir / atomic move) is the one audit item left undone: it sits on *the* native-library load path, so the
+change has a high blast radius and needs careful Windows / `deleteOnExit` / `cleanup()` co-design plus
+cross-platform load testing (a locked-DLL replace on Windows, leftover unique-dir accumulation) that the
+fix-batch could not safely exercise. The race only bites concurrent JVMs sharing one `java.io.tmpdir`
+(e.g. some CI matrices). Pick it up as its own change with a Windows test pass.
 
 **Tier 1 — high impact, fix first**
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,89 @@ cross-cutting initiative.
 
 ## Open — jllama-specific
 
+### Code audit — pre-existing correctness / safety findings (open)
+
+A multi-area audit (2026-06-20) of the **existing** codebase (independent of the tools / vision /
+session PRs) surfaced the items below. None are regressions from recent work. They are intentionally
+**split into tiers so each can land as its own small, focused PR** rather than one large change.
+Items marked **✓ verified** were re-confirmed by reading the cited code directly; the rest were
+read-confirmed by the audit but warrant a quick re-check before the fix.
+
+**Progress (`feature/todo_fixes`):** Tier 1 (N1, N2, J1, P1) **DONE**, plus Tier 2 quick wins
+N4 and J3 **DONE** — verified (452/452 C++ tests, affected Java tests + a new metrics-overflow
+regression, Spotless + clang-format 22.1.5 clean). Remaining: Tier 2 (S1, N3, J5) and all of Tier 3.
+
+**Tier 1 — high impact, fix first**
+
+- **✓ Unhandled C++ exceptions cross the JNI boundary → JVM abort (UB).** Several `JNIEXPORT`
+  entry points call throwing code with no `try/catch`, so a C++ exception propagates across JNI
+  (no Java exception is raised — the process crashes). Most reachable: the **public** API
+  `LlamaModel.jsonSchemaToGrammar(String)` (`LlamaModel.java:436`) → `jllama.cpp:1090`
+  `ordered_json::parse(c_schema)` deterministically aborts the JVM on a malformed schema string.
+  Same class on `encode` / `handleTokenize` / `handleEmbeddings` / `handleRerank` / `applyTemplate`
+  with malformed JSON or an untokenizable prompt, and `applyTemplate`'s unchecked `.at("prompt")`.
+  **Fix:** wrap each entry-point body and convert to `ThrowNew(c_llama_error, e.what())` (the pattern
+  `handleCompletionsOai` / `configureParallelInference` already use). A shared macro covers them uniformly.
+- **✓ `parse_string_array` — null deref + JNI local-reference leak** (`jllama.cpp:339`). The
+  `GetStringUTFChars` result is not null-checked (OOM → `strdup(NULL)`), a `null` array element is UB,
+  and `GetObjectArrayElement` leaks a local ref each iteration — a `handleRerank` with many documents
+  overflows the ~16-slot local-ref table. **Fix:** null-check both, `DeleteLocalRef` per iteration,
+  free already-allocated slots on the error path. Reachable from `loadModel` + `handleRerank`.
+- **✓ `close()` / native `delete()` double-free under concurrent close** (`LlamaModel.java:387`,
+  `jllama.cpp` delete path). `close()` is not `synchronized`, `ctx` is a plain non-volatile `long`,
+  and native `delete()` does check-then-act on the handle with no atomicity; the library explicitly
+  supports async/parallel use, so two closes (or a close racing a try-with-resources unwind) can both
+  free the same handle. **Fix:** `synchronized` close (or atomic handle exchange).
+- **✓ `ServerMetrics.getCumulativeTimings()` truncates cumulative token totals to `int` → negative**
+  (`ServerMetrics.java:174`). `long` startup-cumulative counters cast `(int)` overflow past ~2.1B
+  tokens (e.g. `(int)3_000_000_000L == -1294967296`). **Fix:** widen `Timings.promptN`/`predictedN`
+  to `long` (the per-request `fromJson` path benefits too).
+
+**Tier 2 — medium**
+
+- **✓ Unbounded request-body read → OOM DoS** (`OpenAiCompatServer.java:820`,
+  `OBJECT_MAPPER.readTree(getRequestBody())`). No size cap / `Content-Length` check; unauthenticated
+  when bound to `0.0.0.0` (the bind is configurable and the default has no key). **Fix:** cap body size
+  / reject oversized `Content-Length` (config-driven, sane default).
+- **Streaming reader raw-pointer use-after-free** (`jllama.cpp` `receiveCompletionJson` /
+  `receiveChatCompletionChunk`). The reader pointer is cached under `readers_mutex`, then `next()` is
+  called outside the lock while `delete()`/`erase_reader` can free it. **Fix:** hold a `shared_ptr`
+  across `next()`.
+- **`Session` permanently wedged on an abandoned stream** (`SessionState`). `streamingActive` is cleared
+  only by `commitStreamedReply`; a consumer that throws / `break`s / closes the iterable without
+  committing leaves the flag stuck `true` forever (every later `send`/`stream`/`save`/`restore` throws),
+  and the user turn is committed with no assistant turn. **Fix:** clear the flag on stream close/cancel.
+- **✓ `LlamaIterator.hasNext` not `volatile`** (`LlamaIterator.java:41`). `cancel()` (documented as a
+  cross-thread call) writes it from another thread; the consumer may never observe `false`. The sibling
+  `CancellationToken.cancelled` is `volatile` for exactly this reason. **Fix:** `volatile`.
+- **Log callback throws from a JVM-unattached native thread** (`jllama.cpp` log lambda + `get_jni_env`).
+  ggml/llama internal threads can fire logging; `get_jni_env` throws, unwinding through C frames →
+  `std::terminate`/UB. **Fix:** make the lambda `noexcept`, skip when the thread is unattached.
+
+**Tier 3 — hardening / low**
+
+- **✓ Timing-unsafe API-key comparison** (`OpenAiCompatServer.java:817`, `String.equals`) →
+  `MessageDigest.isEqual`.
+- **✓ `ChatMessage.toolCalls` not defensively copied** (`ChatMessage.java:102`) — `parts` is copied +
+  wrapped, `toolCalls` is stored/returned by reference, breaking the documented-immutable contract.
+- **Single-thread heartbeat pool** (`OpenAiCompatServer.java:171`) — one stalled SSE client blocks the
+  lone scheduler thread, starving every other stream's keep-alives. **Fix:** size the pool / non-blocking
+  heartbeat write.
+- **Float `NaN`/`Infinity` → invalid JSON** in scalar withers (`JsonParameters.withScalar` via
+  `String.valueOf`); the whole request then fails opaquely in the native parser. **Fix:** reject at the
+  public wither.
+- **Native-lib extraction to a fixed temp path** (`LlamaLoader`) — no per-process uniqueness; concurrent
+  JVMs (CI matrices) can interleave a partial `copy` with a peer's `System.load`, and `cleanup()` can
+  delete a file a live peer needs. **Fix:** per-process temp dir / atomic move.
+- **`OSInfo` raw `exec()`** (32-bit ARM detection) leaks `Process` + undrained pipes (can hang init).
+  **Fix:** route through `ProcessRunner` / drain+close streams.
+- **Discovery routes unauthenticated** (`/props`, `/api/show`) — minor metadata disclosure when a key is
+  set; decide intentional-and-document vs. gate.
+- **`completeBatch` partial-failure leak** — on the first `join()` throw, sibling futures keep running
+  unobserved (native slot pressure); await/cancel the rest before rethrowing.
+- **`probabilities` map is last-wins on duplicate token text** (`CompletionResponseParser`) — document,
+  or key by id+position (lossless data already in `logprobs`).
+
 ### OpenAI-compatible HTTP endpoint (shipped; follow-ups open)
 
 `net.ladenthin.llama.server.OpenAiCompatServer` is the single OpenAI-compatible server (JDK

--- a/TODO.md
+++ b/TODO.md
@@ -21,9 +21,9 @@ session PRs) surfaced the items below. None are regressions from recent work. Th
 Items marked **✓ verified** were re-confirmed by reading the cited code directly; the rest were
 read-confirmed by the audit but warrant a quick re-check before the fix.
 
-**Progress (`feature/todo_fixes`):** Tier 1 (N1, N2, J1, P1) **DONE**, plus Tier 2 quick wins
-N4 and J3 **DONE** — verified (452/452 C++ tests, affected Java tests + a new metrics-overflow
-regression, Spotless + clang-format 22.1.5 clean). Remaining: Tier 2 (S1, N3, J5) and all of Tier 3.
+**Progress (`feature/todo_fixes`):** Tier 1 (N1, N2, J1, P1) **DONE** and Tier 2 (N3, N4, S1, J3, J5)
+**DONE** — verified (452/452 C++ tests, affected Java tests + new regressions, Javadoc + Spotless +
+clang-format 22.1.5 clean). Remaining: all of Tier 3.
 
 **Tier 1 — high impact, fix first**
 

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -284,7 +284,18 @@ std::string parse_jstring(JNIEnv *env, jstring java_string) {
  * Combines parse_jstring + json::parse, which every parameter-taking JNI
  * function needs before it can read its arguments.
  */
-static json parse_json_params(JNIEnv *env, jstring jparams) { return json::parse(parse_jstring(env, jparams)); }
+// Parse the JSON request body. On malformed input, converts the C++ parse error into a Java
+// LlamaException (so it never crosses the JNI boundary — which is undefined behavior) and returns
+// false; callers must return their sentinel when this returns false.
+[[nodiscard]] static bool parse_json_params(JNIEnv *env, jstring jparams, json &out) {
+    try {
+        out = json::parse(parse_jstring(env, jparams));
+        return true;
+    } catch (const std::exception &e) {
+        env->ThrowNew(c_llama_error, e.what());
+        return false;
+    }
+}
 
 /**
  * Convenience wrapper around require_json_field_impl (jni_helpers.hpp).
@@ -345,9 +356,20 @@ char **parse_string_array(JNIEnv *env, const jobjectArray string_array, const js
 
     for (jsize i = 0; i < length; i++) {
         auto *const javaString = static_cast<jstring>(env->GetObjectArrayElement(string_array, i));
+        // A null array element (legal from a Java String[]) must not reach GetStringUTFChars.
+        if (javaString == nullptr) {
+            result[i] = strdup("");
+            continue;
+        }
+        // GetStringUTFChars returns nullptr on allocation failure; never strdup(nullptr).
         const char *cString = env->GetStringUTFChars(javaString, nullptr);
-        result[i] = strdup(cString);
-        env->ReleaseStringUTFChars(javaString, cString);
+        result[i] = strdup(cString != nullptr ? cString : "");
+        if (cString != nullptr) {
+            env->ReleaseStringUTFChars(javaString, cString);
+        }
+        // Each GetObjectArrayElement returns a fresh local ref; release it so a large
+        // array (e.g. a rerank with many documents) cannot overflow the local-ref table.
+        env->DeleteLocalRef(javaString);
     }
 
     return result;
@@ -398,6 +420,20 @@ JNIEnv *get_jni_env() {
     JNIEnv *env = nullptr;
     if (g_vm == nullptr || g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
         throw std::runtime_error("Thread is not attached to the JVM");
+    }
+    return env;
+}
+
+/**
+ * Like get_jni_env() but returns nullptr instead of throwing when the calling
+ * thread is not attached to the JVM. Used from the log callback, which can fire
+ * on internal ggml/llama worker threads that were never AttachCurrentThread-ed —
+ * throwing there would unwind through C call frames (undefined behavior).
+ */
+JNIEnv *get_jni_env_or_null() noexcept {
+    JNIEnv *env = nullptr;
+    if (g_vm == nullptr || g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
+        return nullptr;
     }
     return env;
 }
@@ -764,7 +800,10 @@ JNIEXPORT jint JNICALL Java_net_ladenthin_llama_LlamaModel_requestCompletion(JNI
                                                                              jstring jparams) {
     REQUIRE_SERVER_CONTEXT(0);
 
-    json data = parse_json_params(env, jparams);
+    json data;
+    if (!parse_json_params(env, jparams, data)) {
+        return 0;
+    }
 
     const server_task_type type = is_infill_request(data) ? SERVER_TASK_TYPE_INFILL : SERVER_TASK_TYPE_COMPLETION;
 
@@ -874,7 +913,13 @@ JNIEXPORT jfloatArray JNICALL Java_net_ladenthin_llama_LlamaModel_embed(JNIEnv *
     const std::string prompt = parse_jstring(env, jprompt);
     SRV_INF("Calling embedding '%s'\n", prompt.c_str());
 
-    auto tokens = tokenize_mixed(jctx->vocab, prompt, true, true);
+    llama_tokens tokens;
+    try {
+        tokens = tokenize_mixed(jctx->vocab, prompt, true, true);
+    } catch (const std::exception &e) {
+        env->ThrowNew(c_llama_error, e.what());
+        return nullptr;
+    }
     auto rd = ctx_server->get_response_reader();
     server_task task(SERVER_TASK_TYPE_EMBEDDING);
     task.id = rd.get_new_id();
@@ -938,13 +983,20 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleRerank(JNIEn
 JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_applyTemplate(JNIEnv *env, jobject obj, jstring jparams) {
     REQUIRE_SERVER_CONTEXT(nullptr);
 
-    json data = parse_json_params(env, jparams);
+    json data;
+    if (!parse_json_params(env, jparams, data)) {
+        return nullptr;
+    }
 
     json templateData;
     std::vector<raw_buffer> files;
     if (!parse_oai_chat_params(env, ctx_server, data, templateData, files))
         return nullptr;
 
+    if (!templateData.contains("prompt") || !templateData.at("prompt").is_string()) {
+        env->ThrowNew(c_llama_error, "applyTemplate did not produce a string prompt");
+        return nullptr;
+    }
     std::string tok_str = templateData.at("prompt");
     return env->NewStringUTF(tok_str.c_str());
 }
@@ -953,7 +1005,10 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleChatCompleti
                                                                                     jstring jparams) {
     REQUIRE_SERVER_CONTEXT(nullptr);
 
-    json body = parse_json_params(env, jparams);
+    json body;
+    if (!parse_json_params(env, jparams, body)) {
+        return nullptr;
+    }
     json data;
     std::vector<raw_buffer> files;
     if (!parse_oai_chat_params(env, ctx_server, body, data, files))
@@ -967,7 +1022,10 @@ JNIEXPORT jint JNICALL Java_net_ladenthin_llama_LlamaModel_requestChatCompletion
                                                                                  jstring jparams) {
     REQUIRE_SERVER_CONTEXT(0);
 
-    json body = parse_json_params(env, jparams);
+    json body;
+    if (!parse_json_params(env, jparams, body)) {
+        return 0;
+    }
     // Chat template already applied by parse_oai_chat_params; no OAI wrapping on the streaming path.
     json data;
     std::vector<raw_buffer> files;
@@ -987,7 +1045,10 @@ JNIEXPORT jint JNICALL Java_net_ladenthin_llama_LlamaModel_requestChatCompletion
                                                                                        jstring jparams) {
     REQUIRE_SERVER_CONTEXT(0);
 
-    json body = parse_json_params(env, jparams);
+    json body;
+    if (!parse_json_params(env, jparams, body)) {
+        return 0;
+    }
     json data;
     std::vector<raw_buffer> files;
     if (!parse_oai_chat_params(env, ctx_server, body, data, files))
@@ -1001,8 +1062,13 @@ JNIEXPORT jintArray JNICALL Java_net_ladenthin_llama_LlamaModel_encode(JNIEnv *e
     REQUIRE_SERVER_CONTEXT(nullptr);
 
     const std::string c_prompt = parse_jstring(env, jprompt);
-    llama_tokens tokens = tokenize_mixed(jctx->vocab, c_prompt, false, true);
-    return tokens_to_jint_array_impl(env, tokens, c_error_oom);
+    try {
+        llama_tokens tokens = tokenize_mixed(jctx->vocab, c_prompt, false, true);
+        return tokens_to_jint_array_impl(env, tokens, c_error_oom);
+    } catch (const std::exception &e) {
+        env->ThrowNew(c_llama_error, e.what());
+        return nullptr;
+    }
 }
 
 // Detokenise a token sequence to UTF-8, dispatching on vocab-only vs full context.
@@ -1072,8 +1138,13 @@ JNIEXPORT void JNICALL Java_net_ladenthin_llama_LlamaModel_setLogger(JNIEnv *env
         llama_log_set(nullptr, nullptr);
     } else {
         o_log_callback = env->NewGlobalRef(jcallback);
-        log_callback = [](enum ggml_log_level level, const char *text, void *user_data) {
-            JNIEnv *env = get_jni_env();
+        log_callback = [](enum ggml_log_level level, const char *text, void *user_data) noexcept {
+            // Logging can fire from internal native threads with no JNIEnv; skip rather than
+            // throw (an exception here would unwind through llama.cpp's C frames).
+            JNIEnv *env = get_jni_env_or_null();
+            if (env == nullptr || text == nullptr) {
+                return;
+            }
             jstring message = env->NewStringUTF(text);
             jobject log_level = log_level_to_jobject(level);
             env->CallVoidMethod(o_log_callback, m_biconsumer_accept, log_level, message);
@@ -1086,17 +1157,25 @@ JNIEXPORT void JNICALL Java_net_ladenthin_llama_LlamaModel_setLogger(JNIEnv *env
 
 JNIEXPORT jbyteArray JNICALL Java_net_ladenthin_llama_LlamaModel_jsonSchemaToGrammarBytes(JNIEnv *env, jclass clazz,
                                                                                           jstring j_schema) {
-    const std::string c_schema = parse_jstring(env, j_schema);
-    nlohmann::ordered_json c_schema_json = nlohmann::ordered_json::parse(c_schema);
-    const std::string c_grammar = json_schema_to_grammar(c_schema_json);
-    return parse_jbytes(env, c_grammar);
+    try {
+        const std::string c_schema = parse_jstring(env, j_schema);
+        nlohmann::ordered_json c_schema_json = nlohmann::ordered_json::parse(c_schema);
+        const std::string c_grammar = json_schema_to_grammar(c_schema_json);
+        return parse_jbytes(env, c_grammar);
+    } catch (const std::exception &e) {
+        env->ThrowNew(c_llama_error, e.what());
+        return nullptr;
+    }
 }
 
 JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleCompletions(JNIEnv *env, jobject obj,
                                                                                 jstring jparams) {
     REQUIRE_SERVER_CONTEXT(nullptr);
 
-    json data = parse_json_params(env, jparams);
+    json data;
+    if (!parse_json_params(env, jparams, data)) {
+        return nullptr;
+    }
     return dispatch_blocking_completion(env, jctx, data, SERVER_TASK_TYPE_COMPLETION, TASK_RESPONSE_TYPE_NONE);
 }
 
@@ -1104,7 +1183,10 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleCompletionsO
                                                                                    jstring jparams) {
     REQUIRE_SERVER_CONTEXT(nullptr);
 
-    json body = parse_json_params(env, jparams);
+    json body;
+    if (!parse_json_params(env, jparams, body)) {
+        return nullptr;
+    }
     json data;
     try {
         data = oaicompat_completion_params_parse(body);
@@ -1128,7 +1210,10 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleInfill(JNIEn
         return nullptr;
     }
 
-    json data = parse_json_params(env, jparams);
+    json data;
+    if (!parse_json_params(env, jparams, data)) {
+        return nullptr;
+    }
 
     if (!require_json_field(env, data, "input_prefix"))
         return nullptr;
@@ -1139,12 +1224,18 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleInfill(JNIEn
     data["input_extra"] = input_extra;
 
     std::string prompt = json_value(data, "prompt", std::string());
-    std::vector<server_tokens> tokenized_prompts = tokenize_input_prompts(jctx->vocab, nullptr, prompt, false, true);
+    try {
+        std::vector<server_tokens> tokenized_prompts =
+            tokenize_input_prompts(jctx->vocab, nullptr, prompt, false, true);
 
-    data["prompt"] =
-        format_prompt_infill(jctx->vocab, data.at("input_prefix"), data.at("input_suffix"), data.at("input_extra"),
-                             jctx->params.n_batch, jctx->params.n_predict, meta.slot_n_ctx, jctx->params.spm_infill,
-                             tokenized_prompts.empty() ? llama_tokens() : tokenized_prompts[0].get_tokens());
+        data["prompt"] =
+            format_prompt_infill(jctx->vocab, data.at("input_prefix"), data.at("input_suffix"), data.at("input_extra"),
+                                 jctx->params.n_batch, jctx->params.n_predict, meta.slot_n_ctx, jctx->params.spm_infill,
+                                 tokenized_prompts.empty() ? llama_tokens() : tokenized_prompts[0].get_tokens());
+    } catch (const std::exception &e) {
+        env->ThrowNew(c_llama_error, e.what());
+        return nullptr;
+    }
 
     return dispatch_blocking_completion(env, jctx, data, SERVER_TASK_TYPE_INFILL, TASK_RESPONSE_TYPE_NONE);
 }
@@ -1168,7 +1259,10 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleEmbeddings(J
         }
     }
 
-    json body = parse_json_params(env, jparams);
+    json body;
+    if (!parse_json_params(env, jparams, body)) {
+        return nullptr;
+    }
 
     bool force_no_oaicompat = false;
     json prompt;
@@ -1183,7 +1277,13 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleEmbeddings(J
     if (force_no_oaicompat)
         res_type = TASK_RESPONSE_TYPE_NONE;
 
-    std::vector<server_tokens> tokenized_prompts = tokenize_input_prompts(jctx->vocab, nullptr, prompt, true, true);
+    std::vector<server_tokens> tokenized_prompts;
+    try {
+        tokenized_prompts = tokenize_input_prompts(jctx->vocab, nullptr, prompt, true, true);
+    } catch (const std::exception &e) {
+        env->ThrowNew(c_llama_error, e.what());
+        return nullptr;
+    }
 
     for (const auto &toks : tokenized_prompts) {
         if (toks.get_tokens().empty()) {
@@ -1226,7 +1326,13 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_handleTokenize(JNI
     const bool add_special = jaddSpecial;
     const bool with_pieces = jwithPieces;
 
-    llama_tokens tokens = tokenize_mixed(jctx->vocab, content, add_special, true);
+    llama_tokens tokens;
+    try {
+        tokens = tokenize_mixed(jctx->vocab, content, add_special, true);
+    } catch (const std::exception &e) {
+        env->ThrowNew(c_llama_error, e.what());
+        return nullptr;
+    }
 
     json tokens_response = json::array();
 
@@ -1287,7 +1393,10 @@ JNIEXPORT jboolean JNICALL Java_net_ladenthin_llama_LlamaModel_configureParallel
     REQUIRE_SERVER_CONTEXT(JNI_FALSE);
     (void)obj;
 
-    json config = parse_json_params(env, jconfig);
+    json config;
+    if (!parse_json_params(env, jconfig, config)) {
+        return JNI_FALSE;
+    }
 
     std::optional<float> slot_sim_opt;
     std::optional<int> n_threads_opt;

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -819,7 +819,9 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_receiveCompletionJ
                                                                                     jint id_task) {
     REQUIRE_SERVER_CONTEXT(nullptr);
 
-    server_response_reader *rd;
+    // Copy the shared_ptr out under the lock so the reader stays alive across next() below,
+    // which runs without the lock and may race a concurrent erase_reader()/close().
+    std::shared_ptr<server_response_reader> rd;
     {
         std::lock_guard<std::mutex> lk(jctx->readers_mutex);
         auto it = jctx->readers.find(id_task);
@@ -827,7 +829,7 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_receiveCompletionJ
             env->ThrowNew(c_llama_error, "Task not found");
             return nullptr;
         }
-        rd = it->second.get();
+        rd = it->second;
     }
 
     // Upstream b9437 added is_begin partial results whose to_json() returns
@@ -867,7 +869,9 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_receiveChatComplet
                                                                                          jint id_task) {
     REQUIRE_SERVER_CONTEXT(nullptr);
 
-    server_response_reader *rd;
+    // Copy the shared_ptr out under the lock so the reader stays alive across next() below,
+    // which runs without the lock and may race a concurrent erase_reader()/close().
+    std::shared_ptr<server_response_reader> rd;
     {
         std::lock_guard<std::mutex> lk(jctx->readers_mutex);
         auto it = jctx->readers.find(id_task);
@@ -875,7 +879,7 @@ JNIEXPORT jstring JNICALL Java_net_ladenthin_llama_LlamaModel_receiveChatComplet
             env->ThrowNew(c_llama_error, "Task not found");
             return nullptr;
         }
-        rd = it->second.get();
+        rd = it->second;
     }
 
     json payload;

--- a/src/main/cpp/jni_helpers.hpp
+++ b/src/main/cpp/jni_helpers.hpp
@@ -68,7 +68,11 @@ struct jllama_context {
     // Per-streaming-task response readers, keyed by task id.
     // Guarded by readers_mutex.
     std::mutex readers_mutex;
-    std::map<int, std::unique_ptr<server_response_reader>> readers;
+    // shared_ptr (not unique_ptr): the streaming receive paths copy the reader out under
+    // readers_mutex and then call next() *without* the lock, so a concurrent close()/erase
+    // that removes the map entry must not free a reader still in use — the receiver's copy
+    // keeps it alive until next() returns.
+    std::map<int, std::shared_ptr<server_response_reader>> readers;
 };
 
 // Removes the streaming reader entry for `id_task` under the readers_mutex.

--- a/src/main/java/net/ladenthin/llama/LlamaIterator.java
+++ b/src/main/java/net/ladenthin/llama/LlamaIterator.java
@@ -38,7 +38,9 @@ public final class LlamaIterator implements Iterator<LlamaOutput>, AutoCloseable
     private final int taskId;
     private final CompletionResponseParser completionParser = new CompletionResponseParser();
 
-    private boolean hasNext = true;
+    // volatile: cancel() may be called from another thread, so the consuming thread
+    // running next()/hasNext() must observe the flip without a data race.
+    private volatile boolean hasNext = true;
 
     LlamaIterator(LlamaModel model, InferenceParameters parameters) {
         this(model, parameters, false);

--- a/src/main/java/net/ladenthin/llama/LlamaModel.java
+++ b/src/main/java/net/ladenthin/llama/LlamaModel.java
@@ -384,7 +384,9 @@ public class LlamaModel implements AutoCloseable {
     public static native void setLogger(LogFormat format, BiConsumer<LogLevel, String> callback);
 
     @Override
-    public void close() {
+    public synchronized void close() {
+        // synchronized so two concurrent close() calls cannot both observe a live native
+        // handle and double-free it; native delete() is idempotent (a zero handle is a no-op).
         delete();
     }
 

--- a/src/main/java/net/ladenthin/llama/LlamaModel.java
+++ b/src/main/java/net/ladenthin/llama/LlamaModel.java
@@ -176,8 +176,20 @@ public class LlamaModel implements AutoCloseable {
             futures.add(completeAsync(req));
         }
         java.util.List<String> out = new java.util.ArrayList<String>(futures.size());
+        RuntimeException failure = null;
         for (CompletableFuture<String> f : futures) {
-            out.add(f.join());
+            try {
+                out.add(f.join());
+            } catch (RuntimeException e) {
+                // Keep joining the rest so no sibling request is left running unobserved (a native
+                // slot/reader leak) before propagating the first failure.
+                if (failure == null) {
+                    failure = e;
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
         }
         return out;
     }
@@ -196,8 +208,18 @@ public class LlamaModel implements AutoCloseable {
             futures.add(CompletableFuture.supplyAsync(() -> completeWithStats(req)));
         }
         java.util.List<CompletionResult> out = new java.util.ArrayList<CompletionResult>(futures.size());
+        RuntimeException failure = null;
         for (CompletableFuture<CompletionResult> f : futures) {
-            out.add(f.join());
+            try {
+                out.add(f.join());
+            } catch (RuntimeException e) {
+                if (failure == null) {
+                    failure = e;
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
         }
         return out;
     }
@@ -217,8 +239,18 @@ public class LlamaModel implements AutoCloseable {
             futures.add(CompletableFuture.supplyAsync(() -> chat(req)));
         }
         java.util.List<ChatResponse> out = new java.util.ArrayList<ChatResponse>(futures.size());
+        RuntimeException failure = null;
         for (CompletableFuture<ChatResponse> f : futures) {
-            out.add(f.join());
+            try {
+                out.add(f.join());
+            } catch (RuntimeException e) {
+                if (failure == null) {
+                    failure = e;
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
         }
         return out;
     }

--- a/src/main/java/net/ladenthin/llama/Session.java
+++ b/src/main/java/net/ladenthin/llama/Session.java
@@ -149,6 +149,17 @@ public final class Session implements AutoCloseable {
     }
 
     /**
+     * Abandon an in-progress {@link #stream(String)} round without recording an assistant reply,
+     * returning the session to its pre-stream state (the pending user turn is rolled back). Call this
+     * — e.g. in a {@code finally} — when a stream is broken off early or its consumer throws, so the
+     * session is never left wedged (every later {@code send}/{@code stream}/{@code save}/{@code restore}
+     * would otherwise keep throwing). Safe to call when no stream is active.
+     */
+    public void cancelStream() {
+        state.cancelStream();
+    }
+
+    /**
      * Save this session's slot KV cache to {@code filepath}.
      *
      * @param filepath destination file path passed to {@link LlamaModel#saveSlot(int, String)}

--- a/src/main/java/net/ladenthin/llama/SessionState.java
+++ b/src/main/java/net/ladenthin/llama/SessionState.java
@@ -134,6 +134,21 @@ public final class SessionState {
     }
 
     /**
+     * Abandon an in-progress streaming round without recording an assistant reply: clears the
+     * streaming flag and rolls back the pending user turn, returning the state to its pre-stream
+     * shape. Safe to call when no stream is active (no-op), so it can run in a {@code finally}
+     * block to guarantee the session never stays wedged after an abandoned or failed stream.
+     */
+    public void cancelStream() {
+        synchronized (lock) {
+            if (streamingActive) {
+                transcript.removePendingUserTurn();
+                streamingActive = false;
+            }
+        }
+    }
+
+    /**
      * Run an action under the lock, but only when no stream is in progress
      * (used for slot save/restore, which must not race a streaming round).
      *

--- a/src/main/java/net/ladenthin/llama/json/CompletionResponseParser.java
+++ b/src/main/java/net/ladenthin/llama/json/CompletionResponseParser.java
@@ -120,6 +120,11 @@ public class CompletionResponseParser {
      * <p>Returns an empty map when the field is absent or the array is empty.
      * Requires {@code InferenceParameters#withNProbs(int)} to be configured before inference.
      *
+     * <p><b>Lossy on duplicate token text:</b> this flat map is keyed by token string, so when the
+     * same token text occurs more than once in a generation (common for repeated words/punctuation)
+     * only the <em>last</em> occurrence's probability survives. Use {@link #parseLogprobs(JsonNode)}
+     * (an order-preserving list) when every per-token value matters.
+     *
      * @param root the top-level completion response node
      * @return map from token string to probability; empty when no probability data is present
      */

--- a/src/main/java/net/ladenthin/llama/loader/OSInfo.java
+++ b/src/main/java/net/ladenthin/llama/loader/OSInfo.java
@@ -74,6 +74,7 @@ package net.ladenthin.llama.loader;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -354,7 +355,7 @@ public class OSInfo {
             String javaHome = System.getProperty("java.home");
             try {
                 // determine if first JVM found uses ARM hard-float ABI
-                int exitCode = Runtime.getRuntime().exec("which readelf").waitFor();
+                int exitCode = runDiscardingOutput("which", "readelf");
                 if (exitCode == 0) {
                     String[] cmdarray = {
                         "/bin/sh",
@@ -364,7 +365,7 @@ public class OSInfo {
                                 + "' -name 'libjvm.so' | head -1 | xargs readelf -A | "
                                 + "grep 'Tag_ABI_VFP_args: VFP registers'"
                     };
-                    exitCode = Runtime.getRuntime().exec(cmdarray).waitFor();
+                    exitCode = runDiscardingOutput(cmdarray);
                     if (exitCode == 0) {
                         return "armv7";
                     }
@@ -381,6 +382,24 @@ public class OSInfo {
         }
         // Use armv5, soft-float ABI
         return "arm";
+    }
+
+    /**
+     * Run {@code command}, discard its output, and return the exit code. Merges stderr into stdout
+     * and drains the combined stream to EOF <em>before</em> {@code waitFor()}, so the child can never
+     * block writing to a full pipe, and closes every process stream so no file descriptor leaks.
+     * Java&nbsp;8-safe (no {@code Redirect.DISCARD}).
+     */
+    private static int runDiscardingOutput(String... command) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        process.getOutputStream().close();
+        try (InputStream in = process.getInputStream()) {
+            byte[] buffer = new byte[4096];
+            while (in.read(buffer) != -1) {
+                // drain so the child never blocks on a full pipe
+            }
+        }
+        return process.waitFor();
     }
 
     /**

--- a/src/main/java/net/ladenthin/llama/parameters/JsonParameters.java
+++ b/src/main/java/net/ladenthin/llama/parameters/JsonParameters.java
@@ -139,6 +139,15 @@ abstract class JsonParameters {
      */
     @SuppressWarnings("TypeParameterUnusedInFormals")
     protected final <T extends JsonParameters> T withScalar(String key, Object value) {
+        // String.valueOf(Float.NaN)/Infinity produce "NaN"/"Infinity", which are NOT valid JSON
+        // tokens and would make the whole request body unparseable by the native nlohmann parser.
+        // Reject at the source so the caller gets a clear error instead of an opaque downstream failure.
+        if (value instanceof Float && !Float.isFinite((Float) value)) {
+            throw new IllegalArgumentException(key + " must be a finite number but was " + value);
+        }
+        if (value instanceof Double && !Double.isFinite((Double) value)) {
+            throw new IllegalArgumentException(key + " must be a finite number but was " + value);
+        }
         return withPut(key, String.valueOf(value));
     }
 

--- a/src/main/java/net/ladenthin/llama/server/OpenAiCompatServer.java
+++ b/src/main/java/net/ladenthin/llama/server/OpenAiCompatServer.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -170,7 +171,11 @@ public final class OpenAiCompatServer implements AutoCloseable {
         this.config = config;
         this.backend = backend;
         this.requestExecutor = Executors.newCachedThreadPool(namedFactory("jllama-openai-http"));
-        this.heartbeatExecutor = Executors.newScheduledThreadPool(1, namedFactory("jllama-openai-hb"));
+        // Sized for concurrency: a heartbeat write blocks on a slow/stalled client, so a single
+        // shared thread would let one such client starve every other stream's keep-alives. Bound
+        // the impact to roughly one stalled client per thread.
+        this.heartbeatExecutor = Executors.newScheduledThreadPool(
+                Math.max(2, Runtime.getRuntime().availableProcessors()), namedFactory("jllama-openai-hb"));
         this.http = HttpServer.create(new InetSocketAddress(config.getHost(), config.getPort()), 0);
         this.corsFilter = buildCorsFilter(config.getCorsAllowOrigin());
         register("/", this::handleNotFound);
@@ -758,6 +763,10 @@ public final class OpenAiCompatServer implements AutoCloseable {
     }
 
     private void handleProps(HttpExchange exchange) throws IOException {
+        // Deliberately unauthenticated, like the Ollama discovery routes (/api/version, /api/tags,
+        // /api/show): autocomplete/agent clients read context length + capabilities here before they
+        // have (or to discover whether they need) a key. It exposes only public model metadata —
+        // no inference, no secrets — so it intentionally bypasses authorized().
         try {
             if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
                 sendError(exchange, HTTP_METHOD_NOT_ALLOWED, ERROR_TYPE_REQUEST, "Only GET is supported");
@@ -833,7 +842,11 @@ public final class OpenAiCompatServer implements AutoCloseable {
         if (header == null || !header.startsWith(BEARER_PREFIX)) {
             return false;
         }
-        return expected.equals(header.substring(BEARER_PREFIX.length()));
+        // Constant-time comparison so response timing does not leak how many leading bytes
+        // of the bearer token matched.
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        byte[] presentedBytes = header.substring(BEARER_PREFIX.length()).getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(expectedBytes, presentedBytes);
     }
 
     private @Nullable JsonNode readBody(HttpExchange exchange) throws IOException {

--- a/src/main/java/net/ladenthin/llama/server/OpenAiCompatServer.java
+++ b/src/main/java/net/ladenthin/llama/server/OpenAiCompatServer.java
@@ -12,6 +12,7 @@ import com.sun.net.httpserver.Filter;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -130,6 +131,7 @@ public final class OpenAiCompatServer implements AutoCloseable {
     private static final int HTTP_NOT_FOUND = 404;
     private static final int HTTP_METHOD_NOT_ALLOWED = 405;
     private static final int HTTP_SERVER_ERROR = 500;
+    private static final int HTTP_PAYLOAD_TOO_LARGE = 413;
 
     private static final String CONTENT_TYPE_JSON = "application/json; charset=utf-8";
     private static final String CONTENT_TYPE_SSE = "text/event-stream; charset=utf-8";
@@ -794,7 +796,24 @@ public final class OpenAiCompatServer implements AutoCloseable {
             sendError(exchange, HTTP_UNAUTHORIZED, ERROR_TYPE_REQUEST, "Missing or invalid API key");
             return null;
         }
-        JsonNode request = readBody(exchange);
+        String contentLength = exchange.getRequestHeaders().getFirst("Content-Length");
+        if (contentLength != null) {
+            try {
+                if (Long.parseLong(contentLength.trim()) > config.getMaxRequestBodyBytes()) {
+                    sendError(exchange, HTTP_PAYLOAD_TOO_LARGE, ERROR_TYPE_REQUEST, "Request body too large");
+                    return null;
+                }
+            } catch (NumberFormatException ignored) {
+                // Unparseable header — the bounded read below still caps the body.
+            }
+        }
+        JsonNode request;
+        try {
+            request = readBody(exchange);
+        } catch (RequestBodyTooLargeException e) {
+            sendError(exchange, HTTP_PAYLOAD_TOO_LARGE, ERROR_TYPE_REQUEST, "Request body too large");
+            return null;
+        }
         if (request == null || !request.isObject()) {
             sendError(exchange, HTTP_BAD_REQUEST, ERROR_TYPE_REQUEST, "Request body must be a JSON object");
             return null;
@@ -818,11 +837,52 @@ public final class OpenAiCompatServer implements AutoCloseable {
     }
 
     private @Nullable JsonNode readBody(HttpExchange exchange) throws IOException {
-        try (InputStream is = exchange.getRequestBody()) {
+        try (InputStream is = new BoundedInputStream(exchange.getRequestBody(), config.getMaxRequestBodyBytes())) {
             return OBJECT_MAPPER.readTree(is);
         } catch (JsonProcessingException e) {
             LOG.debug("malformed request body", e);
             return null;
+        }
+    }
+
+    /** Signals that the request body exceeded the configured cap. */
+    private static final class RequestBodyTooLargeException extends IOException {
+        private static final long serialVersionUID = 1L;
+
+        RequestBodyTooLargeException(long limit) {
+            super("Request body exceeds " + limit + " bytes");
+        }
+    }
+
+    /** Wraps a stream so reading past {@code limit} bytes throws instead of buffering unboundedly. */
+    private static final class BoundedInputStream extends FilterInputStream {
+        private final long limit;
+        private long count;
+
+        BoundedInputStream(InputStream in, long limit) {
+            super(in);
+            this.limit = limit;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int b = super.read();
+            if (b != -1 && ++count > limit) {
+                throw new RequestBodyTooLargeException(limit);
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] buffer, int off, int len) throws IOException {
+            int n = super.read(buffer, off, len);
+            if (n > 0) {
+                count += n;
+                if (count > limit) {
+                    throw new RequestBodyTooLargeException(limit);
+                }
+            }
+            return n;
         }
     }
 

--- a/src/main/java/net/ladenthin/llama/server/OpenAiServerConfig.java
+++ b/src/main/java/net/ladenthin/llama/server/OpenAiServerConfig.java
@@ -42,6 +42,9 @@ public final class OpenAiServerConfig {
      */
     public static final String DEFAULT_CORS_ALLOW_ORIGIN = "*";
 
+    /** Default maximum accepted request-body size, in bytes (16 MiB). */
+    public static final int DEFAULT_MAX_REQUEST_BODY_BYTES = 16 * 1024 * 1024;
+
     private final String host;
     private final int port;
     private final @Nullable String apiKey;
@@ -51,6 +54,7 @@ public final class OpenAiServerConfig {
     private final long heartbeatMillis;
     private final String corsAllowOrigin;
     private final boolean supportsVision;
+    private final int maxRequestBodyBytes;
 
     private OpenAiServerConfig(Builder builder) {
         this.host = builder.host;
@@ -62,6 +66,7 @@ public final class OpenAiServerConfig {
         this.heartbeatMillis = builder.heartbeatMillis;
         this.corsAllowOrigin = builder.corsAllowOrigin;
         this.supportsVision = builder.supportsVision;
+        this.maxRequestBodyBytes = builder.maxRequestBodyBytes;
     }
 
     /**
@@ -146,6 +151,15 @@ public final class OpenAiServerConfig {
     }
 
     /**
+     * Maximum accepted request-body size, in bytes. Bodies larger than this are rejected with HTTP 413.
+     *
+     * @return the request-body cap in bytes
+     */
+    public int getMaxRequestBodyBytes() {
+        return maxRequestBodyBytes;
+    }
+
+    /**
      * Whether the served model supports image input (a multimodal projector was configured). Advertised
      * to clients that gate on a vision capability (e.g. Copilot's Ollama provider via {@code /api/show}).
      *
@@ -202,6 +216,7 @@ public final class OpenAiServerConfig {
         private long heartbeatMillis = DEFAULT_HEARTBEAT_MILLIS;
         private String corsAllowOrigin = DEFAULT_CORS_ALLOW_ORIGIN;
         private boolean supportsVision;
+        private int maxRequestBodyBytes = DEFAULT_MAX_REQUEST_BODY_BYTES;
 
         private Builder() {}
 
@@ -301,6 +316,18 @@ public final class OpenAiServerConfig {
          */
         public Builder supportsVision(boolean supportsVision) {
             this.supportsVision = supportsVision;
+            return this;
+        }
+
+        /**
+         * Sets the maximum accepted request-body size in bytes. Bodies larger than this are rejected
+         * with HTTP 413 before being buffered.
+         *
+         * @param maxRequestBodyBytes the request-body cap in bytes
+         * @return this builder
+         */
+        public Builder maxRequestBodyBytes(int maxRequestBodyBytes) {
+            this.maxRequestBodyBytes = maxRequestBodyBytes;
             return this;
         }
 

--- a/src/main/java/net/ladenthin/llama/value/ChatMessage.java
+++ b/src/main/java/net/ladenthin/llama/value/ChatMessage.java
@@ -99,7 +99,9 @@ public final class ChatMessage {
         this.role = role;
         this.content = content;
         this.toolCallId = toolCallId;
-        this.toolCalls = toolCalls == null ? Collections.<ToolCall>emptyList() : toolCalls;
+        this.toolCalls = toolCalls == null
+                ? Collections.<ToolCall>emptyList()
+                : Collections.unmodifiableList(new java.util.ArrayList<ToolCall>(toolCalls));
         this.parts = parts;
     }
 

--- a/src/main/java/net/ladenthin/llama/value/ChatTranscript.java
+++ b/src/main/java/net/ladenthin/llama/value/ChatTranscript.java
@@ -107,6 +107,21 @@ public final class ChatTranscript {
     }
 
     /**
+     * Remove a trailing dangling user turn (one not yet completed by an assistant
+     * reply), undoing an {@link #appendUserTurn(String)}. Used to roll back an
+     * abandoned streaming round so the transcript returns to its pre-stream state.
+     *
+     * @return {@code true} if a dangling user turn was removed, {@code false} if there was none
+     */
+    public boolean removePendingUserTurn() {
+        if (!turns.isEmpty() && "user".equals(turns.get(turns.size() - 1).getKey())) {
+            turns.remove(turns.size() - 1);
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Build the wire-format messages list with a pending user turn appended,
      * <b>without mutating</b> this transcript. This is the snapshot a model
      * call receives before the user turn is committed; if the model call

--- a/src/main/java/net/ladenthin/llama/value/ServerMetrics.java
+++ b/src/main/java/net/ladenthin/llama/value/ServerMetrics.java
@@ -170,8 +170,7 @@ public final class ServerMetrics {
         double predictedMs = node.path("t_tokens_generation_total").asDouble(0.0);
         double promptPerSec = promptMs > 0.0 ? promptN * 1000.0 / promptMs : 0.0;
         double predictedPerSec = predictedMs > 0.0 ? predictedN * 1000.0 / predictedMs : 0.0;
-        return new Timings(
-                0, (int) promptN, promptMs, promptPerSec, (int) predictedN, predictedMs, predictedPerSec, 0, 0);
+        return new Timings(0, promptN, promptMs, promptPerSec, predictedN, predictedMs, predictedPerSec, 0, 0);
     }
 
     /**

--- a/src/main/java/net/ladenthin/llama/value/Timings.java
+++ b/src/main/java/net/ladenthin/llama/value/Timings.java
@@ -24,10 +24,10 @@ import org.jspecify.annotations.Nullable;
 public final class Timings {
 
     private final int cacheN;
-    private final int promptN;
+    private final long promptN;
     private final double promptMs;
     private final double promptPerSecond;
-    private final int predictedN;
+    private final long predictedN;
     private final double predictedMs;
     private final double predictedPerSecond;
     private final int draftN;
@@ -49,10 +49,10 @@ public final class Timings {
      */
     public Timings(
             int cacheN,
-            int promptN,
+            long promptN,
             double promptMs,
             double promptPerSecond,
-            int predictedN,
+            long predictedN,
             double predictedMs,
             double predictedPerSecond,
             int draftN,
@@ -81,10 +81,10 @@ public final class Timings {
         }
         return new Timings(
                 node.path("cache_n").asInt(0),
-                node.path("prompt_n").asInt(0),
+                node.path("prompt_n").asLong(0L),
                 node.path("prompt_ms").asDouble(0.0),
                 node.path("prompt_per_second").asDouble(0.0),
-                node.path("predicted_n").asInt(0),
+                node.path("predicted_n").asLong(0L),
                 node.path("predicted_ms").asDouble(0.0),
                 node.path("predicted_per_second").asDouble(0.0),
                 node.path("draft_n").asInt(0),
@@ -103,7 +103,7 @@ public final class Timings {
      * Prompt token count for this completion.
      * @return number of prompt tokens processed
      */
-    public int getPromptN() {
+    public long getPromptN() {
         return promptN;
     }
 
@@ -127,7 +127,7 @@ public final class Timings {
      * Generated token count for this completion.
      * @return number of tokens generated
      */
-    public int getPredictedN() {
+    public long getPredictedN() {
         return predictedN;
     }
 

--- a/src/test/java/net/ladenthin/llama/SessionStateTest.java
+++ b/src/test/java/net/ladenthin/llama/SessionStateTest.java
@@ -69,6 +69,30 @@ public class SessionStateTest {
     }
 
     @Test
+    public void cancelStream_rollsBackPendingUserTurn_andUnwedges() {
+        SessionState state = new SessionState(0, null);
+
+        state.beginStream("q", (systemMessage, wireMessages) -> "HANDLE");
+        assertThat(roles(state.snapshot()), contains("user"));
+
+        // Abandon the stream: the pending user turn is rolled back and the guard cleared.
+        state.cancelStream();
+        assertThat(state.snapshot().size(), is(0));
+
+        // No longer wedged: a follow-up send and a save both succeed.
+        state.send("again", (systemMessage, wireMessages) -> "b");
+        assertThat(roles(state.snapshot()), contains("user", "assistant"));
+        assertThat(state.runWhenNotStreaming("save", () -> "saved"), is("saved"));
+    }
+
+    @Test
+    public void cancelStream_withoutActiveStream_isNoOp() {
+        SessionState state = new SessionState(0, null);
+        state.cancelStream(); // must not throw, transcript untouched
+        assertThat(state.snapshot().size(), is(0));
+    }
+
+    @Test
     public void send_whileStreaming_throwsWithDiagnosticMessage() {
         SessionState state = new SessionState(7, null);
         state.beginStream("q", (systemMessage, wireMessages) -> "HANDLE");

--- a/src/test/java/net/ladenthin/llama/parameters/InferenceParametersTest.java
+++ b/src/test/java/net/ladenthin/llama/parameters/InferenceParametersTest.java
@@ -88,6 +88,18 @@ public class InferenceParametersTest {
     }
 
     @Test
+    public void testNaNFloatRejected() {
+        // NaN/Infinity would serialize to "NaN"/"Infinity" — invalid JSON the native parser rejects.
+        assertThrows(IllegalArgumentException.class, () -> new InferenceParameters("").withTemperature(Float.NaN));
+    }
+
+    @Test
+    public void testInfiniteFloatRejected() {
+        assertThrows(
+                IllegalArgumentException.class, () -> new InferenceParameters("").withTopP(Float.POSITIVE_INFINITY));
+    }
+
+    @Test
     public void testSetParallelToolCalls() {
         InferenceParameters params = new InferenceParameters("").withParallelToolCalls(false);
         assertThat(params.parameters.get("parallel_tool_calls"), is("false"));

--- a/src/test/java/net/ladenthin/llama/server/OpenAiCompatServerHttpTest.java
+++ b/src/test/java/net/ladenthin/llama/server/OpenAiCompatServerHttpTest.java
@@ -101,6 +101,20 @@ public class OpenAiCompatServerHttpTest extends OpenAiServerTestSupport {
     }
 
     @Test
+    public void oversizedRequestBodyRejectedWith413() throws IOException {
+        OpenAiServerConfig cfg = OpenAiServerConfig.builder()
+                .host("127.0.0.1")
+                .port(0)
+                .maxRequestBodyBytes(32)
+                .build();
+        try (OpenAiCompatServer server = new OpenAiCompatServer(new FakeBackend(), cfg).start()) {
+            String body =
+                    "{\"messages\":[{\"role\":\"user\",\"content\":\"this body is well over thirty-two bytes\"}]}";
+            assertThat(post(server.getPort(), "/v1/chat/completions", body, "").code, is(413));
+        }
+    }
+
+    @Test
     public void infillRouteReturnsContent() throws IOException {
         try (OpenAiCompatServer server = new OpenAiCompatServer(new FakeBackend(), config()).start()) {
             String body = "{\"input_prefix\":\"def add(a,b):\\n    return \",\"input_suffix\":\"\"}";

--- a/src/test/java/net/ladenthin/llama/value/ChatMessageTest.java
+++ b/src/test/java/net/ladenthin/llama/value/ChatMessageTest.java
@@ -64,6 +64,20 @@ public class ChatMessageTest {
     }
 
     @Test
+    public void toolCallsListIsDefensivelyCopiedAndUnmodifiable() {
+        java.util.List<ToolCall> source = new java.util.ArrayList<ToolCall>();
+        source.add(new ToolCall("c1", "f", "{}"));
+        ChatMessage m = ChatMessage.assistantToolCalls("", source);
+
+        // Mutating the caller's list must not change the (documented-immutable) message.
+        source.clear();
+        assertThat(m.getToolCalls(), hasSize(1));
+
+        // And the returned list is read-only.
+        assertThrows(UnsupportedOperationException.class, () -> m.getToolCalls().add(new ToolCall("c2", "g", "{}")));
+    }
+
+    @Test
     public void assistantToolCallsKeepsNonNullContent() {
         ChatMessage m =
                 ChatMessage.assistantToolCalls("reason", Collections.singletonList(new ToolCall("c1", "f", "{}")));

--- a/src/test/java/net/ladenthin/llama/value/ChatResponseTest.java
+++ b/src/test/java/net/ladenthin/llama/value/ChatResponseTest.java
@@ -48,7 +48,7 @@ public class ChatResponseTest {
         assertThat(r.getUsage().getCompletionTokens(), is(5L));
         assertThat(r.getUsage().getTotalTokens(), is(17L));
 
-        assertThat(r.getTimings().getPromptN(), is(12));
+        assertThat(r.getTimings().getPromptN(), is(12L));
         assertEquals(100.0, r.getTimings().getPromptMs(), 1e-9);
         assertEquals(100.0, r.getTimings().getPredictedPerSecond(), 1e-9);
 

--- a/src/test/java/net/ladenthin/llama/value/ServerMetricsTest.java
+++ b/src/test/java/net/ladenthin/llama/value/ServerMetricsTest.java
@@ -86,6 +86,17 @@ public class ServerMetricsTest {
     }
 
     @Test
+    public void cumulativeTimingsDoNotOverflowIntOnBusyServer() throws Exception {
+        // A long-running server easily exceeds Integer.MAX_VALUE tokens; an int cast would wrap
+        // these cumulative counters to negative values.
+        ServerMetrics m =
+                parse("{\"n_prompt_tokens_processed_total\":3000000000," + "\"n_tokens_predicted_total\":4000000000}");
+        Timings t = m.getCumulativeTimings();
+        assertEquals(3_000_000_000L, t.getPromptN());
+        assertEquals(4_000_000_000L, t.getPredictedN());
+    }
+
+    @Test
     public void cumulativeTimingsZeroMsYieldsZeroRate() throws Exception {
         ServerMetrics m = parse("{\"n_prompt_tokens_processed_total\":5,\"t_prompt_processing_total\":0}");
         assertEquals(0.0, m.getCumulativeTimings().getPromptPerSecond(), 1e-9);


### PR DESCRIPTION
## Summary

Fixes from the codebase audit recorded in `TODO.md` ("Code audit — pre-existing correctness /
safety findings"). **17 of 18 findings fixed**, split into one commit per tier for reviewability;
the 18th (`LlamaLoader` temp-path) is deferred with a documented rationale.

- **Tier 1 — correctness/safety (`a4325ff`).** Convert escaping C++ exceptions to `LlamaException`
  at every JNI entry point — fixes a **JVM abort** from the public `LlamaModel.jsonSchemaToGrammar(String)`
  on malformed input (and the same class on encode/tokenize/embed/rerank/infill/applyTemplate);
  `parse_string_array` null-deref + JNI local-ref leak; `synchronized close()` so a concurrent
  close cannot **double-free** the native handle; widen `Timings` token counts to `long` so
  cumulative server metrics no longer wrap **negative** past `Integer.MAX_VALUE`.
- **Tier 2 — concurrency/DoS (`3e500aa`).** Hold streaming readers as `shared_ptr` so a concurrent
  `close()`/erase can't free a reader mid-`next()` (**use-after-free**); cap the OpenAI server
  request body (default 16 MiB, configurable) and reject oversized bodies with **HTTP 413** so an
  unbounded/slow-drip body can't OOM the JVM; add `Session.cancelStream()` so an abandoned/failed
  stream no longer **wedges the session permanently**; `LlamaIterator.hasNext` is `volatile`; the
  log callback is `noexcept` + non-throwing env accessor.
- **Tier 3 — hardening (`ac3ad6d`).** Constant-time bearer-key comparison (`MessageDigest.isEqual`);
  size the SSE heartbeat pool to the core count (one stalled client can't starve other streams);
  defensively copy `ChatMessage.toolCalls`; reject non-finite `float`/`double` params (which
  serialize to invalid JSON `NaN`/`Infinity`); drain+close `OSInfo`'s `exec()` streams; make
  `completeBatch`/`chatBatch` join every future before propagating a failure (no abandoned
  in-flight requests); doc-only notes for the deliberately-unauthenticated discovery routes and the
  last-wins `parseProbabilities` map.

**Deferred:** `LlamaLoader` native-lib extraction temp-path race — it sits on *the* native-library
load path (high blast radius) and needs careful Windows / `deleteOnExit` / `cleanup()` co-design
plus cross-platform load testing; tracked as its own follow-up in `TODO.md`.

## Test plan

- [x] Affected unit / integration tests pass locally — **452/452 C++ tests**, all affected Java
  suites, plus **new regressions**: metrics int-overflow, HTTP 413, `cancelStream` rollback,
  NaN/Inf reject, `toolCalls` defensive copy.
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable — `TODO.md` audit section updated with
  per-tier progress + the deferred item. (No public-API/behavior change warranting a CHANGELOG
  user-facing entry beyond the bug fixes; happy to add one if preferred.)



## Note for reviewer

- 3 commits, one per tier — can be reviewed (or split into separate PRs) independently. **Tier 1**
  (`a4325ff`) is the one to land first: it removes a public-API-reachable JVM crash and a
  native double-free.
- Native/Windows-adjacent changes to watch in CI: the `shared_ptr` reader lifetime (Tier 2) and
  the `OSInfo` exec rework (Tier 3) — the Windows + aarch64 jobs are the relevant ones.
- Verified locally: Javadoc + Spotless + clang-format 22.1.5 all clean.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)