### PR TITLE
Post-release: bump to 5.0.4-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To use the latest snapshot, add the repository and dependency to your `pom.xml`:
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>5.0.4-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama</artifactId>
-	<version>5.0.3</version>
+	<version>5.0.4-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary

- Post-release version bump following the **5.0.3** release (tag `v5.0.3`).
- `pom.xml`: `5.0.3` → `5.0.4-SNAPSHOT`.
- `README.md`: the **snapshot** dependency example → `5.0.4-SNAPSHOT` (the release dependency examples stay at `5.0.3`).

## Test plan

- [ ] Affected unit / integration tests pass locally
- [x] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable (version-only change; CHANGELOG already finalized for 5.0.3, `[Unreleased]` left empty)

## Related issues / PRs

- Follows #281 (the 5.0.3 release).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01URUX3HiqQ1wzJnT8qn8c8E)_