### PR TITLE
Release 5.0.4: LangChain4j integration, fine-tuning API, and Maven reactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ from version 5.0.0 onward. Pre-fork releases (`1.x`–`4.2.0`) were authored by
 
 ## [Unreleased]
 
+## [5.0.4] - 2026-07-02
+
+Feature release. Adds in-process LangChain4j adapters, an experimental
+fine-tuning API, and richer model introspection, and restructures the build
+into a Maven reactor (published coordinates unchanged). Tracks llama.cpp
+**b9842 → b9859**.
+
+### Added
+- **LangChain4j integration** (`llama-langchain4j` module): in-process adapters for LangChain4j's `ChatModel`, `StreamingChatModel`, `EmbeddingModel`, and `ScoringModel` over JNI (no HTTP hop). Shipped as a separate artifact `net.ladenthin:llama-langchain4j` (Java 17), versioned and released in lockstep with the core so a Java-8 `net.ladenthin:llama` consumer is unaffected.
+- **In-process fine-tuning** (`LlamaTrainer`): an experimental training API with configurable `TrainingParameters` and `Optimizer` (`args.Optimizer`) driving llama.cpp's optimizer through the JNI binding.
+- **Model introspection via `ModelMeta`** (`value.ModelMeta`): exposes the model's chat template, special tokens, and full key/value metadata.
+
+### Changed
+- Restructured the build into a **Maven reactor**: the native JNI core moved into the `llama/` module under a new aggregator parent POM (`net.ladenthin:llama-parent`, `packaging=pom`), alongside the `llama-langchain4j` module. Both modules inherit a single version, so all artifacts ship in lockstep. Published coordinates (`net.ladenthin:llama`) are **unchanged** — no consumer action required.
+- Upgraded llama.cpp from **b9842 to b9859**. All four local patches (`0001`–`0004`) apply unchanged across the range.
+- CI: the GGUF model set is now downloaded once upfront by a dedicated job and restored (not re-fetched) by every test job, de-duplicating the pipeline.
+- Bumped `palantir-java-format` 2.92.0 → 2.94.0.
+
 ## [5.0.3] - 2026-06-29
 
 Feature release. Headline addition is a full OpenAI-compatible embedded HTTP
@@ -129,7 +147,8 @@ Releases `1.1.1` through `4.2.0` were authored by [@kherud](https://github.com/k
 
 For an architecture-level diff between the pre-fork baseline (`49be664`) and the first 5.0.0 candidate (`24918e4`), see [`docs/history/49be664_24918e4.md`](docs/history/49be664_24918e4.md). For the server-fork-deletion refactor that culminated in 5.0.0, see [`docs/history/REFACTORING.md`](docs/history/REFACTORING.md). For the chat-completion integration that landed in 5.0.0, see [`docs/history/CHAT_INTEGRATION_SUMMARY.md`](docs/history/CHAT_INTEGRATION_SUMMARY.md).
 
-[Unreleased]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.3...HEAD
+[Unreleased]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.4...HEAD
+[5.0.4]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.3...v5.0.4
 [5.0.3]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.2...v5.0.3
 [5.0.2]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.0...v5.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1250,9 +1250,22 @@ target the core with Maven via `-f llama/pom.xml` (or `-pl llama -am` from the r
 file shows `cmake -B build` / `src/main/...` / `mvn compile` at the root, read it as running in
 `llama/`** (the paths moved; the recipes are otherwise unchanged).
 
-**Version bump:** change the `<version>` in the **root** `pom.xml` only; `llama` and
-`llama-langchain4j` inherit it. (The SNAPSHOT/`-SNAPSHOT` line and the README badge still need
-the usual manual update.)
+**Version bump:** the child modules declare **no `<version>` of their own** — their *project*
+version is inherited from the parent. But each child still hardcodes the parent version inside its
+`<parent><version>` pointer (Maven requires a literal there — there is **no `${revision}`/CI-friendly
+versioning** here), so a version change must be applied to **all three poms in lockstep**:
+
+- `pom.xml` (root) — `<version>`
+- `llama/pom.xml` — `<parent><version>`
+- `llama-langchain4j/pom.xml` — `<parent><version>`
+
+The safe way is `mvn -q versions:set -DnewVersion=X.Y.Z -DgenerateBackupPoms=false` from the repo
+root (it updates the parent and every child `<parent>` reference at once). Changing only the root
+`<version>` leaves the children pointing at a non-existent parent and **fails the reactor build**
+(`Could not find artifact net.ladenthin:llama-parent:pom:X.Y.Z`). The README version examples and
+badge still need the usual manual update. (If single-source ergonomics are wanted, the Maven
+CI-friendly `${revision}` property + `flatten-maven-plugin` would let a bump touch only the root —
+that plugin is not configured today, so do not rely on "root only".)
 
 ## LangChain4j integration (`llama-langchain4j` reactor module)
 
@@ -1273,8 +1286,9 @@ consumer.
 Wiring:
 
 1. **`llama-langchain4j/pom.xml`** — `net.ladenthin:llama-langchain4j`, `release 17`, a child of
-   `net.ladenthin:llama-parent` (so it **inherits `${project.version}`** — no hardcoded version,
-   no lockstep guard). Depends on `net.ladenthin:llama:${project.version}` and
+   `net.ladenthin:llama-parent` (so it **inherits `${project.version}`** — no hardcoded *dependency*
+   version, no lockstep guard; the `<parent><version>` literal itself is still bumped in lockstep,
+   see "Version bump" above). Depends on `net.ladenthin:llama:${project.version}` and
    `dev.langchain4j:langchain4j-core`. Builds its own sources/javadoc jars; the `release`
    profile (GPG + Central Publishing) is **inherited from the parent**, not duplicated here.
    Java package stays `net.ladenthin.llama.langchain4j` (package name need not track the artifactId).

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Access this library via Maven (released versions on Maven Central):
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
 </dependency>
 ```
 
@@ -184,14 +184,14 @@ classifier — those are mutually exclusive — and optionally a CPU Windows bui
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
 </dependency>
 
 <!-- CUDA on Linux x86-64 (requires CUDA 13 runtime on the host) -->
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
     <classifier>cuda13-linux-x86-64</classifier>
 </dependency>
 
@@ -199,7 +199,7 @@ classifier — those are mutually exclusive — and optionally a CPU Windows bui
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
     <classifier>opencl-android-aarch64</classifier>
 </dependency>
 
@@ -207,7 +207,7 @@ classifier — those are mutually exclusive — and optionally a CPU Windows bui
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
     <classifier>cuda13-windows-x86-64</classifier>
 </dependency>
 
@@ -215,7 +215,7 @@ classifier — those are mutually exclusive — and optionally a CPU Windows bui
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
     <classifier>vulkan-windows-x86-64</classifier>
 </dependency>
 
@@ -223,7 +223,7 @@ classifier — those are mutually exclusive — and optionally a CPU Windows bui
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
     <classifier>opencl-windows-x86-64</classifier>
 </dependency>
 
@@ -231,7 +231,7 @@ classifier — those are mutually exclusive — and optionally a CPU Windows bui
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4</version>
     <classifier>msvc-windows</classifier>
 </dependency>
 ```

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.4-SNAPSHOT</version>
+		<version>5.0.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.4-SNAPSHOT</version>
+		<version>5.0.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
 	-->
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama-parent</artifactId>
-	<version>5.0.4-SNAPSHOT</version>
+	<version>5.0.4</version>
 	<packaging>pom</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary

- **Release 5.0.4** with LangChain4j in-process adapters (`ChatModel`, `StreamingChatModel`, `EmbeddingModel`, `ScoringModel`), experimental fine-tuning API (`LlamaTrainer`), and model introspection (`ModelMeta`).
- Restructured build into a Maven reactor: native JNI core moved to `llama/` module under new aggregator parent POM (`llama-parent`), alongside new `llama-langchain4j` module. Both inherit a single version and ship in lockstep. Published coordinates (`net.ladenthin:llama`) unchanged.
- Upgraded llama.cpp from b9842 to b9859; all four local patches apply unchanged.
- Updated version in all three POMs (root, `llama/`, `llama-langchain4j/`) and documentation (README, CHANGELOG).

## Test plan

- [x] CI is green on this branch
- [x] Docs / CHANGELOG updated (CHANGELOG.md with 5.0.4 entry, README.md version bumps, CLAUDE.md clarified version-bump procedure)

## Related issues / PRs

Closes the 5.0.4 release.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01QEgh6vtcPWAgQ6scK8pJk7