### PR TITLE
Upgrade palantir-java-format from 2.92.0 to 2.94.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@ SPDX-License-Identifier: MIT
 		<fb-contrib.version>7.7.4</fb-contrib.version>
 		<findsecbugs.version>1.14.0</findsecbugs.version>
 		<spotless.version>3.7.0</spotless.version>
-		<palantir-java-format.version>2.92.0</palantir-java-format.version>
+		<palantir-java-format.version>2.94.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
 	</properties>


### PR DESCRIPTION
## Summary

- Upgrade `palantir-java-format` dependency from version 2.92.0 to 2.94.0
- This is a minor version bump of the code formatting tool used in the build pipeline

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01DxT73BpL3JQyFn2SoXhnuJ