### PR TITLE
ci: sync gradle signing preflight to the shared cross-repo version

### DIFF
--- a/.github/signing-selftest/build.gradle.kts
+++ b/.github/signing-selftest/build.gradle.kts
@@ -3,15 +3,13 @@
 // SPDX-License-Identifier: MIT
 
 // Throwaway signing project used ONLY by the `verify-signing-key-gradle`
-// preflight job in .github/workflows/publish.yml. It mirrors the signing setup
-// in llama-android/build.gradle.kts (the AAR publish): the SAME env var names
-// and the SAME `useInMemoryPgpKeys(key, passphrase)` call, so running
-// `gradle signMakeArtifact` here reproduces the exact Gradle/BouncyCastle
-// signing path the AAR uses — the path that failed with a null PGPPrivateKey,
-// which the gpg-based `verify-signing-key` job cannot exercise.
-//
-// It signs a tiny throwaway Zip; the job asserts only that the detached .asc
-// was produced. No secret is ever printed (the key/passphrase arrive via env).
+// preflight job in .github/workflows/publish.yml. It signs a tiny throwaway Zip
+// through Gradle's `signing` plugin + `useInMemoryPgpKeys` (BouncyCastle) — the
+// exact path any Gradle-based publish (e.g. an Android AAR) uses to sign release
+// artifacts, and a stricter parser of the armored key than the `gpg` CLI. The
+// job asserts only that the detached .asc was produced; no secret is ever
+// printed (the key/passphrase arrive via env). Kept identical across the sibling
+// repos so a future Gradle publish is pre-validated ("prepared for Gradle").
 plugins {
     base
     signing
@@ -19,10 +17,11 @@ plugins {
 
 val signingKey = System.getenv("MAVEN_GPG_PRIVATE_KEY")
 val signingPassphrase = System.getenv("MAVEN_GPG_PASSPHRASE")
-// Optional: the signing (sub)key id, e.g. 07D2D767. When set, Gradle selects
-// that key instead of the primary — needed here because gpg signs with the
-// 4096-bit signing subkey while the 2-arg useInMemoryPgpKeys picks the primary
-// (whose secret this BouncyCastle can't unlock → the null-PGPPrivateKey NPE).
+// Optional signing (sub)key id (e.g. 07D2D767). When set, Gradle selects that
+// key instead of the primary — required when the key's signing capability lives
+// on a subkey (gpg auto-selects it, but the 2-arg useInMemoryPgpKeys picks the
+// primary, whose secret BouncyCastle may not be able to unlock -> null
+// PGPPrivateKey). Driven by the GPG_KEY_ID env secret.
 val signingKeyId = System.getenv("MAVEN_GPG_KEY_ID")
 require(!signingKey.isNullOrBlank()) { "MAVEN_GPG_PRIVATE_KEY is empty" }
 

--- a/.github/signing-selftest/settings.gradle.kts
+++ b/.github/signing-selftest/settings.gradle.kts
@@ -1,1 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
 rootProject.name = "signing-selftest"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,23 +175,24 @@ jobs:
           echo "RESULT: OK — key imports, is not expired, is signing-capable, and the passphrase successfully unlocked it to produce a VALID signature. maven-gpg-plugin will be able to sign with this key/passphrase."
 
   # ---------------------------------------------------------------------------
-  # GPG signing-key preflight — GRADLE / BouncyCastle path (java-llama.cpp ONLY).
-  # The sibling `verify-signing-key` job tests the `gpg` CLI path (maven-gpg-plugin,
-  # used by every repo's Maven publish). This repo ALSO signs the `llama-android`
-  # AAR via Gradle's `signing` plugin + `useInMemoryPgpKeys` (BouncyCastle), which
-  # is STRICTER at parsing the armored key and is exactly where the AAR snapshot
-  # signing failed (null PGPPrivateKey). This job drives `useInMemoryPgpKeys` on a
-  # throwaway signing project — the only faithful test of that path. Standalone
-  # (no `needs:`), parallel at pipeline start, `environment: maven-central` so it
-  # reads the same secret the AAR publish uses. Red-by-design where the secret is
-  # not delivered (see the gpg job's note).
+  # GPG signing-key preflight — GRADLE / BouncyCastle path.
+  # Companion to the `verify-signing-key` (gpg) job above: that one mirrors
+  # maven-gpg-plugin (how the Maven artifacts are signed); this one drives
+  # Gradle's `signing` plugin + `useInMemoryPgpKeys` (BouncyCastle) — the path any
+  # Gradle-based publish (e.g. an Android AAR) uses to sign. BouncyCastle is a
+  # STRICTER parser of the armored key than gpg, so it catches key/format problems
+  # gpg tolerates (e.g. the primary-vs-signing-subkey null-PGPPrivateKey issue).
+  # It signs a throwaway project (.github/signing-selftest/) — no repo build is
+  # involved — so this job is IDENTICAL across the sibling repos and validates the
+  # release key via the Gradle path even in repos that do not publish via Gradle
+  # yet ("prepared for Gradle"). Standalone (no `needs:`), parallel at pipeline
+  # start, `environment: maven-central` so it reads the same secret the publish
+  # uses. Red-by-design where the secret is not delivered (see the gpg job's note).
   #
   # SECURITY: prints no secret material. Key/passphrase reach Gradle only via env
-  # (MAVEN_GPG_PRIVATE_KEY / MAVEN_GPG_PASSPHRASE, read by System.getenv at
-  # runtime); `set -x` is never enabled; the passphrase is `::add-mask::`ed; Gradle
-  # runs with `--stacktrace` only (no `--info`/`--debug`). Only the produced `.asc`
-  # (exit code) is asserted. Uses Gradle 8.14.3 — the same version the AAR publish
-  # uses — so the BouncyCastle version under test matches production.
+  # (read by System.getenv at runtime); `set -x` is never enabled; the passphrase
+  # is `::add-mask::`ed; Gradle runs with `--stacktrace` only. Only the produced
+  # `.asc` (exit code) is asserted. Uses Gradle 8.14.3.
   # ---------------------------------------------------------------------------
   verify-signing-key-gradle:
     name: Verify GPG signing key — Gradle/BouncyCastle path (no secrets printed)
@@ -221,8 +222,6 @@ jobs:
           fi
           if [ -n "${MAVEN_GPG_PASSPHRASE:-}" ]; then echo "::add-mask::${MAVEN_GPG_PASSPHRASE}"; fi
 
-          # The throwaway signing project is committed (readable, reviewable) at
-          # .github/signing-selftest/ — it mirrors llama-android/build.gradle.kts.
           PROJ=".github/signing-selftest"
           echo "== Sign a throwaway artifact through Gradle's useInMemoryPgpKeys (BouncyCastle) =="
           gradle --no-daemon -p "$PROJ" signMakeArtifact --stacktrace
@@ -230,9 +229,9 @@ jobs:
           ASC="$PROJ/build/signing-selftest.zip.asc"
           if [ -f "$ASC" ]; then
             echo "  Detached signature produced: $(wc -c < "$ASC") armored bytes"
-            echo "RESULT: OK — Gradle's useInMemoryPgpKeys accepted the armored key + passphrase and produced a signature. The llama-android AAR publish will be able to sign with this key/passphrase."
+            echo "RESULT: OK — Gradle's useInMemoryPgpKeys accepted the armored key + passphrase and produced a signature."
           else
-            echo "::error::Gradle signing produced no .asc — useInMemoryPgpKeys could not build a usable signatory from MAVEN_GPG_PRIVATE_KEY / MAVEN_GPG_PASSPHRASE (the AAR-publish failure mode)."
+            echo "::error::Gradle signing produced no .asc — useInMemoryPgpKeys could not build a usable signatory from MAVEN_GPG_PRIVATE_KEY / MAVEN_GPG_PASSPHRASE."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Genericizes the `verify-signing-key-gradle` job comment and the `.github/signing-selftest/` project so they are **byte-identical to the sibling repos** (the harness is now a shared "prepared for Gradle" canary, not jllama-specific wording). Follow-up to #306/#307.
- The real `llama-android` AAR signing fix (subkey selection via `MAVEN_GPG_KEY_ID`) is unchanged — this PR only touches the harness wording/files for cross-repo uniformity.

## Test plan

- [x] `verify-signing-key-gradle` already verified green on `main` after #307 (subkey selection works).
- [ ] Re-confirm green on `main` after this cosmetic sync (identical behavior; only comments + SPDX headers changed).

## Related issues / PRs

Refs #306, #307. Cross-repo harness sync (BAF / streambuffer / llamacpp-ai-index carry the identical job).

## Checklist

- [x] My commits follow Conventional Commits
- [x] No behavioral change to the AAR signing path; no secret material exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018pwn51YPBbtiuUyiLRrfrG)_