### PR TITLE
Start next development iteration 5.0.6-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To use the latest snapshot, add the repository and dependency to your `pom.xml`:
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.5-SNAPSHOT</version>
+    <version>5.0.6-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.5</version>
+		<version>5.0.6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.5</version>
+		<version>5.0.6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -88,7 +88,7 @@ SPDX-License-Identifier: MIT
 		<spotless.version>3.8.0</spotless.version>
 		<palantir-java-format.version>2.94.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.outputTimestamp>2026-07-04T19:41:11Z</project.build.outputTimestamp>
+		<project.build.outputTimestamp>2026-07-05T07:13:51Z</project.build.outputTimestamp>
 	</properties>
 
 	<!--

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
 	-->
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama-parent</artifactId>
-	<version>5.0.5</version>
+	<version>5.0.6-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary

- Release 5.0.5 is finished and merged to `main` (#295, #296). This opens the next development cycle.
- Bump the reactor version `5.0.5` → `5.0.6-SNAPSHOT` across the parent and both child POMs (via `mvn versions:set`, so the parent and both `<parent><version>` pointers move in lockstep).
- Point the README "Snapshot builds" snippet at `5.0.6-SNAPSHOT`. The stable dependency snippets stay at `5.0.5` (the last released version).

## Test plan

- [x] Affected unit / integration tests pass locally — N/A (version metadata + docs only)
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable — README snapshot-channel line bumped
- [x] `mvn validate` on the full reactor passes; stable snippets remain `5.0.5`, snapshot line + all three poms are `5.0.6-SNAPSHOT`

## Related issues / PRs

- Follows the 5.0.5 release (#295) and the post-release README/doc consistency fix (#296).

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXWwtbpTWjesgJdBWS27GJ)_