### PR TITLE
fix(android-llmservice): migrate Kotlin jvmTarget to compilerOptions DSL; Gradle 8.14.4; allowBackup=false

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1131,7 +1131,10 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: "8.14.3"
+          # Kotlin 2.4's Gradle plugin deprecates Gradle < 8.14.4; the app uses the Kotlin
+          # Android plugin, so bump this job to 8.14.4 (also carries two security fixes). The
+          # AAR/lib jobs stay on the more-compatible 8.14.3 — they use no Kotlin Gradle plugin.
+          gradle-version: "8.14.4"
       - name: Enable KVM group permissions (GitHub-hosted runner)
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/android-llmservice/app/build.gradle.kts
+++ b/android-llmservice/app/build.gradle.kts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -82,8 +84,13 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
+}
+
+kotlin {
+    // Kotlin 2.x: the old `android { kotlinOptions { jvmTarget = "17" } }` string DSL is now a
+    // hard error — configure the JVM target through the compilerOptions DSL instead.
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/android-llmservice/app/src/main/AndroidManifest.xml
+++ b/android-llmservice/app/src/main/AndroidManifest.xml
@@ -12,8 +12,14 @@ SPDX-License-Identifier: MIT
       no permission prompt and is fully Google-Play compliant (no MANAGE_EXTERNAL_STORAGE).
       No INTERNET permission either — LLM Service is fully offline; nothing leaves the device.
     -->
+    <!--
+      allowBackup=false: this is a privacy app whose whole promise is that data stays on the
+      device. The saved session (chat content) and the copied model live in private filesDir;
+      disabling backup keeps them out of adb backup and cloud auto-backup so nothing leaves the
+      device that way. Also resolves the CodeQL "Application backup allowed" alert.
+    -->
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
         android:supportsRtl="true"


### PR DESCRIPTION
## Summary

- **Fix the `build-android-llmservice` CI failure.** With Kotlin 2.4.0 the `android { kotlinOptions { jvmTarget = "17" } }` string DSL is now a **hard error**. Migrated to the `compilerOptions` DSL: a top-level `kotlin { compilerOptions { jvmTarget.set(JvmTarget.JVM_17) } }` block (+ `import org.jetbrains.kotlin.gradle.dsl.JvmTarget`).
- **Bump the app CI job to Gradle 8.14.4** (clears the Kotlin-plugin deprecation warning for Gradle < 8.14.4 and picks up two Gradle security fixes). AGP 8.7.3 / Kotlin 2.4.0 stay; the AAR/lib jobs remain on 8.14.3 (they use no Kotlin Gradle plugin, so are unaffected).
- **`allowBackup=false`** in the app manifest — resolves the CodeQL *"Application backup allowed"* alert and matches the app's privacy promise (the saved session + copied model in `filesDir` stay out of adb/cloud backup).

## Test plan

- [ ] Affected unit / integration tests pass locally — _not runnable in this environment (no Android SDK); the failure was at Gradle config/script-compile, so downstream stages (Kotlin compile, Compose, R8, emulator UI test) are validated for the first time by this PR's CI._
- [ ] CI is green on this branch — _to be confirmed by this PR run (`build-android-llmservice`)._
- [x] Docs / CHANGELOG updated where applicable — _n/a: build-config + manifest fix; no doc surface changes._

## Related issues / PRs

Refs #310 (introduced `android-llmservice`; its merge-to-`main` run surfaced this build failure + the CodeQL alert).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes — the `allowBackup=false` change is a public hardening (resolves a code-scanning alert), not a sensitive vulnerability requiring private disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m)_