### PR TITLE
test(loader): cover LlamaLoader.resourceMatchesFile match + content-mismatch branches

### DIFF
--- a/src/test/java/net/ladenthin/llama/loader/LlamaLoaderTest.java
+++ b/src/test/java/net/ladenthin/llama/loader/LlamaLoaderTest.java
@@ -23,10 +23,15 @@ import org.junit.jupiter.api.Test;
                 + "cleanup; contentsEquals performs a correct byte-level stream comparison "
                 + "including BufferedInputStream wrapping and length mismatches; getTempDir "
                 + "honours the 'net.ladenthin.llama.tmpdir' system-property override; and "
-                + "getNativeResourcePath produces the expected classpath resource prefix.")
+                + "getNativeResourcePath produces the expected classpath resource prefix; and "
+                + "resourceMatchesFile compares a classpath resource to an on-disk file byte-for-byte.")
 public class LlamaLoaderTest {
 
     private static final String TMPDIR_PROP = LlamaSystemProperties.PREFIX + ".tmpdir";
+
+    /** A small file present on the test classpath, used as a byte-comparison fixture. */
+    private static final String EXISTING_TEST_RESOURCE = "/images/test-image.jpg";
+
     private String previousTmpDir;
 
     @BeforeEach
@@ -106,6 +111,38 @@ public class LlamaLoaderTest {
             java.nio.file.Files.write(tmp, new byte[] {1, 2, 3});
             // A missing classpath resource must compare as "not matching", never throw.
             assertFalse(LlamaLoader.resourceMatchesFile("/net/ladenthin/llama/does-not-exist.bin", tmp));
+        } finally {
+            java.nio.file.Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    public void resourceMatchesFileTrueWhenBytesIdentical() throws IOException {
+        // The fast-path reuse predicate: a present resource and a byte-identical on-disk copy match.
+        java.nio.file.Path tmp = java.nio.file.Files.createTempFile("llama-loader-test", ".bin");
+        try {
+            try (java.io.InputStream in = LlamaLoader.class.getResourceAsStream(EXISTING_TEST_RESOURCE)) {
+                assertNotNull(in, "fixture must be on the test classpath: " + EXISTING_TEST_RESOURCE);
+                java.nio.file.Files.copy(in, tmp, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+            assertTrue(LlamaLoader.resourceMatchesFile(EXISTING_TEST_RESOURCE, tmp));
+        } finally {
+            java.nio.file.Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    public void resourceMatchesFileFalseWhenContentDiffers() throws IOException {
+        // A present resource whose on-disk copy diverges (here: one extra trailing byte) must NOT match,
+        // so a stale/partial file is never mistaken for the shipped library on the reuse fast path.
+        java.nio.file.Path tmp = java.nio.file.Files.createTempFile("llama-loader-test", ".bin");
+        try {
+            try (java.io.InputStream in = LlamaLoader.class.getResourceAsStream(EXISTING_TEST_RESOURCE)) {
+                assertNotNull(in, "fixture must be on the test classpath: " + EXISTING_TEST_RESOURCE);
+                java.nio.file.Files.copy(in, tmp, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+            java.nio.file.Files.write(tmp, new byte[] {0}, java.nio.file.StandardOpenOption.APPEND);
+            assertFalse(LlamaLoader.resourceMatchesFile(EXISTING_TEST_RESOURCE, tmp));
         } finally {
             java.nio.file.Files.deleteIfExists(tmp);
         }


### PR DESCRIPTION
## Summary

Follow-up test coverage for the native-lib extraction race fix (#260). That PR added
`LlamaLoader.resourceMatchesFile(...)` — the fast-path reuse predicate that lets extraction reuse a
byte-identical existing copy instead of replacing a file a peer JVM may already have loaded — but
unit-tested only its **absent-resource → false** branch. This adds the two core branches:

- a present classpath resource vs a **byte-identical** on-disk copy → **true** (the reuse predicate itself), and
- a present resource whose on-disk copy **diverges** (one extra trailing byte) → **false**, so a stale/partial
  file is never mistaken for the shipped library on the reuse fast path.

Uses the committed `src/test/resources/images/test-image.jpg` classpath fixture; the tests are pure-Java
and need no model or native library. The `@ClaudeGenerated` class-purpose annotation is extended to mention
`resourceMatchesFile`.

The private `extractFile` / `moveIntoPlace` atomic-move + reuse flow stays covered end-to-end by
`NativeLibraryLoadSmokeTest` in the CI Java Tests jobs (which build the real native lib); it is not cleanly
unit-testable here without reflection.

## Test plan

- [x] `mvn test -Dtest=LlamaLoaderTest` → **25/25 green** (was 23; +2 new branch tests).
- [x] Spotless clean (`mvn spotless:apply` no-op after formatting).
- [x] Test-only change — no production code touched; not in PIT scope, so the mutation gate is unaffected.

## Notes for reviewer

Test-only, +38/−1 in a single file (`LlamaLoaderTest.java`). No public API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg1mYW7hHjtVvAfMeMEmPq)_