### PR TITLE
Upgrade checker and spotless dependencies

### DIFF
--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -60,7 +60,7 @@ SPDX-License-Identifier: MIT
 		<lombok.version>1.18.46</lombok.version>
 		<errorprone.version>2.50.0</errorprone.version>
 		<nullaway.version>0.13.7</nullaway.version>
-		<checker.version>4.2.0</checker.version>
+		<checker.version>4.2.1</checker.version>
 		<jackson.version>2.22.0</jackson.version>
 		<reactor.version>3.8.6</reactor.version>
 		<slf4j.version>2.0.18</slf4j.version>
@@ -85,7 +85,7 @@ SPDX-License-Identifier: MIT
 		<spotbugs.version>4.10.2.0</spotbugs.version>
 		<fb-contrib.version>7.7.4</fb-contrib.version>
 		<findsecbugs.version>1.14.0</findsecbugs.version>
-		<spotless.version>3.7.0</spotless.version>
+		<spotless.version>3.8.0</spotless.version>
 		<palantir-java-format.version>2.94.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>


### PR DESCRIPTION
## Summary

- Upgrade checker framework from 4.2.0 to 4.2.1
- Upgrade spotless from 3.7.0 to 3.8.0

These are minor version updates for build-time dependencies that improve code quality tooling.

## Test plan

- [ ] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01XcMHBw6HJDBHy31c9PWatN