### PR TITLE
Add GPG signing key preflight checks to CI pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,68 @@ jobs:
           echo "RESULT: OK — key imports, is not expired, is signing-capable, and the passphrase successfully unlocked it to produce a VALID signature. maven-gpg-plugin will be able to sign with this key/passphrase."
 
   # ---------------------------------------------------------------------------
+  # GPG signing-key preflight — GRADLE / BouncyCastle path (java-llama.cpp ONLY).
+  # The sibling `verify-signing-key` job tests the `gpg` CLI path (maven-gpg-plugin,
+  # used by every repo's Maven publish). This repo ALSO signs the `llama-android`
+  # AAR via Gradle's `signing` plugin + `useInMemoryPgpKeys` (BouncyCastle), which
+  # is STRICTER at parsing the armored key and is exactly where the AAR snapshot
+  # signing failed (null PGPPrivateKey). This job drives `useInMemoryPgpKeys` on a
+  # throwaway signing project — the only faithful test of that path. Standalone
+  # (no `needs:`), parallel at pipeline start, `environment: maven-central` so it
+  # reads the same secret the AAR publish uses. Red-by-design where the secret is
+  # not delivered (see the gpg job's note).
+  #
+  # SECURITY: prints no secret material. Key/passphrase reach Gradle only via env
+  # (MAVEN_GPG_PRIVATE_KEY / MAVEN_GPG_PASSPHRASE, read by System.getenv at
+  # runtime); `set -x` is never enabled; the passphrase is `::add-mask::`ed; Gradle
+  # runs with `--stacktrace` only (no `--info`/`--debug`). Only the produced `.asc`
+  # (exit code) is asserted. Uses Gradle 8.14.3 — the same version the AAR publish
+  # uses — so the BouncyCastle version under test matches production.
+  # ---------------------------------------------------------------------------
+  verify-signing-key-gradle:
+    name: Verify GPG signing key — Gradle/BouncyCastle path (no secrets printed)
+    runs-on: ubuntu-latest
+    environment: maven-central
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.14.3"
+      - name: Sign a throwaway artifact via useInMemoryPgpKeys (BouncyCastle)
+        shell: bash
+        env:
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail   # NOTE: deliberately NO `set -x` — it would echo the passphrase.
+
+          if [ -z "${MAVEN_GPG_PRIVATE_KEY:-}" ]; then
+            echo "::error::MAVEN_GPG_PRIVATE_KEY is empty for this run. The maven-central environment did not deliver the secret to this ref (fork PR / other branch). Nothing to verify."
+            exit 1
+          fi
+          if [ -n "${MAVEN_GPG_PASSPHRASE:-}" ]; then echo "::add-mask::${MAVEN_GPG_PASSPHRASE}"; fi
+
+          WORK="$(mktemp -d)"
+          echo 'cm9vdFByb2plY3QubmFtZSA9ICJzaWduaW5nLXNlbGZ0ZXN0Igo=' | base64 -d > "$WORK/settings.gradle.kts"
+          echo 'cGx1Z2lucyB7CiAgICBiYXNlCiAgICBzaWduaW5nCn0KLy8gTWlycm9ycyBsbGFtYS1hbmRyb2lkL2J1aWxkLmdyYWRsZS5rdHM6IHNhbWUgZW52IHZhciBuYW1lcywgc2FtZQovLyB1c2VJbk1lbW9yeVBncEtleXMoa2V5LCBwYXNzcGhyYXNlKSBjYWxsLCBzbyB0aGlzIHJlcHJvZHVjZXMgdGhlIGV4YWN0Ci8vIEdyYWRsZS9Cb3VuY3lDYXN0bGUgc2lnbmluZyBwYXRoIHRoZSBBQVIgcHVibGlzaCB1c2VzLgp2YWwgc2lnbmluZ0tleSA9IFN5c3RlbS5nZXRlbnYoIk1BVkVOX0dQR19QUklWQVRFX0tFWSIpCnZhbCBzaWduaW5nUGFzc3BocmFzZSA9IFN5c3RlbS5nZXRlbnYoIk1BVkVOX0dQR19QQVNTUEhSQVNFIikKcmVxdWlyZSghc2lnbmluZ0tleS5pc051bGxPckJsYW5rKCkpIHsgIk1BVkVOX0dQR19QUklWQVRFX0tFWSBpcyBlbXB0eSIgfQoKdmFsIG1ha2VBcnRpZmFjdCA9IHRhc2tzLnJlZ2lzdGVyPFppcD4oIm1ha2VBcnRpZmFjdCIpIHsKICAgIGFyY2hpdmVCYXNlTmFtZS5zZXQoInNpZ25pbmctc2VsZnRlc3QiKQogICAgZGVzdGluYXRpb25EaXJlY3Rvcnkuc2V0KGxheW91dC5idWlsZERpcmVjdG9yeSkKICAgIGZyb20obGF5b3V0LnByb2plY3REaXJlY3RvcnkuZmlsZSgic2V0dGluZ3MuZ3JhZGxlLmt0cyIpKQp9CnNpZ25pbmcgewogICAgdXNlSW5NZW1vcnlQZ3BLZXlzKHNpZ25pbmdLZXksIHNpZ25pbmdQYXNzcGhyYXNlID86ICIiKQogICAgc2lnbihtYWtlQXJ0aWZhY3QuZ2V0KCkpCn0K' | base64 -d > "$WORK/build.gradle.kts"
+
+          echo "== Sign a throwaway artifact through Gradle's useInMemoryPgpKeys (BouncyCastle) =="
+          gradle --no-daemon -p "$WORK" signMakeArtifact --stacktrace
+
+          ASC="$WORK/build/signing-selftest.zip.asc"
+          if [ -f "$ASC" ]; then
+            echo "  Detached signature produced: $(wc -c < "$ASC") armored bytes"
+            echo "RESULT: OK — Gradle's useInMemoryPgpKeys accepted the armored key + passphrase and produced a signature. The llama-android AAR publish will be able to sign with this key/passphrase."
+          else
+            echo "::error::Gradle signing produced no .asc — useInMemoryPgpKeys could not build a usable signatory from MAVEN_GPG_PRIVATE_KEY / MAVEN_GPG_PASSPHRASE (the AAR-publish failure mode)."
+            exit 1
+          fi
+          rm -rf "$WORK"
+
+  # ---------------------------------------------------------------------------
   # Download + cache the GGUF test models ONCE, upfront, for the whole pipeline.
   # Every Java test job (`test-java-*`) and the langchain4j integration job `needs:` this
   # job and then only RESTORES the shared cache (key gguf-models-<manifest hash>) — so the ~5 GB model

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,119 @@ jobs:
       - run: echo "Start gate elapsed — proceeding with pipeline."
 
   # ---------------------------------------------------------------------------
+  # GPG signing-key preflight (standalone, no `needs:` — runs in parallel at the
+  # very start on every trigger). Reproduces what maven-gpg-plugin does at deploy
+  # time so a bad/expired key or wrong passphrase is caught in ~20s instead of
+  # failing the publish stage. Declares `environment: maven-central` so it reads
+  # the SAME GPG_PRIVATE_KEY / GPG_PASSPHRASE secret the publish jobs use.
+  #
+  # It is EXPECTED to go RED on refs where the secret is not delivered — fork PRs
+  # and other contributors' branches (secrets are withheld there). That red is
+  # the intended signal: "this ref cannot sign a release", not a regression.
+  #
+  # SECURITY: this job NEVER prints secret material. It imports the key into an
+  # ephemeral keyring, prints only PUBLIC key metadata (key id, fingerprint,
+  # owner UID, algorithm, created/expiry — all of which live on public
+  # keyservers), and validates the passphrase by producing + verifying a
+  # throwaway signature. The passphrase is passed on fd 3 (never argv, never a
+  # log line), `set -x` is deliberately never enabled, and the passphrase is
+  # additionally `::add-mask::`ed.
+  # ---------------------------------------------------------------------------
+  verify-signing-key:
+    name: Verify GPG signing key (no secrets printed)
+    runs-on: ubuntu-latest
+    environment: maven-central
+    steps:
+      - name: Import key + run sign/verify self-test (prints only PUBLIC metadata)
+        shell: bash
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail   # NOTE: deliberately NO `set -x` — it would echo the passphrase.
+
+          if [ -z "${GPG_PRIVATE_KEY:-}" ]; then
+            echo "::error::GPG_PRIVATE_KEY is empty for this run. Either the secret is not set, or it is scoped to a different environment/branch than 'maven-central' on this ref. Nothing to verify."
+            exit 1
+          fi
+          # Defensive: even though we never print it, register the passphrase as a
+          # masked value so any accidental echo downstream is redacted.
+          if [ -n "${GPG_PASSPHRASE:-}" ]; then echo "::add-mask::${GPG_PASSPHRASE}"; fi
+
+          echo "gpg: $(gpg --version | head -n1)"
+
+          # Ephemeral, private keyring; removed on exit.
+          export GNUPGHOME="$(mktemp -d)"
+          chmod 700 "$GNUPGHOME"
+          cleanup() { gpgconf --kill gpg-agent >/dev/null 2>&1 || true; rm -rf "$GNUPGHOME"; }
+          trap cleanup EXIT
+
+          echo "== Import private key into an ephemeral keyring (key via stdin, never argv) =="
+          printf '%s\n' "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+          COLONS="$(gpg --list-secret-keys --with-colons --fixed-list-mode)"
+          SECCOUNT="$(printf '%s\n' "$COLONS" | awk -F: '$1=="sec"{n++} END{print n+0}')"
+          echo "Secret keys imported: $SECCOUNT"
+          if [ "$SECCOUNT" -lt 1 ]; then
+            echo "::error::No secret key was imported — GPG_PRIVATE_KEY is not a valid armored secret key (check that the secret contains the full -----BEGIN PGP PRIVATE KEY BLOCK----- with intact newlines)."
+            exit 1
+          fi
+
+          KEYID="$(printf '%s\n' "$COLONS"  | awk -F: '$1=="sec"{print $5; exit}')"
+          ALGO="$(printf '%s\n'  "$COLONS"  | awk -F: '$1=="sec"{print $4; exit}')"
+          CREATED="$(printf '%s\n' "$COLONS"| awk -F: '$1=="sec"{print $6; exit}')"
+          EXPIRES="$(printf '%s\n' "$COLONS"| awk -F: '$1=="sec"{print $7; exit}')"
+          FPR="$(printf '%s\n'   "$COLONS"  | awk -F: '$1=="fpr"{print $10; exit}')"
+
+          echo "== PUBLIC key metadata =="
+          echo "  Key ID (long):  $KEYID"
+          echo "  Fingerprint:    $FPR"
+          echo "  Pubkey algo id: $ALGO"
+          echo "  Created (UTC):  $(date -u -d "@$CREATED" 2>/dev/null || echo "$CREATED")"
+          echo "  Owner UID(s):"
+          printf '%s\n' "$COLONS" | awk -F: '$1=="uid"{print "    - " $10}'
+
+          # --- Expiration gate ---
+          NOW="$(date -u +%s)"
+          if [ -n "$EXPIRES" ]; then
+            echo "  Expires (UTC):  $(date -u -d "@$EXPIRES" 2>/dev/null || echo "$EXPIRES")"
+            if [ "$EXPIRES" -le "$NOW" ]; then
+              echo "::error::Signing key is EXPIRED — Maven Central will reject its signatures. Extend the key's expiry and update the GPG_PRIVATE_KEY secret."
+              exit 1
+            fi
+            echo "  Days to expiry: $(( (EXPIRES - NOW) / 86400 ))"
+            if [ "$(( (EXPIRES - NOW) / 86400 ))" -lt 30 ]; then
+              echo "::warning::Signing key expires in under 30 days — plan to rotate it."
+            fi
+          else
+            echo "  Expires (UTC):  never"
+          fi
+
+          # --- Signing-capability gate ---
+          if printf '%s\n' "$COLONS" | awk -F: '($1=="sec"||$1=="ssb"){print $12}' | grep -q 's'; then
+            echo "  Signing capability: present"
+          else
+            echo "::error::No signing-capable (sub)key found — this key cannot produce release signatures."
+            exit 1
+          fi
+
+          # --- Passphrase unlock + sign + verify roundtrip (the exact failure mode) ---
+          # Passphrase on fd 3 only. Payload is a throwaway nonce; only the signature's
+          # validity (exit codes) matters — no secret is ever emitted.
+          echo "== Passphrase unlock + detached-sign + verify self-test =="
+          WORK="$(mktemp -d)"
+          printf '%s' "ai-index signing-selftest" > "$WORK/payload.txt"
+          gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+              --local-user "$KEYID" \
+              --detach-sign --armor --output "$WORK/payload.txt.asc" "$WORK/payload.txt" \
+              3<<<"${GPG_PASSPHRASE:-}"
+          echo "  Signature produced: $(wc -c < "$WORK/payload.txt.asc") armored bytes"
+          gpg --batch --verify "$WORK/payload.txt.asc" "$WORK/payload.txt"
+          rm -rf "$WORK"
+
+          echo "RESULT: OK — key imports, is not expired, is signing-capable, and the passphrase successfully unlocked it to produce a VALID signature. maven-gpg-plugin will be able to sign with this key/passphrase."
+
+  # ---------------------------------------------------------------------------
   # Download + cache the GGUF test models ONCE, upfront, for the whole pipeline.
   # Every Java test job (`test-java-*`) and the langchain4j integration job `needs:` this
   # job and then only RESTORES the shared cache (key gguf-models-<manifest hash>) — so the ~5 GB model


### PR DESCRIPTION
## Summary

- Add two new standalone CI jobs (`verify-signing-key` and `verify-signing-key-gradle`) that validate GPG signing keys and passphrases before the publish stage
- The `verify-signing-key` job tests the `gpg` CLI path (used by maven-gpg-plugin) by importing the key, checking expiration, verifying signing capability, and performing a sign/verify roundtrip
- The `verify-signing-key-gradle` job tests the Gradle/BouncyCastle path (used by the llama-android AAR publish) by attempting to sign a throwaway artifact via `useInMemoryPgpKeys`
- Both jobs run in parallel at pipeline start with no dependencies, read from the `maven-central` environment, and are designed to fail gracefully (red-by-design) on refs where secrets are not delivered (fork PRs, contributor branches)
- Security-hardened: no secret material is ever printed; passphrases are passed only via file descriptors or environment variables and are masked; only public key metadata is logged

## Test plan

- CI is green on this branch
- Both new jobs will run on every trigger and catch GPG key/passphrase issues in ~20s instead of failing during the publish stage
- Jobs are expected to go red on fork PRs and contributor branches (where the `maven-central` environment secret is not delivered) — this is the intended signal that the ref cannot sign a release

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (GPG key validation is security-hardening; no secrets are printed)

https://claude.ai/code/session_018pwn51YPBbtiuUyiLRrfrG