### PR TITLE
Start next development iteration 5.0.7-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To use the latest snapshot, add the repository and dependency to your `pom.xml`:
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.6-SNAPSHOT</version>
+    <version>5.0.7-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/llama-kotlin/pom.xml
+++ b/llama-kotlin/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.6</version>
+		<version>5.0.7-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.6</version>
+		<version>5.0.7-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.6</version>
+		<version>5.0.7-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -88,7 +88,7 @@ SPDX-License-Identifier: MIT
 		<spotless.version>3.8.0</spotless.version>
 		<palantir-java-format.version>2.94.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.outputTimestamp>2026-07-07T07:24:29Z</project.build.outputTimestamp>
+		<project.build.outputTimestamp>2026-07-07T07:32:17Z</project.build.outputTimestamp>
 	</properties>
 
 	<!--

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
 	-->
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama-parent</artifactId>
-	<version>5.0.6</version>
+	<version>5.0.7-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary

- Post-release snapshot bump after the 5.0.6 release (#302): `mvn versions:set 5.0.7-SNAPSHOT` across the four reactor poms (root `<version>` + each child `<parent><version>` in lockstep, refreshing `project.build.outputTimestamp`)
- `README.md` snapshot dependency example → `5.0.7-SNAPSHOT`; the release dependency examples stay at the just-released `5.0.6`

## Test plan

- [x] `mvn validate` resolves the full reactor at the new version locally
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable (README snapshot line; CHANGELOG already carries a fresh `[Unreleased]` section — no change needed)

## Related issues / PRs

Follow-up to #302 (5.0.6 release preparation), per Step 3 of the release process.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PytupxRpm1RxB8QzcstKfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PytupxRpm1RxB8QzcstKfY)_