### PR TITLE
Release version 5.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Access this library via Maven (released versions on Maven Central):
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
 </dependency>
 ```
 
@@ -204,14 +204,14 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
 </dependency>
 
 <!-- CUDA on Linux x86-64 (requires CUDA 13 runtime on the host) -->
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>cuda13-linux-x86-64</classifier>
 </dependency>
 
@@ -219,7 +219,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>opencl-android-aarch64</classifier>
 </dependency>
 
@@ -227,7 +227,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>cuda13-windows-x86-64</classifier>
 </dependency>
 
@@ -235,7 +235,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>vulkan-windows-x86-64</classifier>
 </dependency>
 
@@ -243,7 +243,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>vulkan-linux-x86-64</classifier>
 </dependency>
 
@@ -251,7 +251,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>vulkan-linux-aarch64</classifier>
 </dependency>
 
@@ -259,7 +259,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>opencl-windows-x86-64</classifier>
 </dependency>
 
@@ -267,7 +267,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>msvc-windows</classifier>
 </dependency>
 
@@ -275,7 +275,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>rocm-linux-x86-64</classifier>
 </dependency>
 
@@ -283,7 +283,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>rocm-windows-x86-64</classifier>
 </dependency>
 
@@ -291,7 +291,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>sycl-fp16-linux-x86-64</classifier>
 </dependency>
 
@@ -299,7 +299,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>sycl-fp32-linux-x86-64</classifier>
 </dependency>
 
@@ -307,7 +307,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>sycl-windows-x86-64</classifier>
 </dependency>
 
@@ -315,7 +315,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>opencl-windows-aarch64</classifier>
 </dependency>
 
@@ -323,7 +323,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>openvino-linux-x86-64</classifier>
 </dependency>
 
@@ -331,7 +331,7 @@ exclusive — and optionally a CPU Windows build.
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
     <classifier>openvino-windows-x86-64</classifier>
 </dependency>
 ```
@@ -864,7 +864,7 @@ forcing that floor on every core consumer. It ships and versions in lockstep wit
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama-langchain4j</artifactId>
-    <version>5.0.4</version>
+    <version>5.0.5</version>
 </dependency>
 ```
 

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.5-SNAPSHOT</version>
+		<version>5.0.5</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.5-SNAPSHOT</version>
+		<version>5.0.5</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -88,7 +88,7 @@ SPDX-License-Identifier: MIT
 		<spotless.version>3.8.0</spotless.version>
 		<palantir-java-format.version>2.94.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
+		<project.build.outputTimestamp>2026-07-04T19:41:11Z</project.build.outputTimestamp>
 	</properties>
 
 	<!--

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
 	-->
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama-parent</artifactId>
-	<version>5.0.5-SNAPSHOT</version>
+	<version>5.0.5</version>
 	<packaging>pom</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary

- Bump version from 5.0.5-SNAPSHOT to 5.0.5 across all modules (parent pom, llama, llama-langchain4j)
- Update README.md to reflect the new release version in all Maven dependency examples
- Set reproducible build timestamp to `2026-07-04T19:41:11Z`

## Test plan

- [x] CI is green on this branch
- [x] Docs updated (README.md version references)

## Related issues / PRs

<!-- Release commit for version 5.0.5 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01RXWwtbpTWjesgJdBWS27GJ