### PR TITLE
docs: document PIT mutation testing policy and audioFile hermiticity issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1100,10 +1100,9 @@ See [`../workspace/policies/ci-test-diagnostics.md`](../workspace/policies/ci-te
 ## PIT Mutation Testing
 
 See [`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md).
-Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`
-(the bare goal fails with `NoSuchFileException: {argLine}`). Note: this repo's gate reaches 100%
-only with the audio fixture present; without it, `value.ContentPart.audioFile(Path)` is
-uncovered (98%) — see §4 of the policy.
+Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`.
+Repo-specific gotcha: the gate reaches 100% only with the audio fixture present — without it
+`value.ContentPart.audioFile(Path)` is uncovered (98%); see policy §4 and `TODO.md`.
 
 ## JPMS Module Descriptor
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1097,6 +1097,14 @@ See [`../workspace/policies/lombok-config.md`](../workspace/policies/lombok-conf
 
 See [`../workspace/policies/ci-test-diagnostics.md`](../workspace/policies/ci-test-diagnostics.md).
 
+## PIT Mutation Testing
+
+See [`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md).
+Run PIT with the lifecycle prefix — `mvn test-compile org.pitest:pitest-maven:mutationCoverage`
+(the bare goal fails with `NoSuchFileException: {argLine}`). Note: this repo's gate reaches 100%
+only with the audio fixture present; without it, `value.ContentPart.audioFile(Path)` is
+uncovered (98%) — see §4 of the policy.
+
 ## JPMS Module Descriptor
 
 This repo ships a `module-info.java` compiled in a separate `release 9` execution. Javadoc

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,19 @@ cross-cutting initiative.
 
 ## Open — jllama-specific
 
+### PIT gate not hermetic — `value.ContentPart.audioFile(Path)` (open)
+
+The PIT mutation gate reaches 100% **only when the audio test fixture is present**. Without it the
+run is **98%**: 4 `NO_COVERAGE` mutants in `value.ContentPart.audioFile(Path)` (the null file-name
+guard, the `.wav`/`.mp3` extension dispatch, and `Files.readAllBytes`). The only test that exercises
+that method is `AudioInputIntegrationTest`, which is model-/fixture-gated and self-skips (`Assume`)
+when no audio clip is supplied (`net.ladenthin.llama.audio.input` — no committed default). So any
+environment lacking the clip (e.g. a network-restricted sandbox) reds the gate. Fix: add a hermetic
+temp-file unit test for `audioFile(Path)` — write a few bytes to a `@TempDir` `*.wav` / `*.mp3` and
+assert the format dispatch — mirroring the existing `imageFile(Path)` temp-file tests (PNG/JPG/GIF/
+WEBP), which already make the image path hermetic. See
+[`../workspace/policies/pit-mutation-testing.md`](../workspace/policies/pit-mutation-testing.md) §4.
+
 ### Code audit — pre-existing correctness / safety findings (RESOLVED — PRs #258 + #260)
 
 A multi-area audit (2026-06-20) of the **existing** codebase surfaced 18 correctness/safety findings,

--- a/pom.xml
+++ b/pom.xml
@@ -673,12 +673,12 @@ SPDX-License-Identifier: MIT
 			</plugin>
 			<plugin>
 				<!--
-				  PIT mutation testing is scoped to packages that have reached 100%
-					  mutation parity, gated at a 100% threshold on every CI build. Expand
-					  the targetClasses globs as further packages reach parity (see README
-					  TODO). The value/ and exception/ trees are at 100% (verified with
-					  pitest-maven 1.25.4); their unit tests are pure-Java (no native
-					  libjllama / model file needed).
+				  Generic PIT policy (version, 100% gate, invocation, expansion rule):
+				  see ../workspace/policies/pit-mutation-testing.md.
+				  Repo-specific: the gated value/exception/args/json classes are pure-Java
+				  (no native libjllama or model file needed); targetClasses/targetTests are
+				  kept in lock-step. NOTE: value.ContentPart.audioFile(Path) mutants are only
+				  killed with the audio fixture present — see TODO.md and policy §4.
 				-->
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>


### PR DESCRIPTION
## Summary

- Added a new TODO item documenting that the PIT mutation gate is non-hermetic for `value.ContentPart.audioFile(Path)` — it reaches 100% only when the audio test fixture is present, and proposes adding hermetic temp-file unit tests mirroring the existing `imageFile(Path)` tests.
- Updated `pom.xml` PIT plugin comment to reference the new centralized mutation testing policy document and call out the audio fixture dependency.
- Added PIT Mutation Testing section to `CLAUDE.md` with invocation instructions and the repo-specific gotcha about the audio fixture.

## Test plan

N/A — documentation and policy clarification only.

## Related issues / PRs

None.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_017i6A5bMhgCSbiKibQhxwuz