### PR TITLE
Post-release: bump to 5.0.5-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ forcing that floor on every core consumer. It ships and versions in lockstep wit
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama-langchain4j</artifactId>
-    <version>5.0.5-SNAPSHOT</version>
+    <version>5.0.4</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To use the latest snapshot, add the repository and dependency to your `pom.xml`:
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4-SNAPSHOT</version>
+    <version>5.0.5-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -719,7 +719,7 @@ forcing that floor on every core consumer. It ships and versions in lockstep wit
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama-langchain4j</artifactId>
-    <version>5.0.4-SNAPSHOT</version>
+    <version>5.0.5-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,57 +1,31 @@
 # Release Process
 
-This document is the maintainer-facing release procedure. End users should consult [CHANGELOG.md](../CHANGELOG.md).
+The maintainer-facing release procedure is **centralized in the workspace repo**:
+[`../workspace/workflows/release-process.md`](../workspace/workflows/release-process.md).
 
-> **This repo is a Maven reactor.** The root `pom.xml` is the parent (`net.ladenthin:llama-parent`);
-> the two modules (`llama/`, `llama-langchain4j/`) inherit its version **but hardcode it in their
-> `<parent><version>`** — there is no `${revision}` single-sourcing, so a version change must touch
-> **all three poms in lockstep** or the reactor build fails with
-> `Could not find artifact net.ladenthin:llama-parent:pom:{VERSION}`. `mvn versions:set` does all
-> three in one command. See the "Version bump" note in [CLAUDE.md](../CLAUDE.md) for the rationale.
+java-llama.cpp is a **Maven reactor**, so two repo-specific points extend the canonical procedure.
 
-> Paste this prompt into a new Claude Code session, fill in the four placeholders, and send it to perform a release.
+## Reactor version bump (all three poms)
 
+The root `pom.xml` is the parent (`net.ladenthin:llama-parent`); the `llama/` and
+`llama-langchain4j/` modules inherit its version **but hardcode it in their `<parent><version>`**
+(there is no `${revision}` single-sourcing). A version change — the release strip in Step 1 and the
+post-release bump in Step 3 — must touch **all three poms in lockstep**, or the reactor build fails
+with `Could not find artifact net.ladenthin:llama-parent:pom:{VERSION}`. Use:
+
+```bash
+mvn -q versions:set -DnewVersion={VERSION} -DgenerateBackupPoms=false
 ```
-Release `{PROJECT}` to Maven Central.
 
-**Step 1 — Prepare the release (do immediately):**
-1. Read the current version from the root `pom.xml` on `main` — it will be `{VERSION}-SNAPSHOT`.
-2. Set the release version across **all three reactor poms** in lockstep (root `<version>` +
-   `llama/pom.xml` and `llama-langchain4j/pom.xml` `<parent><version>`):
-   `mvn -q versions:set -DnewVersion={VERSION} -DgenerateBackupPoms=false`
-   Changing only the root pom leaves the children pointing at a non-existent parent and fails the build.
-3. In `README.md`, set **every release** dependency example (core Quick Start, the classifier
-   table, and the LangChain4j section) to `{VERSION}`, and verify the single **snapshot** example
-   (under "Snapshot builds") stays `{VERSION}-SNAPSHOT`.
-4. In `llama-langchain4j/README.md`, set the `## Dependency` snippet to `{VERSION}` — it is a
-   release snippet and is NOT covered by the root-README edits (it drifts silently otherwise).
-5. Finalize `CHANGELOG.md`: rename the `[Unreleased]` heading to `[{VERSION}] - {DATE}`, add a fresh
-   empty `[Unreleased]` above it, and update the compare-link footer — add
-   `[{VERSION}]: .../compare/v{PREV}...v{VERSION}` and repoint
-   `[Unreleased]: .../compare/v{VERSION}...HEAD`.
-6. Commit the changes on a branch and open a PR; merge/fast-forward it into `main`.
+from the repo root — it updates the root `<version>` plus both children's `<parent><version>` at
+once. See the "Version bump" note in [CLAUDE.md](../CLAUDE.md) for the rationale.
 
-**Step 2 — Wait for manual confirmation:**
-I will (a) create the `v{VERSION}` tag + GitHub release on the merged commit and (b) run the
-**Publish** workflow via `workflow_dispatch` with `publish_to_central=true` (the `publish-release`
-job is gated on that input **and** the `v*` tag; one reactor `mvn -P release deploy` signs and
-publishes the parent pom, `llama`, and `llama-langchain4j` together). Wait for me to confirm the
-release is live on Maven Central before proceeding.
+## Extra README dependency snippet
 
-**Step 3 — Post-release snapshot bump (after my confirmation):**
-On a fresh branch off the updated `main`:
-- Bump all three poms to `{NEXT_VERSION}-SNAPSHOT`:
-  `mvn -q versions:set -DnewVersion={NEXT_VERSION}-SNAPSHOT -DgenerateBackupPoms=false`
-- `README.md` snapshot dependency example → `{NEXT_VERSION}-SNAPSHOT`
-  (the release examples — including `llama-langchain4j/README.md` — stay at `{VERSION}`).
-Commit and open a PR.
+Besides the root `README.md`, the `llama-langchain4j/README.md` `## Dependency` section carries a
+**release** dependency snippet that must also be set to `{VERSION}` in Step 1 — it is not covered by
+the root-README edits and drifts silently otherwise (the release examples stay at `{VERSION}` on the
+Step 3 snapshot bump).
 
-**Placeholders:**
-
-| Placeholder      | Value                                        |
-|------------------|----------------------------------------------|
-| `{PROJECT}`      | *(project name)*                             |
-| `{VERSION}`      | *(release version, e.g. `1.3.0`)*           |
-| `{PREV}`         | *(previous release, e.g. `1.2.0`)*          |
-| `{NEXT_VERSION}` | *(next snapshot base, e.g. `1.3.1`)*        |
-```
+One reactor `mvn -P release deploy` signs and publishes the parent pom, `llama`, and
+`llama-langchain4j` together at the same version.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,30 +2,49 @@
 
 This document is the maintainer-facing release procedure. End users should consult [CHANGELOG.md](../CHANGELOG.md).
 
-> Paste this prompt into a new Claude Code session, fill in the three placeholders, and send it to perform a release.
+> **This repo is a Maven reactor.** The root `pom.xml` is the parent (`net.ladenthin:llama-parent`);
+> the two modules (`llama/`, `llama-langchain4j/`) inherit its version **but hardcode it in their
+> `<parent><version>`** — there is no `${revision}` single-sourcing, so a version change must touch
+> **all three poms in lockstep** or the reactor build fails with
+> `Could not find artifact net.ladenthin:llama-parent:pom:{VERSION}`. `mvn versions:set` does all
+> three in one command. See the "Version bump" note in [CLAUDE.md](../CLAUDE.md) for the rationale.
+
+> Paste this prompt into a new Claude Code session, fill in the four placeholders, and send it to perform a release.
 
 ```
 Release `{PROJECT}` to Maven Central.
 
 **Step 1 — Prepare the release (do immediately):**
-1. Read the current version from `pom.xml` on `main` — it will be `{VERSION}-SNAPSHOT`
-2. Strip `-SNAPSHOT` from `pom.xml` (→ `{VERSION}`)
-3. In `README.md`, update **both**:
-   - The release dependency example to `{VERSION}`
-   - The snapshot dependency example to `{VERSION}-SNAPSHOT` (it should already match, but verify)
-4. Commit both files directly to `main` (no pull request)
+1. Read the current version from the root `pom.xml` on `main` — it will be `{VERSION}-SNAPSHOT`.
+2. Set the release version across **all three reactor poms** in lockstep (root `<version>` +
+   `llama/pom.xml` and `llama-langchain4j/pom.xml` `<parent><version>`):
+   `mvn -q versions:set -DnewVersion={VERSION} -DgenerateBackupPoms=false`
+   Changing only the root pom leaves the children pointing at a non-existent parent and fails the build.
+3. In `README.md`, set **every release** dependency example (core Quick Start, the classifier
+   table, and the LangChain4j section) to `{VERSION}`, and verify the single **snapshot** example
+   (under "Snapshot builds") stays `{VERSION}-SNAPSHOT`.
+4. In `llama-langchain4j/README.md`, set the `## Dependency` snippet to `{VERSION}` — it is a
+   release snippet and is NOT covered by the root-README edits (it drifts silently otherwise).
+5. Finalize `CHANGELOG.md`: rename the `[Unreleased]` heading to `[{VERSION}] - {DATE}`, add a fresh
+   empty `[Unreleased]` above it, and update the compare-link footer — add
+   `[{VERSION}]: .../compare/v{PREV}...v{VERSION}` and repoint
+   `[Unreleased]: .../compare/v{VERSION}...HEAD`.
+6. Commit the changes on a branch and open a PR; merge/fast-forward it into `main`.
 
 **Step 2 — Wait for manual confirmation:**
-I will create the `v{VERSION}` tag and GitHub release manually — wait for me to confirm
-the release is published on Maven Central before proceeding.
+I will (a) create the `v{VERSION}` tag + GitHub release on the merged commit and (b) run the
+**Publish** workflow via `workflow_dispatch` with `publish_to_central=true` (the `publish-release`
+job is gated on that input **and** the `v*` tag; one reactor `mvn -P release deploy` signs and
+publishes the parent pom, `llama`, and `llama-langchain4j` together). Wait for me to confirm the
+release is live on Maven Central before proceeding.
 
 **Step 3 — Post-release snapshot bump (after my confirmation):**
-Bump **both** files on `main`:
-- `pom.xml` → `{NEXT_VERSION}-SNAPSHOT`
+On a fresh branch off the updated `main`:
+- Bump all three poms to `{NEXT_VERSION}-SNAPSHOT`:
+  `mvn -q versions:set -DnewVersion={NEXT_VERSION}-SNAPSHOT -DgenerateBackupPoms=false`
 - `README.md` snapshot dependency example → `{NEXT_VERSION}-SNAPSHOT`
-  (the release dependency examples stay at the just-released `{VERSION}`)
-
-Commit both changes together directly to `main`.
+  (the release examples — including `llama-langchain4j/README.md` — stay at `{VERSION}`).
+Commit and open a PR.
 
 **Placeholders:**
 
@@ -33,5 +52,6 @@ Commit both changes together directly to `main`.
 |------------------|----------------------------------------------|
 | `{PROJECT}`      | *(project name)*                             |
 | `{VERSION}`      | *(release version, e.g. `1.3.0`)*           |
+| `{PREV}`         | *(previous release, e.g. `1.2.0`)*          |
 | `{NEXT_VERSION}` | *(next snapshot base, e.g. `1.3.1`)*        |
 ```

--- a/llama-langchain4j/README.md
+++ b/llama-langchain4j/README.md
@@ -62,7 +62,7 @@ ScoringModel reranker     = new JllamaScoringModel(rerankLlama);
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama-langchain4j</artifactId>
-    <version>5.0.4-SNAPSHOT</version>
+    <version>5.0.4</version>
 </dependency>
 ```
 

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.4</version>
+		<version>5.0.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.4</version>
+		<version>5.0.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
 	-->
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama-parent</artifactId>
-	<version>5.0.4</version>
+	<version>5.0.5-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
5.0.4 is released on Maven Central. This opens the next development cycle.

## Changes
- Bump all three reactor poms to `5.0.5-SNAPSHOT`, in lockstep:
  - `pom.xml` (root) — `<version>`
  - `llama/pom.xml` — `<parent><version>`
  - `llama-langchain4j/pom.xml` — `<parent><version>`
- Point the README **snapshot** dependency examples at `5.0.5-SNAPSHOT`.
- The README **release** dependency examples stay at the just-released `5.0.4`.

## Notes
- Branched fresh off `main` @ 5.0.4 — single commit, fast-forwards cleanly.
- Version bumped across all three poms per the reactor's version-bump rule (the child `<parent><version>` literals are not single-sourced; changing root alone would fail the reactor build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEgh6vtcPWAgQ6scK8pJk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEgh6vtcPWAgQ6scK8pJk7)_