### PR TITLE
fix(signing): select GPG signing subkey for the Gradle/BouncyCastle AAR path

### DIFF
--- a/.github/signing-selftest/build.gradle.kts
+++ b/.github/signing-selftest/build.gradle.kts
@@ -19,6 +19,11 @@ plugins {
 
 val signingKey = System.getenv("MAVEN_GPG_PRIVATE_KEY")
 val signingPassphrase = System.getenv("MAVEN_GPG_PASSPHRASE")
+// Optional: the signing (sub)key id, e.g. 07D2D767. When set, Gradle selects
+// that key instead of the primary — needed here because gpg signs with the
+// 4096-bit signing subkey while the 2-arg useInMemoryPgpKeys picks the primary
+// (whose secret this BouncyCastle can't unlock → the null-PGPPrivateKey NPE).
+val signingKeyId = System.getenv("MAVEN_GPG_KEY_ID")
 require(!signingKey.isNullOrBlank()) { "MAVEN_GPG_PRIVATE_KEY is empty" }
 
 val makeArtifact = tasks.register<Zip>("makeArtifact") {
@@ -28,6 +33,10 @@ val makeArtifact = tasks.register<Zip>("makeArtifact") {
 }
 
 signing {
-    useInMemoryPgpKeys(signingKey, signingPassphrase ?: "")
+    if (!signingKeyId.isNullOrBlank()) {
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassphrase ?: "")
+    } else {
+        useInMemoryPgpKeys(signingKey, signingPassphrase ?: "")
+    }
     sign(makeArtifact.get())
 }

--- a/.github/signing-selftest/build.gradle.kts
+++ b/.github/signing-selftest/build.gradle.kts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+// Throwaway signing project used ONLY by the `verify-signing-key-gradle`
+// preflight job in .github/workflows/publish.yml. It mirrors the signing setup
+// in llama-android/build.gradle.kts (the AAR publish): the SAME env var names
+// and the SAME `useInMemoryPgpKeys(key, passphrase)` call, so running
+// `gradle signMakeArtifact` here reproduces the exact Gradle/BouncyCastle
+// signing path the AAR uses — the path that failed with a null PGPPrivateKey,
+// which the gpg-based `verify-signing-key` job cannot exercise.
+//
+// It signs a tiny throwaway Zip; the job asserts only that the detached .asc
+// was produced. No secret is ever printed (the key/passphrase arrive via env).
+plugins {
+    base
+    signing
+}
+
+val signingKey = System.getenv("MAVEN_GPG_PRIVATE_KEY")
+val signingPassphrase = System.getenv("MAVEN_GPG_PASSPHRASE")
+require(!signingKey.isNullOrBlank()) { "MAVEN_GPG_PRIVATE_KEY is empty" }
+
+val makeArtifact = tasks.register<Zip>("makeArtifact") {
+    archiveBaseName.set("signing-selftest")
+    destinationDirectory.set(layout.buildDirectory)
+    from(layout.projectDirectory.file("settings.gradle.kts"))
+}
+
+signing {
+    useInMemoryPgpKeys(signingKey, signingPassphrase ?: "")
+    sign(makeArtifact.get())
+}

--- a/.github/signing-selftest/settings.gradle.kts
+++ b/.github/signing-selftest/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "signing-selftest"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -211,6 +211,7 @@ jobs:
         env:
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
         run: |
           set -euo pipefail   # NOTE: deliberately NO `set -x` — it would echo the passphrase.
 
@@ -2970,6 +2971,7 @@ jobs:
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
       # Runs even when the deploy step failed: a Central publish-poll timeout reds the
       # job *after* the bundle was uploaded (and typically published server-side), while
       # the signed jars + .asc files already exist in target/ (signing happens at
@@ -3167,6 +3169,7 @@ jobs:
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
       # Runs even when the deploy step failed: a Central publish-poll timeout reds the
       # job *after* the bundle was uploaded (and typically published server-side), while
       # the signed jars + .asc files already exist in target/ (signing happens at

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -198,6 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: maven-central
     steps:
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           java-version: '21'
@@ -219,14 +220,13 @@ jobs:
           fi
           if [ -n "${MAVEN_GPG_PASSPHRASE:-}" ]; then echo "::add-mask::${MAVEN_GPG_PASSPHRASE}"; fi
 
-          WORK="$(mktemp -d)"
-          echo 'cm9vdFByb2plY3QubmFtZSA9ICJzaWduaW5nLXNlbGZ0ZXN0Igo=' | base64 -d > "$WORK/settings.gradle.kts"
-          echo 'cGx1Z2lucyB7CiAgICBiYXNlCiAgICBzaWduaW5nCn0KLy8gTWlycm9ycyBsbGFtYS1hbmRyb2lkL2J1aWxkLmdyYWRsZS5rdHM6IHNhbWUgZW52IHZhciBuYW1lcywgc2FtZQovLyB1c2VJbk1lbW9yeVBncEtleXMoa2V5LCBwYXNzcGhyYXNlKSBjYWxsLCBzbyB0aGlzIHJlcHJvZHVjZXMgdGhlIGV4YWN0Ci8vIEdyYWRsZS9Cb3VuY3lDYXN0bGUgc2lnbmluZyBwYXRoIHRoZSBBQVIgcHVibGlzaCB1c2VzLgp2YWwgc2lnbmluZ0tleSA9IFN5c3RlbS5nZXRlbnYoIk1BVkVOX0dQR19QUklWQVRFX0tFWSIpCnZhbCBzaWduaW5nUGFzc3BocmFzZSA9IFN5c3RlbS5nZXRlbnYoIk1BVkVOX0dQR19QQVNTUEhSQVNFIikKcmVxdWlyZSghc2lnbmluZ0tleS5pc051bGxPckJsYW5rKCkpIHsgIk1BVkVOX0dQR19QUklWQVRFX0tFWSBpcyBlbXB0eSIgfQoKdmFsIG1ha2VBcnRpZmFjdCA9IHRhc2tzLnJlZ2lzdGVyPFppcD4oIm1ha2VBcnRpZmFjdCIpIHsKICAgIGFyY2hpdmVCYXNlTmFtZS5zZXQoInNpZ25pbmctc2VsZnRlc3QiKQogICAgZGVzdGluYXRpb25EaXJlY3Rvcnkuc2V0KGxheW91dC5idWlsZERpcmVjdG9yeSkKICAgIGZyb20obGF5b3V0LnByb2plY3REaXJlY3RvcnkuZmlsZSgic2V0dGluZ3MuZ3JhZGxlLmt0cyIpKQp9CnNpZ25pbmcgewogICAgdXNlSW5NZW1vcnlQZ3BLZXlzKHNpZ25pbmdLZXksIHNpZ25pbmdQYXNzcGhyYXNlID86ICIiKQogICAgc2lnbihtYWtlQXJ0aWZhY3QuZ2V0KCkpCn0K' | base64 -d > "$WORK/build.gradle.kts"
-
+          # The throwaway signing project is committed (readable, reviewable) at
+          # .github/signing-selftest/ — it mirrors llama-android/build.gradle.kts.
+          PROJ=".github/signing-selftest"
           echo "== Sign a throwaway artifact through Gradle's useInMemoryPgpKeys (BouncyCastle) =="
-          gradle --no-daemon -p "$WORK" signMakeArtifact --stacktrace
+          gradle --no-daemon -p "$PROJ" signMakeArtifact --stacktrace
 
-          ASC="$WORK/build/signing-selftest.zip.asc"
+          ASC="$PROJ/build/signing-selftest.zip.asc"
           if [ -f "$ASC" ]; then
             echo "  Detached signature produced: $(wc -c < "$ASC") armored bytes"
             echo "RESULT: OK — Gradle's useInMemoryPgpKeys accepted the armored key + passphrase and produced a signature. The llama-android AAR publish will be able to sign with this key/passphrase."
@@ -234,7 +234,6 @@ jobs:
             echo "::error::Gradle signing produced no .asc — useInMemoryPgpKeys could not build a usable signatory from MAVEN_GPG_PRIVATE_KEY / MAVEN_GPG_PASSPHRASE (the AAR-publish failure mode)."
             exit 1
           fi
-          rm -rf "$WORK"
 
   # ---------------------------------------------------------------------------
   # Download + cache the GGUF test models ONCE, upfront, for the whole pipeline.

--- a/llama-android/build.gradle.kts
+++ b/llama-android/build.gradle.kts
@@ -295,9 +295,19 @@ publishing {
 // Sign only when CI provides the key (same GPG key the Maven release uses).
 val signingKey = System.getenv("MAVEN_GPG_PRIVATE_KEY")
 val signingPassphrase = System.getenv("MAVEN_GPG_PASSPHRASE")
+// The signing (sub)key id (e.g. 07D2D767). When set, Gradle selects that key
+// instead of the primary. This key's signing capability lives on a 4096-bit
+// subkey; gpg (maven-gpg-plugin) auto-selects it, but the 2-arg
+// useInMemoryPgpKeys picks the primary — whose secret this BouncyCastle can't
+// unlock, failing with a null PGPPrivateKey. Selecting the subkey by id fixes it.
+val signingKeyId = System.getenv("MAVEN_GPG_KEY_ID")
 if (signingKey != null) {
     signing {
-        useInMemoryPgpKeys(signingKey, signingPassphrase ?: "")
+        if (!signingKeyId.isNullOrBlank()) {
+            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassphrase ?: "")
+        } else {
+            useInMemoryPgpKeys(signingKey, signingPassphrase ?: "")
+        }
         sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Summary

- Fixes the `llama-android` AAR publish failing with `Cannot invoke "org.bouncycastle.openpgp.PGPPrivateKey.getPublicKeyPacket()" because "<parameter1>" is null`. Gradle's 2-arg `useInMemoryPgpKeys` selects the **primary** GPG key, whose secret this BouncyCastle can't unlock; `gpg`/maven-gpg-plugin auto-select the 4096-bit **signing subkey** (`07D2D767`) and sign fine. Both Gradle signing setups now select that subkey via the 3-arg `useInMemoryPgpKeys(keyId, key, passphrase)` when `MAVEN_GPG_KEY_ID` is set (env secret `GPG_KEY_ID`), falling back to the previous 2-arg behavior otherwise.
- Follow-up to the merged preflight jobs (#306): makes the isolated `verify-signing-key-gradle` self-test project **committed and readable** at `.github/signing-selftest/` instead of an opaque base64 blob.

## Test plan

- [x] The `verify-signing-key` (gpg) job is green on `main` — the key/passphrase are valid.
- [x] The `verify-signing-key-gradle` job reproduced the exact null-`PGPPrivateKey` failure on `main` — confirming the bug is BouncyCastle-selecting-the-primary, not a bad key.
- [ ] After merge, `verify-signing-key-gradle` goes **green** on `main` (the harness only runs under the `maven-central` environment gate on `main`), proving the subkey selection. The real AAR publish runs the identical code + same secret, so it is covered by the same result.

## Related issues / PRs

Refs #306 (the preflight jobs this builds on).

## Checklist

- [x] My commits follow Conventional Commits
- [x] No new secret material is exposed — `GPG_KEY_ID` is a public key id (present in the key's fingerprint); the private key and passphrase never appear in any log (passphrase on fd 3, `set -x` never enabled, `::add-mask::`ed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018pwn51YPBbtiuUyiLRrfrG)_