### PR TITLE
feat(android-llmservice): sampling settings (fix repeat loop), in-app log viewer, draggable model name

### DIFF
--- a/android-llmservice/README.md
+++ b/android-llmservice/README.md
@@ -174,8 +174,8 @@ android-llmservice/
         ├── main/res/values/{strings,themes}.xml + values-*/strings.xml (13 languages)
         ├── main/res/xml/locales_config.xml
         ├── main/kotlin/net/ladenthin/android/llmservice/
-        │   ├── MainActivity.kt      # Compose UI + SAF picker + flag language menu + save/load
-        │   ├── ChatViewModel.kt     # model load + streaming chat + session save/load (the logic)
+        │   ├── MainActivity.kt      # Compose UI + SAF picker + flag menu + save/load + settings + log viewer
+        │   ├── ChatViewModel.kt     # model load + streaming chat + sampling settings + in-app log + session (the logic)
         │   ├── Languages.kt         # the flag/language list
         │   └── SessionStore.kt      # private local JSON persistence (filesDir)
         └── androidTest/kotlin/net/ladenthin/android/llmservice/

--- a/android-llmservice/TODO.md
+++ b/android-llmservice/TODO.md
@@ -45,6 +45,9 @@ Everything else in the brief is feasible with standard AndroidX + the existing b
 | Private local save / load session | ✅ | JSON in `filesDir`, app-private, nothing uploaded |
 | `allowBackup=false` (data stays on device) | ✅ | resolves CodeQL alert; privacy posture |
 | minSdk 28, arm64-v8a + x86_64, signed release `.aab`, on-device emulator UI test | ✅ | |
+| Generation settings sheet (temperature, Top-K/P, Min-P, **repeat penalty**, repeat range, max tokens) | ✅ | ⚙️ in the top bar; live sliders + reset. The repeat-penalty default (1.1) fixes the degenerate repetition loop on small models |
+| In-app log: always-visible one-line strip + full viewer (copy-all, save-as-txt via SAF, clear) | ✅ | 🧾 strip at the bottom; tap to open, ✕ to close |
+| Draggable (horizontally scrollable) model-name title | ✅ | long names can be dragged into view — no auto-marquee wobble |
 
 ---
 
@@ -56,7 +59,7 @@ Everything else in the brief is feasible with standard AndroidX + the existing b
 | Material 3 theme + brand palette (indigo `#476EAC`, lavender, charcoal, cream) | Polished, on-brand look | S–M | 🔧 | currently default `MaterialTheme`; add color scheme + shapes/elevation |
 | Light + dark ("technical dark" / "soft light") | Brief's hybrid direction | S | 🔧 | Compose supports; wire dynamic + manual toggle |
 | Smooth transitions / motion polish | "more polished than a dev demo" | S | ⬜ | Compose animations, shared-element nav |
-| Optional 5th destination: Tools / Logs | Advanced users | S | ⬜ | keep out of bottom bar to avoid crowding (overflow/menu) |
+| Optional 5th destination: Tools / Logs | Advanced users | S | 🔧 | **log** shipped as a bottom strip + full viewer (copy/save-txt/clear); a dedicated Tools destination is still todo |
 
 ## 2. Onboarding & device readiness
 
@@ -76,7 +79,7 @@ Everything else in the brief is feasible with standard AndroidX + the existing b
 | Feature | Purpose | Effort | Status | Notes |
 |---|---|---|---|---|
 | Streaming responses + bubbles | Core chat | S | ✅ | polish to pastel user bubbles / larger AI cards |
-| Top bar: model chip · "Local" · RAM indicator · offline badge · switch | Context + control | M | 🔧 | model name shown; RAM/switch/offline todo |
+| Top bar: model chip · "Local" · RAM indicator · offline badge · switch | Context + control | M | 🔧 | model name shown (now horizontally draggable so long names are fully readable); RAM/switch/offline todo |
 | Markdown rendering (code, lists, tables, headings) | Readable answers | M | ⬜ | add a Compose Markdown renderer (e.g. compose-markdown) |
 | Copy / regenerate / stop / clear-chat actions | Standard chat UX | M | 🔧 | **stop** = `CancellationToken` (façade wires it; `completeSuspend`/flow cancel) |
 | Prompt shortcut chips (Summarize / Explain code / Translate / …) | Fast starts | S | ⬜ | localized prompt templates |
@@ -131,7 +134,7 @@ See decision #1. All rows below assume a new in-app Ktor/NanoHTTPD HTTP layer wr
 |---|---|---|---|---|
 | CPU threads | Tune speed | S | ⬜ | `ModelParameters.setThreads` / `setThreadsBatch` |
 | Context length | Memory vs. history | S | ⬜ | `setCtxSize` |
-| Temperature / Max tokens | Sampling control | S | ⬜ | `withTemperature` / `withNPredict` (+ TopK/TopP/MinP available) |
+| Temperature / Max tokens / Top-K / Top-P / Min-P / **repeat penalty** + range | Sampling control | S | ✅ | shipped in the ⚙️ Generation settings sheet (live sliders + reset); `withTemperature`/`withNPredict`/`withTopK`/`withTopP`/`withMinP`/`withRepeatPenalty`/`withRepeatLastN`. The repeat-penalty default is what stops the small-model repetition loop |
 | GPU acceleration toggle | Speed on Adreno | M | 🔧 | `setGpuLayers`; **Adreno/OpenCL AAR only** (see §7) |
 | Battery saver mode | Protect battery | M | ⬜ | throttle threads / ngl on low battery |
 | Thermal protection | Prevent overheating | M | ⬜ | `PowerManager.getCurrentThermalStatus()` → pause/throttle |

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/ChatViewModel.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/ChatViewModel.kt
@@ -9,6 +9,8 @@ import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import java.io.File
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,6 +52,28 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     /** A localized-at-the-UI error: the [type] selects the template, [detail] fills it in. */
     data class ErrorInfo(val type: ErrorType, val detail: String)
 
+    /**
+     * Sampling / generation knobs surfaced in the Settings sheet. The defaults are chosen to give
+     * a coherent reply on small on-device models: a [repeatPenalty] > 1 with a non-zero
+     * [repeatLastN] is what stops the degenerate "…spezifischen spezifischen…" repetition loop that
+     * a bare greedy/no-penalty decode falls into (the reported SmolVLM-500M behaviour). All are
+     * forwarded verbatim to [InferenceParameters]; see [GenerationSettings.DEFAULT].
+     */
+    data class GenerationSettings(
+        val temperature: Float = 0.7f,
+        val topK: Int = 40,
+        val topP: Float = 0.95f,
+        val minP: Float = 0.05f,
+        val repeatPenalty: Float = 1.1f,
+        val repeatLastN: Int = 64,
+        val maxTokens: Int = 256,
+    ) {
+        companion object {
+            /** The shipped defaults (also the "Reset" target). */
+            val DEFAULT = GenerationSettings()
+        }
+    }
+
     /** Immutable snapshot the Compose UI renders. */
     data class UiState(
         val modelState: ModelState = ModelState.NONE,
@@ -58,10 +82,19 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         val generating: Boolean = false,
         val error: ErrorInfo? = null,
         val notice: Notice? = null,
+        val settings: GenerationSettings = GenerationSettings.DEFAULT,
     )
 
     private val _uiState = MutableStateFlow(UiState())
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    /**
+     * Rolling in-app log (newest last), shown as a one-line strip at the bottom and in full in the
+     * log viewer. Kept separate from [uiState] so per-token chat updates don't re-emit the whole
+     * log list. Capped at [MAX_LOG_LINES]; entries are prefixed with a local wall-clock time.
+     */
+    private val _log = MutableStateFlow<List<String>>(emptyList())
+    val log: StateFlow<List<String>> = _log.asStateFlow()
 
     private var model: LlamaModel? = null
     private var modelPath: String? = null
@@ -75,8 +108,30 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     private var chatTemplate: String? = null
 
     private companion object {
-        const val MAX_TOKENS = 256
         const val CONTEXT_SIZE = 2048
+        const val MAX_LOG_LINES = 500
+    }
+
+    /** Appends one timestamped line to the rolling [log] (trimmed to [MAX_LOG_LINES]). */
+    private fun log(line: String) {
+        val ts = LocalTime.now().truncatedTo(ChronoUnit.SECONDS)
+        _log.update { (it + "$ts  $line").takeLast(MAX_LOG_LINES) }
+    }
+
+    /** Replaces the sampling settings (from the Settings sheet). */
+    fun updateSettings(settings: GenerationSettings) {
+        _uiState.update { it.copy(settings = settings) }
+    }
+
+    /** Restores the shipped default sampling settings. */
+    fun resetSettings() {
+        _uiState.update { it.copy(settings = GenerationSettings.DEFAULT) }
+        log("Settings reset to defaults")
+    }
+
+    /** Clears the in-app log buffer. */
+    fun clearLog() {
+        _log.value = emptyList()
     }
 
     /**
@@ -109,6 +164,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private suspend fun openModel(path: String, displayName: String, template: String?) {
+        log("Loading model: $displayName")
         try {
             val loaded = withContext(Dispatchers.IO) {
                 LlamaModel(
@@ -125,7 +181,9 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             _uiState.update {
                 it.copy(modelState = ModelState.READY, modelName = displayName, error = null)
             }
+            log("Model ready: $displayName (ctx=$CONTEXT_SIZE, CPU)")
         } catch (t: Throwable) {
+            log("Load failed: ${t.message ?: "load failed"}")
             _uiState.update {
                 it.copy(modelState = ModelState.NONE, error = ErrorInfo(ErrorType.LOAD, t.message ?: "load failed"))
             }
@@ -149,13 +207,23 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         // Append an empty assistant message that grows as tokens arrive.
         _uiState.update { it.copy(messages = history + Message("assistant", ""), generating = true, error = null) }
 
+        val s = _uiState.value.settings
         generation = viewModelScope.launch {
             val pairs = history.map { Pair(it.role, it.text) }
+            // Apply the sampling knobs. repeatPenalty (> 1) + repeatLastN are the ones that break
+            // the degenerate repetition loop small on-device models fall into with a bare decode.
             var params = InferenceParameters("")
                 .withMessages(systemPrompt, pairs)
-                .withNPredict(MAX_TOKENS)
+                .withNPredict(s.maxTokens)
+                .withTemperature(s.temperature)
+                .withTopK(s.topK)
+                .withTopP(s.topP)
+                .withMinP(s.minP)
+                .withRepeatPenalty(s.repeatPenalty)
+                .withRepeatLastN(s.repeatLastN)
             chatTemplate?.let { params = params.withChatTemplate(it) }
 
+            log("Generating (temp=${s.temperature}, repeat=${s.repeatPenalty}/${s.repeatLastN}, maxTokens=${s.maxTokens})")
             val reply = StringBuilder()
             try {
                 active.generateChatFlow(params)
@@ -164,7 +232,9 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                         reply.append(output.text)
                         _uiState.update { state -> state.replaceLastAssistant(reply.toString()) }
                     }
+                log("Reply complete (${reply.length} chars)")
             } catch (t: Throwable) {
+                log("Generation failed: ${t.message ?: "generation failed"}")
                 _uiState.update { state ->
                     state.replaceLastAssistant(reply.toString())
                         .copy(error = ErrorInfo(ErrorType.GENERATION, t.message ?: "generation failed"))
@@ -185,6 +255,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             withContext(Dispatchers.IO) {
                 SessionStore.save(getApplication(), pathAtSave, nameAtSave, messagesAtSave)
             }
+            log("Session saved (${messagesAtSave.size} messages)")
             _uiState.update { it.copy(notice = Notice.SESSION_SAVED) }
         }
     }
@@ -194,9 +265,11 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             val saved = withContext(Dispatchers.IO) { SessionStore.load(getApplication()) }
             if (saved == null) {
+                log("Load session: no saved chat")
                 _uiState.update { it.copy(notice = Notice.NO_SESSION) }
                 return@launch
             }
+            log("Session loaded (${saved.messages.size} messages)")
             _uiState.update { it.copy(messages = saved.messages, notice = Notice.SESSION_LOADED) }
             val path = saved.modelPath
             if (path != null && File(path).canRead() && modelPath != path) {

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
@@ -8,23 +8,31 @@ import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import android.provider.OpenableColumns
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -34,6 +42,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -48,13 +57,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.util.Locale
+import kotlin.math.roundToInt
 
 /**
  * Single-screen KISS demo: pick a GGUF from the file system, then chat with it fully on-device.
@@ -117,10 +133,22 @@ private fun ChatScreen(viewModel: ChatViewModel) {
         }
     }
 
+    var showSettings by remember { mutableStateOf(false) }
+    var showLog by remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(state.modelName ?: stringResource(R.string.app_name)) },
+                title = {
+                    // Horizontally scrollable so a long model name can be dragged into view in full,
+                    // without an auto-scrolling marquee that would "wobble" constantly.
+                    Text(
+                        text = state.modelName ?: stringResource(R.string.app_name),
+                        maxLines = 1,
+                        softWrap = false,
+                        modifier = Modifier.horizontalScroll(rememberScrollState()),
+                    )
+                },
                 actions = {
                     IconButton(
                         onClick = { viewModel.saveSession() },
@@ -131,10 +159,14 @@ private fun ChatScreen(viewModel: ChatViewModel) {
                     IconButton(onClick = { viewModel.loadSession() }) {
                         Text("📂", modifier = Modifier.testTag("loadButton"))
                     }
+                    IconButton(onClick = { showSettings = true }) {
+                        Text("⚙️", modifier = Modifier.testTag("settingsButton"))
+                    }
                     LanguageMenu()
                 },
             )
         },
+        bottomBar = { LogStrip(viewModel = viewModel, onOpen = { showLog = true }) },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
@@ -150,6 +182,161 @@ private fun ChatScreen(viewModel: ChatViewModel) {
                     Conversation(state = state, onSend = viewModel::send, onChoose = onChoose)
             }
         }
+    }
+
+    if (showSettings) {
+        SettingsDialog(
+            settings = state.settings,
+            onChange = viewModel::updateSettings,
+            onReset = viewModel::resetSettings,
+            onClose = { showSettings = false },
+        )
+    }
+    if (showLog) {
+        LogDialog(viewModel = viewModel, onClose = { showLog = false })
+    }
+}
+
+/** The always-visible one-line log strip at the very bottom; tap to open the full [LogDialog]. */
+@Composable
+private fun LogStrip(viewModel: ChatViewModel, onOpen: () -> Unit) {
+    val log by viewModel.log.collectAsStateWithLifecycle()
+    val last = log.lastOrNull() ?: stringResource(R.string.log_empty)
+    Surface(tonalElevation = 2.dp) {
+        Row(
+            modifier = Modifier.fillMaxWidth().clickable(onClick = onOpen).testTag("logStrip")
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("🧾", modifier = Modifier.padding(end = 8.dp))
+            Text(
+                text = last,
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+/** Full-screen log viewer with copy-all, save-as-txt (SAF) and clear; ✕ (top-right) closes it. */
+@Composable
+private fun LogDialog(viewModel: ChatViewModel, onClose: () -> Unit) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val log by viewModel.log.collectAsStateWithLifecycle()
+    val text = log.joinToString("\n")
+    val copiedMsg = stringResource(R.string.toast_log_copied)
+    val savedMsg = stringResource(R.string.toast_log_saved)
+
+    val saver = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("text/plain")) { uri: Uri? ->
+        if (uri != null) {
+            context.contentResolver.openOutputStream(uri)?.use { it.write(text.toByteArray(Charsets.UTF_8)) }
+            Toast.makeText(context, savedMsg, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    Dialog(onDismissRequest = onClose, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Surface(modifier = Modifier.fillMaxSize().padding(12.dp), shape = MaterialTheme.shapes.large) {
+            Column(modifier = Modifier.fillMaxSize().padding(12.dp)) {
+                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = stringResource(R.string.log_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(onClick = onClose) { Text("✕", modifier = Modifier.testTag("logClose")) }
+                }
+                SelectionContainer(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                    Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                        Text(
+                            text = text.ifEmpty { stringResource(R.string.log_empty) },
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(onClick = { viewModel.clearLog() }) { Text(stringResource(R.string.log_clear)) }
+                    TextButton(
+                        onClick = {
+                            clipboard.setText(AnnotatedString(text))
+                            Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+                        },
+                        enabled = text.isNotEmpty(),
+                    ) {
+                        Text(stringResource(R.string.log_copy_all))
+                    }
+                    TextButton(onClick = { saver.launch("llm-service-log.txt") }, enabled = text.isNotEmpty()) {
+                        Text(stringResource(R.string.log_save_as))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Sampling-knobs sheet. Changes apply live; "Reset defaults" restores the shipped values. */
+@Composable
+private fun SettingsDialog(
+    settings: ChatViewModel.GenerationSettings,
+    onChange: (ChatViewModel.GenerationSettings) -> Unit,
+    onReset: () -> Unit,
+    onClose: () -> Unit,
+) {
+    Dialog(onDismissRequest = onClose) {
+        Surface(shape = MaterialTheme.shapes.large, tonalElevation = 6.dp) {
+            Column(modifier = Modifier.padding(20.dp).verticalScroll(rememberScrollState())) {
+                Text(stringResource(R.string.settings_title), style = MaterialTheme.typography.titleLarge)
+                Spacer(Modifier.height(12.dp))
+                FloatSetting(R.string.settings_temperature, settings.temperature, 0f..2f) {
+                    onChange(settings.copy(temperature = it))
+                }
+                IntSetting(R.string.settings_top_k, settings.topK, 0..100) { onChange(settings.copy(topK = it)) }
+                FloatSetting(R.string.settings_top_p, settings.topP, 0f..1f) { onChange(settings.copy(topP = it)) }
+                FloatSetting(R.string.settings_min_p, settings.minP, 0f..1f) { onChange(settings.copy(minP = it)) }
+                FloatSetting(R.string.settings_repeat_penalty, settings.repeatPenalty, 1f..2f) {
+                    onChange(settings.copy(repeatPenalty = it))
+                }
+                IntSetting(R.string.settings_repeat_last_n, settings.repeatLastN, 0..256) {
+                    onChange(settings.copy(repeatLastN = it))
+                }
+                IntSetting(R.string.settings_max_tokens, settings.maxTokens, 16..1024) {
+                    onChange(settings.copy(maxTokens = it))
+                }
+                Spacer(Modifier.height(8.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = onReset) { Text(stringResource(R.string.settings_reset)) }
+                    TextButton(onClick = onClose) { Text(stringResource(R.string.action_close)) }
+                }
+            }
+        }
+    }
+}
+
+/** A labelled float slider showing its current value (2 decimals, locale-independent). */
+@Composable
+private fun FloatSetting(labelRes: Int, value: Float, range: ClosedFloatingPointRange<Float>, onChange: (Float) -> Unit) {
+    Column(modifier = Modifier.padding(vertical = 4.dp)) {
+        Text("${stringResource(labelRes)}: ${String.format(Locale.US, "%.2f", value)}", style = MaterialTheme.typography.bodyMedium)
+        Slider(value = value, onValueChange = onChange, valueRange = range)
+    }
+}
+
+/** A labelled integer slider (rounds the slider's float to the nearest int). */
+@Composable
+private fun IntSetting(labelRes: Int, value: Int, range: IntRange, onChange: (Int) -> Unit) {
+    Column(modifier = Modifier.padding(vertical = 4.dp)) {
+        Text("${stringResource(labelRes)}: $value", style = MaterialTheme.typography.bodyMedium)
+        Slider(
+            value = value.toFloat(),
+            onValueChange = { onChange(it.roundToInt()) },
+            valueRange = range.first.toFloat()..range.last.toFloat(),
+        )
     }
 }
 

--- a/android-llmservice/app/src/main/res/values-ar/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ar/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">تم حفظ المحادثة</string>
     <string name="toast_session_loaded">تم تحميل المحادثة</string>
     <string name="toast_session_none">لا توجد محادثة محفوظة</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">الإعدادات</string>
+    <string name="settings_title">إعدادات التوليد</string>
+    <string name="settings_temperature">درجة الحرارة</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">عقوبة التكرار</string>
+    <string name="settings_repeat_last_n">نطاق التكرار</string>
+    <string name="settings_max_tokens">الحد الأقصى للرموز</string>
+    <string name="settings_reset">إعادة التعيين إلى الافتراضي</string>
+    <string name="action_close">إغلاق</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">السجل</string>
+    <string name="log_title">السجل</string>
+    <string name="log_empty">لا يوجد إخراج للسجل بعد.</string>
+    <string name="log_copy_all">نسخ الكل</string>
+    <string name="log_save_as">حفظ باسم…</string>
+    <string name="log_clear">مسح</string>
+    <string name="toast_log_copied">تم نسخ السجل</string>
+    <string name="toast_log_saved">تم حفظ السجل</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-de/strings.xml
+++ b/android-llmservice/app/src/main/res/values-de/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">Chat gespeichert</string>
     <string name="toast_session_loaded">Chat geladen</string>
     <string name="toast_session_none">Kein gespeicherter Chat</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">Einstellungen</string>
+    <string name="settings_title">Generierungseinstellungen</string>
+    <string name="settings_temperature">Temperatur</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">Wiederholungsstrafe</string>
+    <string name="settings_repeat_last_n">Wiederholungsbereich</string>
+    <string name="settings_max_tokens">Max. Tokens</string>
+    <string name="settings_reset">Standard wiederherstellen</string>
+    <string name="action_close">Schließen</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">Protokoll</string>
+    <string name="log_title">Protokoll</string>
+    <string name="log_empty">Noch keine Protokollausgabe.</string>
+    <string name="log_copy_all">Alles kopieren</string>
+    <string name="log_save_as">Speichern unter…</string>
+    <string name="log_clear">Leeren</string>
+    <string name="toast_log_copied">Protokoll kopiert</string>
+    <string name="toast_log_saved">Protokoll gespeichert</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-es/strings.xml
+++ b/android-llmservice/app/src/main/res/values-es/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">Chat guardado</string>
     <string name="toast_session_loaded">Chat cargado</string>
     <string name="toast_session_none">No hay chat guardado</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">Ajustes</string>
+    <string name="settings_title">Ajustes de generación</string>
+    <string name="settings_temperature">Temperatura</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">Penalización por repetición</string>
+    <string name="settings_repeat_last_n">Rango de repetición</string>
+    <string name="settings_max_tokens">Tokens máximos</string>
+    <string name="settings_reset">Restablecer valores</string>
+    <string name="action_close">Cerrar</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">Registro</string>
+    <string name="log_title">Registro</string>
+    <string name="log_empty">Aún no hay salida de registro.</string>
+    <string name="log_copy_all">Copiar todo</string>
+    <string name="log_save_as">Guardar como…</string>
+    <string name="log_clear">Borrar</string>
+    <string name="toast_log_copied">Registro copiado</string>
+    <string name="toast_log_saved">Registro guardado</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-fr/strings.xml
+++ b/android-llmservice/app/src/main/res/values-fr/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">Discussion enregistrée</string>
     <string name="toast_session_loaded">Discussion chargée</string>
     <string name="toast_session_none">Aucune discussion enregistrée</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">Paramètres</string>
+    <string name="settings_title">Paramètres de génération</string>
+    <string name="settings_temperature">Température</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">Pénalité de répétition</string>
+    <string name="settings_repeat_last_n">Portée de répétition</string>
+    <string name="settings_max_tokens">Jetons max</string>
+    <string name="settings_reset">Réinitialiser</string>
+    <string name="action_close">Fermer</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">Journal</string>
+    <string name="log_title">Journal</string>
+    <string name="log_empty">Aucune sortie de journal pour l\'instant.</string>
+    <string name="log_copy_all">Tout copier</string>
+    <string name="log_save_as">Enregistrer sous…</string>
+    <string name="log_clear">Effacer</string>
+    <string name="toast_log_copied">Journal copié</string>
+    <string name="toast_log_saved">Journal enregistré</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-hi/strings.xml
+++ b/android-llmservice/app/src/main/res/values-hi/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">चैट सहेजी गई</string>
     <string name="toast_session_loaded">चैट लोड हो गई</string>
     <string name="toast_session_none">कोई सहेजी गई चैट नहीं</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">सेटिंग्स</string>
+    <string name="settings_title">जनरेशन सेटिंग्स</string>
+    <string name="settings_temperature">तापमान</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">दोहराव दंड</string>
+    <string name="settings_repeat_last_n">दोहराव सीमा</string>
+    <string name="settings_max_tokens">अधिकतम टोकन</string>
+    <string name="settings_reset">डिफ़ॉल्ट रीसेट करें</string>
+    <string name="action_close">बंद करें</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">लॉग</string>
+    <string name="log_title">लॉग</string>
+    <string name="log_empty">अभी तक कोई लॉग आउटपुट नहीं।</string>
+    <string name="log_copy_all">सभी कॉपी करें</string>
+    <string name="log_save_as">इस रूप में सहेजें…</string>
+    <string name="log_clear">साफ़ करें</string>
+    <string name="toast_log_copied">लॉग कॉपी किया गया</string>
+    <string name="toast_log_saved">लॉग सहेजा गया</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-it/strings.xml
+++ b/android-llmservice/app/src/main/res/values-it/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">Chat salvata</string>
     <string name="toast_session_loaded">Chat caricata</string>
     <string name="toast_session_none">Nessuna chat salvata</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">Impostazioni</string>
+    <string name="settings_title">Impostazioni di generazione</string>
+    <string name="settings_temperature">Temperatura</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">Penalità di ripetizione</string>
+    <string name="settings_repeat_last_n">Intervallo di ripetizione</string>
+    <string name="settings_max_tokens">Token massimi</string>
+    <string name="settings_reset">Ripristina predefiniti</string>
+    <string name="action_close">Chiudi</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">Registro</string>
+    <string name="log_title">Registro</string>
+    <string name="log_empty">Nessun output di registro ancora.</string>
+    <string name="log_copy_all">Copia tutto</string>
+    <string name="log_save_as">Salva con nome…</string>
+    <string name="log_clear">Cancella</string>
+    <string name="toast_log_copied">Registro copiato</string>
+    <string name="toast_log_saved">Registro salvato</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ja/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ja/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">チャットを保存しました</string>
     <string name="toast_session_loaded">チャットを読み込みました</string>
     <string name="toast_session_none">保存されたチャットはありません</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">設定</string>
+    <string name="settings_title">生成設定</string>
+    <string name="settings_temperature">温度</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">繰り返しペナルティ</string>
+    <string name="settings_repeat_last_n">繰り返し範囲</string>
+    <string name="settings_max_tokens">最大トークン数</string>
+    <string name="settings_reset">デフォルトに戻す</string>
+    <string name="action_close">閉じる</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">ログ</string>
+    <string name="log_title">ログ</string>
+    <string name="log_empty">まだログ出力がありません。</string>
+    <string name="log_copy_all">すべてコピー</string>
+    <string name="log_save_as">名前を付けて保存…</string>
+    <string name="log_clear">クリア</string>
+    <string name="toast_log_copied">ログをコピーしました</string>
+    <string name="toast_log_saved">ログを保存しました</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ko/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ko/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">채팅이 저장되었습니다</string>
     <string name="toast_session_loaded">채팅을 불러왔습니다</string>
     <string name="toast_session_none">저장된 채팅이 없습니다</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">설정</string>
+    <string name="settings_title">생성 설정</string>
+    <string name="settings_temperature">온도</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">반복 페널티</string>
+    <string name="settings_repeat_last_n">반복 범위</string>
+    <string name="settings_max_tokens">최대 토큰</string>
+    <string name="settings_reset">기본값으로 재설정</string>
+    <string name="action_close">닫기</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">로그</string>
+    <string name="log_title">로그</string>
+    <string name="log_empty">아직 로그 출력이 없습니다.</string>
+    <string name="log_copy_all">모두 복사</string>
+    <string name="log_save_as">다른 이름으로 저장…</string>
+    <string name="log_clear">지우기</string>
+    <string name="toast_log_copied">로그 복사됨</string>
+    <string name="toast_log_saved">로그 저장됨</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-pt/strings.xml
+++ b/android-llmservice/app/src/main/res/values-pt/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">Conversa salva</string>
     <string name="toast_session_loaded">Conversa carregada</string>
     <string name="toast_session_none">Nenhuma conversa salva</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">Definições</string>
+    <string name="settings_title">Definições de geração</string>
+    <string name="settings_temperature">Temperatura</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">Penalização de repetição</string>
+    <string name="settings_repeat_last_n">Intervalo de repetição</string>
+    <string name="settings_max_tokens">Tokens máximos</string>
+    <string name="settings_reset">Repor predefinições</string>
+    <string name="action_close">Fechar</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">Registo</string>
+    <string name="log_title">Registo</string>
+    <string name="log_empty">Ainda sem saída de registo.</string>
+    <string name="log_copy_all">Copiar tudo</string>
+    <string name="log_save_as">Guardar como…</string>
+    <string name="log_clear">Limpar</string>
+    <string name="toast_log_copied">Registo copiado</string>
+    <string name="toast_log_saved">Registo guardado</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ru/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ru/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">Чат сохранён</string>
     <string name="toast_session_loaded">Чат загружен</string>
     <string name="toast_session_none">Нет сохранённого чата</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">Настройки</string>
+    <string name="settings_title">Параметры генерации</string>
+    <string name="settings_temperature">Температура</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">Штраф за повтор</string>
+    <string name="settings_repeat_last_n">Диапазон повтора</string>
+    <string name="settings_max_tokens">Макс. токенов</string>
+    <string name="settings_reset">Сбросить настройки</string>
+    <string name="action_close">Закрыть</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">Журнал</string>
+    <string name="log_title">Журнал</string>
+    <string name="log_empty">Пока нет записей журнала.</string>
+    <string name="log_copy_all">Копировать всё</string>
+    <string name="log_save_as">Сохранить как…</string>
+    <string name="log_clear">Очистить</string>
+    <string name="toast_log_copied">Журнал скопирован</string>
+    <string name="toast_log_saved">Журнал сохранён</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-tr/strings.xml
+++ b/android-llmservice/app/src/main/res/values-tr/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">Sohbet kaydedildi</string>
     <string name="toast_session_loaded">Sohbet yüklendi</string>
     <string name="toast_session_none">Kayıtlı sohbet yok</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">Ayarlar</string>
+    <string name="settings_title">Üretim ayarları</string>
+    <string name="settings_temperature">Sıcaklık</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">Tekrar cezası</string>
+    <string name="settings_repeat_last_n">Tekrar aralığı</string>
+    <string name="settings_max_tokens">Maks. jeton</string>
+    <string name="settings_reset">Varsayılanlara sıfırla</string>
+    <string name="action_close">Kapat</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">Günlük</string>
+    <string name="log_title">Günlük</string>
+    <string name="log_empty">Henüz günlük çıktısı yok.</string>
+    <string name="log_copy_all">Tümünü kopyala</string>
+    <string name="log_save_as">Farklı kaydet…</string>
+    <string name="log_clear">Temizle</string>
+    <string name="toast_log_copied">Günlük kopyalandı</string>
+    <string name="toast_log_saved">Günlük kaydedildi</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android-llmservice/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,4 +20,26 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">对话已保存</string>
     <string name="toast_session_loaded">对话已加载</string>
     <string name="toast_session_none">没有已保存的对话</string>
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">设置</string>
+    <string name="settings_title">生成设置</string>
+    <string name="settings_temperature">温度</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">重复惩罚</string>
+    <string name="settings_repeat_last_n">重复范围</string>
+    <string name="settings_max_tokens">最大令牌数</string>
+    <string name="settings_reset">恢复默认</string>
+    <string name="action_close">关闭</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">日志</string>
+    <string name="log_title">日志</string>
+    <string name="log_empty">暂无日志输出。</string>
+    <string name="log_copy_all">全部复制</string>
+    <string name="log_save_as">另存为…</string>
+    <string name="log_clear">清除</string>
+    <string name="toast_log_copied">日志已复制</string>
+    <string name="toast_log_saved">日志已保存</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values/strings.xml
+++ b/android-llmservice/app/src/main/res/values/strings.xml
@@ -23,4 +23,27 @@ SPDX-License-Identifier: MIT
     <string name="toast_session_saved">Chat saved</string>
     <string name="toast_session_loaded">Chat loaded</string>
     <string name="toast_session_none">No saved chat</string>
+
+    <!-- Settings sheet (sampling knobs). Top-K/Top-P/Min-P are technical terms kept as-is. -->
+    <string name="cd_settings">Settings</string>
+    <string name="settings_title">Generation settings</string>
+    <string name="settings_temperature">Temperature</string>
+    <string name="settings_top_k">Top-K</string>
+    <string name="settings_top_p">Top-P</string>
+    <string name="settings_min_p">Min-P</string>
+    <string name="settings_repeat_penalty">Repeat penalty</string>
+    <string name="settings_repeat_last_n">Repeat range</string>
+    <string name="settings_max_tokens">Max tokens</string>
+    <string name="settings_reset">Reset defaults</string>
+    <string name="action_close">Close</string>
+
+    <!-- Log strip + log viewer -->
+    <string name="cd_log">Log</string>
+    <string name="log_title">Log</string>
+    <string name="log_empty">No log output yet.</string>
+    <string name="log_copy_all">Copy all</string>
+    <string name="log_save_as">Save as…</string>
+    <string name="log_clear">Clear</string>
+    <string name="toast_log_copied">Log copied</string>
+    <string name="toast_log_saved">Log saved</string>
 </resources>


### PR DESCRIPTION
## Summary

On-device feedback: SmolVLM-500M returned a degenerate `…spezifischen spezifischen…` repetition loop, and the model name was cut off in the top bar. Root cause of the loop: `ChatViewModel.send()` set **no sampling parameters at all** (no repeat penalty, no temperature) — a bare decode on a small model collapses into repetition.

- **Generation settings sheet** (⚙️ in the top bar): live sliders for temperature, Top‑K, Top‑P, Min‑P, **repeat penalty**, repeat range and max tokens, plus *Reset defaults*. `send()` now forwards these to `InferenceParameters` (`withTemperature`/`withTopK`/`withTopP`/`withMinP`/`withRepeatPenalty`/`withRepeatLastN`/`withNPredict`). The default **repeat penalty 1.1 + repeat range 64** is what breaks the repetition loop.
- **In-app log**: an always-visible one-line strip at the bottom (🧾, wraps to 2 display lines) that opens a full-screen viewer with **copy-all**, **save-as-.txt** (SAF `CreateDocument`) and **clear**; ✕ closes it. `ChatViewModel` keeps a capped rolling log (model load/ready, generation start/finish, errors, session save/load, settings reset).
- **Draggable model name**: the top-bar title is now horizontally scrollable, so a long name can be dragged fully into view — single line, no auto-marquee wobble.
- **i18n**: new UI strings added to the default resources and translated across all **13** shipped languages.
- Docs: `android-llmservice/TODO.md` + `README.md` updated to reflect what shipped; remaining items (dedicated Tools destination, RAM/switch top-bar chips, CPU-threads / context-length settings) stay tracked.

No new files, no new dependencies (SAF + clipboard + `java.time` only). The instrumented UI test's tags (`promptInput`/`sendButton`) and `uiState` contract are unchanged.

## Test plan

- [ ] Affected unit / integration tests pass locally
- [x] CI is green on this branch — the `build-android-llmservice` job compiles the app + runs the on-device Compose test on the emulator (validates the new settings/log UI compiles and inference still streams)
- [x] Docs / CHANGELOG updated where applicable — `TODO.md` + `README.md`

## Related issues / PRs

Follow-up to the `android-llmservice` app (PRs #310–#313). No related issue number.

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m)_