### PR TITLE
Add tests for ChatTranscript.removePendingUserTurn and JNI exception handling

### DIFF
--- a/src/test/java/net/ladenthin/llama/LlamaModelTest.java
+++ b/src/test/java/net/ladenthin/llama/LlamaModelTest.java
@@ -692,6 +692,14 @@ public class LlamaModelTest {
     }
 
     @Test
+    public void testJsonSchemaToGrammarRejectsMalformedSchema() {
+        // Regression for the JNI exception-boundary fix (audit Tier 1, PR #258): a malformed schema
+        // string used to let a C++ json::parse exception escape across the JNI boundary and abort the
+        // JVM. It must now surface as a catchable LlamaException instead of crashing the process.
+        assertThrows(LlamaException.class, () -> LlamaModel.jsonSchemaToGrammar("{ this is not valid json"));
+    }
+
+    @Test
     public void testTemplate() {
 
         List<Pair<String, String>> userMessages = new ArrayList<>();

--- a/src/test/java/net/ladenthin/llama/value/ChatTranscriptTest.java
+++ b/src/test/java/net/ladenthin/llama/value/ChatTranscriptTest.java
@@ -110,6 +110,44 @@ class ChatTranscriptTest {
         }
 
         @Test
+        @DisplayName("removePendingUserTurn drops a trailing user turn and reports true")
+        void removePendingUserTurnDropsTrailingUserTurn() {
+            ChatTranscript t = new ChatTranscript(null);
+            t.appendUserTurn("pending question");
+            assertThat("precondition: one dangling user turn", t.size(), is(1));
+
+            boolean removed = t.removePendingUserTurn();
+
+            assertThat("a dangling user turn must be reported as removed", removed, is(true));
+            assertThat("transcript is rolled back to its pre-stream (empty) shape", t.size(), is(0));
+        }
+
+        @Test
+        @DisplayName("removePendingUserTurn is a no-op when the last turn is an assistant turn")
+        void removePendingUserTurnKeepsCommittedRound() {
+            ChatTranscript t = new ChatTranscript(null);
+            t.appendRound("q", "a"); // last turn is "assistant", not a dangling user turn
+
+            boolean removed = t.removePendingUserTurn();
+
+            assertThat("a committed round has no dangling user turn to remove", removed, is(false));
+            assertThat("the committed round must be left intact", t.size(), is(2));
+            assertThat(t.snapshot().get(0).getRole(), is("user"));
+            assertThat(t.snapshot().get(1).getRole(), is("assistant"));
+        }
+
+        @Test
+        @DisplayName("removePendingUserTurn is a safe no-op on an empty transcript")
+        void removePendingUserTurnNoOpOnEmptyTranscript() {
+            ChatTranscript t = new ChatTranscript("system");
+
+            boolean removed = t.removePendingUserTurn();
+
+            assertThat("an empty transcript has nothing to remove", removed, is(false));
+            assertThat(t.size(), is(0));
+        }
+
+        @Test
         @DisplayName("messagesWithPendingUserTurn does NOT mutate the transcript")
         void messagesWithPendingUserTurnDoesNotMutate() {
             ChatTranscript t = new ChatTranscript("system");


### PR DESCRIPTION
## Summary

- Add three unit tests for `ChatTranscript.removePendingUserTurn()` covering the happy path (removes trailing user turn), no-op cases (committed round, empty transcript), and expected return values
- Add regression test for `LlamaModel.jsonSchemaToGrammar()` to verify that malformed JSON schemas now surface as catchable `LlamaException` instead of crashing the JVM via uncaught C++ exceptions across the JNI boundary

## Test plan

- [x] Affected unit tests pass locally
- [x] CI is green on this branch

## Related issues / PRs

Regression test for JNI exception-boundary fix (audit Tier 1, PR #258)

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01Qg1mYW7hHjtVvAfMeMEmPq