### PR TITLE
Add ModelParameters.enableSwaFull() for SWA KV cache control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ from version 5.0.0 onward. Pre-fork releases (`1.x`–`4.2.0`) were authored by
 - Explicit `setMmprojAuto(boolean)` and `setMmprojOffload(boolean)` controls, including the upstream `--no-mmproj-auto` and `--no-mmproj-offload` flags.
 - Per-request KV controls: `InferenceParameters.withSlotId(int)` and `withCacheReuse(int)`.
 - Per-request DRY sampling to `InferenceParameters` (`dry_multiplier`/`dry_base`/`dry_allowed_length`/`dry_penalty_last_n`/`dry_sequence_breakers`).
+- `ModelParameters.enableSwaFull()` (`--swa-full`): keep full-size SWA KV cache to enable cross-request prompt-prefix reuse.
 - Typed cache observability through `Usage.getCachedTokens()`, `Usage.getProcessedPromptTokens()`, `SlotMetrics`, and `ServerMetrics.getSlotMetrics()`.
 - Authenticated JSON `GET /metrics` and `GET /slots` endpoints on the embedded server.
 

--- a/src/main/java/net/ladenthin/llama/args/ModelFlag.java
+++ b/src/main/java/net/ladenthin/llama/args/ModelFlag.java
@@ -22,6 +22,11 @@ public enum ModelFlag {
     /** Enable Flash Attention. */
     FLASH_ATTN("--flash-attn"),
 
+    /** Keep the full-size sliding-window-attention (SWA) KV cache, enabling cross-request
+     *  prompt-prefix reuse (pairs with --cache-reuse) at ~2x the SWA-layer KV RAM. Default off.
+     *  Env: LLAMA_ARG_SWA_FULL. */
+    SWA_FULL("--swa-full"),
+
     /** Disable internal libllama performance timings. */
     NO_PERF("--no-perf"),
 

--- a/src/main/java/net/ladenthin/llama/parameters/ModelParameters.java
+++ b/src/main/java/net/ladenthin/llama/parameters/ModelParameters.java
@@ -256,6 +256,17 @@ public final class ModelParameters extends CliParameters {
     }
 
     /**
+     * Use the full-size SWA KV cache so the sliding-window layers' KV is reusable across requests
+     * (restores prompt-prefix cache reuse with {@link #setCacheReuse(int)}); costs ~2x SWA-layer
+     * KV RAM. Off by default; only beneficial for multi-request sessions sharing a prompt prefix.
+     *
+     * @return this builder
+     */
+    public ModelParameters enableSwaFull() {
+        return setFlag(ModelFlag.SWA_FULL);
+    }
+
+    /**
      * Disable internal libllama performance timings (default: false).
      *
      * @return this builder

--- a/src/test/java/net/ladenthin/llama/args/ModelFlagTest.java
+++ b/src/test/java/net/ladenthin/llama/args/ModelFlagTest.java
@@ -19,6 +19,7 @@ public class ModelFlagTest {
         return Arrays.asList(new Object[][] {
             {ModelFlag.NO_CONTEXT_SHIFT, "--no-context-shift"},
             {ModelFlag.FLASH_ATTN, "--flash-attn"},
+            {ModelFlag.SWA_FULL, "--swa-full"},
             {ModelFlag.NO_PERF, "--no-perf"},
             {ModelFlag.ESCAPE, "--escape"},
             {ModelFlag.NO_ESCAPE, "--no-escape"},
@@ -66,7 +67,7 @@ public class ModelFlagTest {
 
     @Test
     public void testEnumCount() {
-        assertEquals(34, ModelFlag.values().length);
+        assertEquals(35, ModelFlag.values().length);
     }
 
     @ParameterizedTest(name = "{0} -> {1}")

--- a/src/test/java/net/ladenthin/llama/parameters/ModelParametersExtendedTest.java
+++ b/src/test/java/net/ladenthin/llama/parameters/ModelParametersExtendedTest.java
@@ -642,6 +642,18 @@ public class ModelParametersExtendedTest {
     }
 
     @Test
+    public void testEnableSwaFull() {
+        ModelParameters p = new ModelParameters().enableSwaFull();
+        assertThat(p.parameters, hasKey("--swa-full"));
+        assertThat(p.parameters.get("--swa-full"), is(nullValue()));
+    }
+
+    @Test
+    public void testSwaFullNotEnabledByDefault() {
+        assertThat(new ModelParameters().parameters, not(hasKey("--swa-full")));
+    }
+
+    @Test
     public void testDisablePerf() {
         ModelParameters p = new ModelParameters().disablePerf();
         assertThat(p.parameters, hasKey("--no-perf"));


### PR DESCRIPTION
## Summary

- Add `ModelParameters.enableSwaFull()` method to enable the `--swa-full` flag, which keeps the full-size sliding-window-attention (SWA) KV cache to enable cross-request prompt-prefix reuse (pairs with `--cache-reuse`).
- Add `ModelFlag.SWA_FULL` enum entry with corresponding CLI flag and documentation.
- Update unit tests and enum count to reflect the new flag.

## Test plan

- [x] Added unit tests in `ModelParametersExtendedTest` covering `enableSwaFull()` and default behavior
- [x] Added unit test in `ModelFlagTest` to verify the CLI flag mapping
- [x] Updated enum count assertion in `ModelFlagTest` from 34 to 35
- [x] CHANGELOG updated with the new feature

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01SRXbL5RqW3B1XZRea3Rfc7