### PR TITLE
Docs: refresh stale README/pom notes after the PR #298 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ Inference of Meta's LLaMA model (and others) in pure C/C++.
 - **Raw JSON endpoint handlers** mirroring the upstream llama.cpp HTTP server (`/completions`, `/v1/completions`, `/embeddings`, `/infill`, `/tokenize`, `/detokenize`).
 - **Two runnable HTTP server modes, one fat-jar entry.** The fat jar's `Main-Class` is `ServerLauncher`, which dispatches on the `--jllama-openai-compat` flag. Without it, `java -jar …-jar-with-dependencies.jar -m model.gguf --port 8080` runs the full upstream llama.cpp server (embedded **WebUI**, every llama-server flag forwarded) hosted inside `libjllama` over JNI — no separate `llama-server.exe`. With it, `java -jar … --jllama-openai-compat --model model.gguf --port 8080` runs the Java-transport, zero-extra-dependency **OpenAI-compatible** server (`OpenAiCompatServer`, streaming SSE) instead. Both are also runnable directly by class name via `java -cp … net.ladenthin.llama.server.{NativeServer,OpenAiCompatServer}`.
 - **Model metadata** access (`getModelMeta()`) and **server management** (metrics, slot save/restore, runtime thread reconfiguration).
-- Pre-built native binaries for Linux (x86-64, aarch64), macOS (x86-64, arm64), and Windows (x86-64, x86); CUDA, Metal, and Vulkan supported via local build.
+- **Conversation checkpoints** — `Session.checkpoint(...)` / `rewind(...)` / `fork(...)` branch and roll back a chat (KV-cache slot save/restore + transcript snapshot) without re-prefilling.
+- **GGUF metadata inspection** without loading the model (`GgufInspector` — pure Java, reads header + key/value table only, big-endian aware).
+- **Multi-model router mode** (`--models-dir` + per-request model selection, managed via the typed `RouterClient`) and **attach mode** (`NativeServer(LlamaModel, ...)` serves an already-loaded model over the full upstream HTTP frontend — one copy of the weights).
+- Pre-built native binaries in the default JAR for Linux (x86-64, aarch64, s390x), macOS (x86-64, arm64 — Metal included), Windows (x86-64, x86, arm64) and Android (arm64, x86-64); GPU backends (CUDA, Vulkan, OpenCL, ROCm/HIP, SYCL, OpenVINO) ship as Maven classifiers — see [Choosing the right classifier](#choosing-the-right-classifier). Android additionally ships as the [`llama-android` AAR](#importing-in-android) with the optional `llama-kotlin` coroutines façade.
 
 ## Quick Start
 
@@ -1132,7 +1135,9 @@ keep class net.ladenthin.llama.** { *; }
 
 ## TODO
 
-- **Expand PIT mutation-testing scope.** PIT is wired in `pom.xml` and runs on every CI build (in the `test-java-linux-x86_64` job) with `<mutationThreshold>100</mutationThreshold>`, but `<targetClasses>` is currently narrowed to a single class (`Pair`). The intent is to exercise the wiring and gate against regressions on that single class today; widen `<targetClasses>` incrementally as additional classes reach mutation-test parity. Final target: `<param>net.ladenthin.llama.*</param>` matching the streambuffer pattern.
+Open work items live in [`TODO.md`](TODO.md).
+
+- **Expand PIT mutation-testing scope.** PIT is wired in `pom.xml` and runs on every CI build (in the `test-java-linux-x86_64` job) with `<mutationThreshold>100</mutationThreshold>`. `<targetClasses>` currently covers `net.ladenthin.llama.value.*`, `exception.*`, `args.*` and four `json` parsers (295 mutations, 100% killed, hermetic — no model or fixture needed); widen it incrementally as additional classes reach mutation-test parity. Final target: `<param>net.ladenthin.llama.*</param>` matching the streambuffer pattern.
 
 ## Feature Ideas
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -694,8 +694,8 @@ SPDX-License-Identifier: MIT
 				  see ../workspace/policies/pit-mutation-testing.md.
 				  Repo-specific: the gated value/exception/args/json classes are pure-Java
 				  (no native libjllama or model file needed); targetClasses/targetTests are
-				  kept in lock-step. NOTE: value.ContentPart.audioFile(Path) mutants are only
-				  killed with the audio fixture present — see TODO.md and policy §4.
+				  kept in lock-step. The gate is hermetic: ContentPartTest's @TempDir tests
+				  cover value.ContentPart.audioFile(Path), so no fixture is required.
 				-->
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>


### PR DESCRIPTION
## Summary

- **README "Features" list**: the closing bullet still described the pre-classifier era ("CUDA, Metal, and Vulkan supported via local build") with an incomplete platform list. It now states the actual default-JAR platform set (Linux x86-64/aarch64/s390x, macOS incl. Metal, Windows x86-64/x86/arm64, Android arm64/x86-64), points at the classifier table for the six GPU backends, and mentions the `llama-android` AAR + `llama-kotlin` façade. Also adds the missing headline bullets for conversation checkpoints, GGUF metadata inspection, and the router/attach server modes (their dedicated sections already existed further down).
- **README "TODO" section**: claimed PIT `targetClasses` was "narrowed to a single class (`Pair`)" — it has long covered `value.*`/`exception.*`/`args.*` plus four `json` parsers (295 mutations, 100% killed, hermetic). Now states the actual scope and links `TODO.md` as the canonical open-items list.
- **`llama/pom.xml` PIT comment**: removed the obsolete "audioFile mutants only killed with the audio fixture present" note — the gate is hermetic via `ContentPartTest`'s `@TempDir` tests.

Documentation-only follow-up from the post-merge audit of #298; no code, build, or CI behavior changes.

## Test plan

- [x] Affected unit / integration tests pass locally (docs-only; `reuse lint` clean, pom edit is a comment)
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable (this PR *is* the docs update)

## Related issues / PRs

Follow-up to #298.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVMuGj2shABrHWJ9sNqLqX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVMuGj2shABrHWJ9sNqLqX)_