### PR TITLE
feat(android-llmservice): chat actions — stop, copy, regenerate, clear + offline badge

### DIFF
--- a/android-llmservice/README.md
+++ b/android-llmservice/README.md
@@ -174,8 +174,8 @@ android-llmservice/
         ├── main/res/values/{strings,themes}.xml + values-*/strings.xml (13 languages)
         ├── main/res/xml/locales_config.xml
         ├── main/kotlin/net/ladenthin/android/llmservice/
-        │   ├── MainActivity.kt      # Compose UI + SAF picker + flag menu + save/load + settings + log viewer
-        │   ├── ChatViewModel.kt     # model load + streaming chat + sampling settings + in-app log + session (the logic)
+        │   ├── MainActivity.kt      # Compose UI + SAF picker + flag menu + save/load + settings + log + chat actions (stop/copy/regenerate/clear)
+        │   ├── ChatViewModel.kt     # model load + streaming chat (stop/regenerate) + sampling settings + in-app log + session (the logic)
         │   ├── Languages.kt         # the flag/language list
         │   └── SessionStore.kt      # private local JSON persistence (filesDir)
         └── androidTest/kotlin/net/ladenthin/android/llmservice/

--- a/android-llmservice/TODO.md
+++ b/android-llmservice/TODO.md
@@ -72,7 +72,7 @@ Everything else in the brief is feasible with standard AndroidX + the existing b
 | Battery level / charging | Warn on heavy inference | XS | ⬜ | `BatteryManager` |
 | GPU acceleration available? | Show if Adreno/OpenCL usable | M | ⬜ | only the OpenCL/Adreno AAR path (see §7); detect ICD presence |
 | Recommended model size heuristic | Approachable guidance | S | ⬜ | derive from free RAM + quant table |
-| Offline-mode status badge | Reinforce privacy | XS | ✅/🔧 | app is already offline; surface it |
+| Offline-mode status badge | Reinforce privacy | XS | ✅ | "🔒 Offline · fully on-device" chip on the model-picker screen |
 
 ## 3. Chat screen
 
@@ -81,7 +81,7 @@ Everything else in the brief is feasible with standard AndroidX + the existing b
 | Streaming responses + bubbles | Core chat | S | ✅ | polish to pastel user bubbles / larger AI cards |
 | Top bar: model chip · "Local" · RAM indicator · offline badge · switch | Context + control | M | 🔧 | model name shown (now horizontally draggable so long names are fully readable); RAM/switch/offline todo |
 | Markdown rendering (code, lists, tables, headings) | Readable answers | M | ⬜ | add a Compose Markdown renderer (e.g. compose-markdown) |
-| Copy / regenerate / stop / clear-chat actions | Standard chat UX | M | 🔧 | **stop** = `CancellationToken` (façade wires it; `completeSuspend`/flow cancel) |
+| Copy / regenerate / stop / clear-chat actions | Standard chat UX | M | ✅ | **stop** cancels the streaming coroutine (façade closes the source); **copy**/**regenerate** act on the last reply; **clear** in the top bar with a confirm. Per-message copy (any bubble) is a possible follow-up |
 | Prompt shortcut chips (Summarize / Explain code / Translate / …) | Fast starts | S | ⬜ | localized prompt templates |
 | Attachment button → image input (vision) | Multimodal chat | L | ⬜ | `ContentPart.imageFile(...)` + a **vision GGUF + mmproj**; SAF image picker |
 | Audio input (speech) | Multimodal chat | L | ⬜ | `ContentPart.audioFile(...)` + an audio-capable model + mmproj |
@@ -123,7 +123,7 @@ See decision #1. All rows below assume a new in-app Ktor/NanoHTTPD HTTP layer wr
 | Feature | Purpose | Effort | Status | Notes |
 |---|---|---|---|---|
 | Offline mode toggle | Reinforce/lock offline | XS | 🔧 | app is already networkless; make it explicit |
-| Clear chat history | Control | XS | ⬜ | complements save/load |
+| Clear chat history | Control | XS | ✅ | 🗑 in the top bar (confirm dialog); complements save/load |
 | Encrypt local conversations | Protect the saved session | M | ⬜ | Jetpack `security-crypto` `EncryptedFile` |
 | "No analytics / no tracking" transparency | Trust | XS | ✅ | trivially true today; surface it |
 | Require biometric unlock | Protect the app | M | ⬜ | `androidx.biometric` |

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/ChatViewModel.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/ChatViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import java.io.File
 import java.time.LocalTime
 import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -202,9 +203,35 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         if (text.isEmpty() || active == null || _uiState.value.generating) {
             return
         }
+        startGeneration(active, _uiState.value.messages + Message("user", text), systemPrompt)
+    }
 
-        val history = _uiState.value.messages + Message("user", text)
-        // Append an empty assistant message that grows as tokens arrive.
+    /**
+     * Regenerates the reply to the most recent user turn: drops the trailing assistant reply and
+     * re-runs generation from the conversation up to and including that user turn. No-op if busy,
+     * no model, or there is no user turn yet. Useful after tuning the sampling settings.
+     *
+     * @param systemPrompt the localized system prompt (resolved from resources by the UI)
+     */
+    fun regenerate(systemPrompt: String) {
+        val active = model
+        if (active == null || _uiState.value.generating) {
+            return
+        }
+        val messages = _uiState.value.messages
+        val lastUserIdx = messages.indexOfLast { it.role == "user" }
+        if (lastUserIdx < 0) {
+            return
+        }
+        log("Regenerating reply")
+        startGeneration(active, messages.subList(0, lastUserIdx + 1).toList(), systemPrompt)
+    }
+
+    /**
+     * Shared streaming path for [send] and [regenerate]. [history] must already end with the user
+     * turn to answer; this appends the empty assistant message that grows as tokens arrive.
+     */
+    private fun startGeneration(active: LlamaModel, history: List<Message>, systemPrompt: String) {
         _uiState.update { it.copy(messages = history + Message("assistant", ""), generating = true, error = null) }
 
         val s = _uiState.value.settings
@@ -233,6 +260,10 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                         _uiState.update { state -> state.replaceLastAssistant(reply.toString()) }
                     }
                 log("Reply complete (${reply.length} chars)")
+            } catch (t: CancellationException) {
+                // User pressed Stop: keep the partial reply, no error. Rethrow to honour cancellation.
+                _uiState.update { state -> state.replaceLastAssistant(reply.toString()) }
+                throw t
             } catch (t: Throwable) {
                 log("Generation failed: ${t.message ?: "generation failed"}")
                 _uiState.update { state ->
@@ -243,6 +274,23 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                 _uiState.update { it.copy(generating = false) }
             }
         }
+    }
+
+    /** Cancels an in-flight generation, keeping whatever partial reply has streamed so far. */
+    fun stopGeneration() {
+        if (_uiState.value.generating) {
+            log("Generation stopped")
+            generation?.cancel()
+        }
+    }
+
+    /** Clears the current conversation. No-op while generating (the UI disables it then). */
+    fun clearChat() {
+        if (_uiState.value.generating) {
+            return
+        }
+        _uiState.update { it.copy(messages = emptyList(), error = null) }
+        log("Chat cleared")
     }
 
     /** Saves the current conversation (and its model path) to private local storage. */

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -135,6 +136,7 @@ private fun ChatScreen(viewModel: ChatViewModel) {
 
     var showSettings by remember { mutableStateOf(false) }
     var showLog by remember { mutableStateOf(false) }
+    var showClearConfirm by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -159,6 +161,12 @@ private fun ChatScreen(viewModel: ChatViewModel) {
                     IconButton(onClick = { viewModel.loadSession() }) {
                         Text("📂", modifier = Modifier.testTag("loadButton"))
                     }
+                    IconButton(
+                        onClick = { showClearConfirm = true },
+                        enabled = state.messages.isNotEmpty() && !state.generating,
+                    ) {
+                        Text("🗑", modifier = Modifier.testTag("clearButton"))
+                    }
                     IconButton(onClick = { showSettings = true }) {
                         Text("⚙️", modifier = Modifier.testTag("settingsButton"))
                     }
@@ -179,11 +187,33 @@ private fun ChatScreen(viewModel: ChatViewModel) {
                     ChooseModelView(error = errorText(state.error), onChoose = onChoose)
 
                 else ->
-                    Conversation(state = state, onSend = viewModel::send, onChoose = onChoose)
+                    Conversation(
+                        state = state,
+                        onSend = viewModel::send,
+                        onStop = viewModel::stopGeneration,
+                        onRegenerate = viewModel::regenerate,
+                        onChoose = onChoose,
+                    )
             }
         }
     }
 
+    if (showClearConfirm) {
+        AlertDialog(
+            onDismissRequest = { showClearConfirm = false },
+            title = { Text(stringResource(R.string.clear_confirm_title)) },
+            text = { Text(stringResource(R.string.clear_confirm_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.clearChat()
+                    showClearConfirm = false
+                }) { Text(stringResource(R.string.action_clear)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearConfirm = false }) { Text(stringResource(R.string.action_cancel)) }
+            },
+        )
+    }
     if (showSettings) {
         SettingsDialog(
             settings = state.settings,
@@ -387,6 +417,7 @@ private fun ChooseModelView(error: String?, onChoose: () -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
+        OfflineBadge(modifier = Modifier.padding(bottom = 16.dp))
         Text(text = stringResource(R.string.intro_pick_model), textAlign = TextAlign.Center)
         Button(
             onClick = onChoose,
@@ -404,9 +435,14 @@ private fun ChooseModelView(error: String?, onChoose: () -> Unit) {
 private fun Conversation(
     state: ChatViewModel.UiState,
     onSend: (String, String) -> Unit,
+    onStop: () -> Unit,
+    onRegenerate: (String) -> Unit,
     onChoose: () -> Unit,
 ) {
     val systemPrompt = stringResource(R.string.system_prompt)
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val copiedMsg = stringResource(R.string.toast_copied)
     Column(modifier = Modifier.fillMaxSize()) {
         val listState = rememberLazyListState()
         LaunchedEffect(state.messages.size, state.messages.lastOrNull()?.text) {
@@ -420,6 +456,33 @@ private fun Conversation(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             items(state.messages) { message -> MessageBubble(message) }
+        }
+
+        // Copy / Regenerate act on the last assistant reply, shown only when it's a finished,
+        // non-empty reply and we're idle.
+        val lastReply = state.messages.lastOrNull()?.takeIf { it.role == "assistant" && it.text.isNotBlank() }
+        if (lastReply != null && !state.generating && state.modelState == ChatViewModel.ModelState.READY) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(
+                    onClick = {
+                        clipboard.setText(AnnotatedString(lastReply.text))
+                        Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+                    },
+                    modifier = Modifier.testTag("copyButton"),
+                ) {
+                    Text(stringResource(R.string.action_copy))
+                }
+                TextButton(
+                    onClick = { onRegenerate(systemPrompt) },
+                    modifier = Modifier.testTag("regenerateButton"),
+                ) {
+                    Text(stringResource(R.string.action_regenerate))
+                }
+            }
         }
 
         if (state.modelState != ChatViewModel.ModelState.READY) {
@@ -447,17 +510,43 @@ private fun Conversation(
                 placeholder = { Text(stringResource(R.string.hint_message)) },
                 enabled = ready && !state.generating,
             )
-            Button(
-                onClick = {
-                    onSend(draft, systemPrompt)
-                    draft = ""
-                },
-                enabled = ready && !state.generating && draft.isNotBlank(),
-                modifier = Modifier.padding(start = 8.dp).testTag("sendButton"),
-            ) {
-                Text(stringResource(R.string.action_send))
+            if (state.generating) {
+                // Swap Send for Stop while a reply streams, so a runaway/repetitive reply can be cut off.
+                Button(
+                    onClick = onStop,
+                    modifier = Modifier.padding(start = 8.dp).testTag("stopButton"),
+                ) {
+                    Text(stringResource(R.string.action_stop))
+                }
+            } else {
+                Button(
+                    onClick = {
+                        onSend(draft, systemPrompt)
+                        draft = ""
+                    },
+                    enabled = ready && draft.isNotBlank(),
+                    modifier = Modifier.padding(start = 8.dp).testTag("sendButton"),
+                ) {
+                    Text(stringResource(R.string.action_send))
+                }
             }
         }
+    }
+}
+
+/** Small "fully on-device" chip reinforcing the app's zero-network, nothing-leaves-the-device posture. */
+@Composable
+private fun OfflineBadge(modifier: Modifier = Modifier) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        shape = MaterialTheme.shapes.small,
+        modifier = modifier,
+    ) {
+        Text(
+            text = stringResource(R.string.badge_offline),
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+        )
     }
 }
 

--- a/android-llmservice/app/src/main/res/values-ar/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ar/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">مسح</string>
     <string name="toast_log_copied">تم نسخ السجل</string>
     <string name="toast_log_saved">تم حفظ السجل</string>
+    <!-- Chat actions -->
+    <string name="action_stop">إيقاف</string>
+    <string name="action_copy">نسخ</string>
+    <string name="action_regenerate">إعادة توليد</string>
+    <string name="action_clear">مسح</string>
+    <string name="action_cancel">إلغاء</string>
+    <string name="cd_clear">مسح المحادثة</string>
+    <string name="toast_copied">تم النسخ</string>
+    <string name="clear_confirm_title">مسح المحادثة؟</string>
+    <string name="clear_confirm_message">يؤدي هذا إلى إزالة جميع الرسائل في المحادثة الحالية.</string>
+    <string name="badge_offline">🔒 دون اتصال · بالكامل على الجهاز</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-de/strings.xml
+++ b/android-llmservice/app/src/main/res/values-de/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">Leeren</string>
     <string name="toast_log_copied">Protokoll kopiert</string>
     <string name="toast_log_saved">Protokoll gespeichert</string>
+    <!-- Chat actions -->
+    <string name="action_stop">Stopp</string>
+    <string name="action_copy">Kopieren</string>
+    <string name="action_regenerate">Neu generieren</string>
+    <string name="action_clear">Löschen</string>
+    <string name="action_cancel">Abbrechen</string>
+    <string name="cd_clear">Chat löschen</string>
+    <string name="toast_copied">Kopiert</string>
+    <string name="clear_confirm_title">Chat löschen?</string>
+    <string name="clear_confirm_message">Dies entfernt alle Nachrichten in der aktuellen Unterhaltung.</string>
+    <string name="badge_offline">🔒 Offline · vollständig auf dem Gerät</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-es/strings.xml
+++ b/android-llmservice/app/src/main/res/values-es/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">Borrar</string>
     <string name="toast_log_copied">Registro copiado</string>
     <string name="toast_log_saved">Registro guardado</string>
+    <!-- Chat actions -->
+    <string name="action_stop">Detener</string>
+    <string name="action_copy">Copiar</string>
+    <string name="action_regenerate">Regenerar</string>
+    <string name="action_clear">Borrar</string>
+    <string name="action_cancel">Cancelar</string>
+    <string name="cd_clear">Borrar chat</string>
+    <string name="toast_copied">Copiado</string>
+    <string name="clear_confirm_title">¿Borrar chat?</string>
+    <string name="clear_confirm_message">Esto elimina todos los mensajes de la conversación actual.</string>
+    <string name="badge_offline">🔒 Sin conexión · totalmente en el dispositivo</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-fr/strings.xml
+++ b/android-llmservice/app/src/main/res/values-fr/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">Effacer</string>
     <string name="toast_log_copied">Journal copié</string>
     <string name="toast_log_saved">Journal enregistré</string>
+    <!-- Chat actions -->
+    <string name="action_stop">Arrêter</string>
+    <string name="action_copy">Copier</string>
+    <string name="action_regenerate">Régénérer</string>
+    <string name="action_clear">Effacer</string>
+    <string name="action_cancel">Annuler</string>
+    <string name="cd_clear">Effacer la conversation</string>
+    <string name="toast_copied">Copié</string>
+    <string name="clear_confirm_title">Effacer la conversation ?</string>
+    <string name="clear_confirm_message">Cela supprime tous les messages de la conversation actuelle.</string>
+    <string name="badge_offline">🔒 Hors ligne · entièrement sur l\'appareil</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-hi/strings.xml
+++ b/android-llmservice/app/src/main/res/values-hi/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">साफ़ करें</string>
     <string name="toast_log_copied">लॉग कॉपी किया गया</string>
     <string name="toast_log_saved">लॉग सहेजा गया</string>
+    <!-- Chat actions -->
+    <string name="action_stop">रोकें</string>
+    <string name="action_copy">कॉपी करें</string>
+    <string name="action_regenerate">फिर से बनाएँ</string>
+    <string name="action_clear">साफ़ करें</string>
+    <string name="action_cancel">रद्द करें</string>
+    <string name="cd_clear">चैट साफ़ करें</string>
+    <string name="toast_copied">कॉपी किया गया</string>
+    <string name="clear_confirm_title">चैट साफ़ करें?</string>
+    <string name="clear_confirm_message">यह वर्तमान बातचीत के सभी संदेश हटा देता है।</string>
+    <string name="badge_offline">🔒 ऑफ़लाइन · पूरी तरह डिवाइस पर</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-it/strings.xml
+++ b/android-llmservice/app/src/main/res/values-it/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">Cancella</string>
     <string name="toast_log_copied">Registro copiato</string>
     <string name="toast_log_saved">Registro salvato</string>
+    <!-- Chat actions -->
+    <string name="action_stop">Ferma</string>
+    <string name="action_copy">Copia</string>
+    <string name="action_regenerate">Rigenera</string>
+    <string name="action_clear">Cancella</string>
+    <string name="action_cancel">Annulla</string>
+    <string name="cd_clear">Cancella chat</string>
+    <string name="toast_copied">Copiato</string>
+    <string name="clear_confirm_title">Cancellare la chat?</string>
+    <string name="clear_confirm_message">Rimuove tutti i messaggi della conversazione attuale.</string>
+    <string name="badge_offline">🔒 Offline · completamente sul dispositivo</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ja/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ja/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">クリア</string>
     <string name="toast_log_copied">ログをコピーしました</string>
     <string name="toast_log_saved">ログを保存しました</string>
+    <!-- Chat actions -->
+    <string name="action_stop">停止</string>
+    <string name="action_copy">コピー</string>
+    <string name="action_regenerate">再生成</string>
+    <string name="action_clear">クリア</string>
+    <string name="action_cancel">キャンセル</string>
+    <string name="cd_clear">チャットをクリア</string>
+    <string name="toast_copied">コピーしました</string>
+    <string name="clear_confirm_title">チャットをクリアしますか？</string>
+    <string name="clear_confirm_message">現在の会話のすべてのメッセージを削除します。</string>
+    <string name="badge_offline">🔒 オフライン · 完全にデバイス上</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ko/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ko/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">지우기</string>
     <string name="toast_log_copied">로그 복사됨</string>
     <string name="toast_log_saved">로그 저장됨</string>
+    <!-- Chat actions -->
+    <string name="action_stop">중지</string>
+    <string name="action_copy">복사</string>
+    <string name="action_regenerate">다시 생성</string>
+    <string name="action_clear">지우기</string>
+    <string name="action_cancel">취소</string>
+    <string name="cd_clear">채팅 지우기</string>
+    <string name="toast_copied">복사됨</string>
+    <string name="clear_confirm_title">채팅을 지우시겠어요?</string>
+    <string name="clear_confirm_message">현재 대화의 모든 메시지가 삭제됩니다.</string>
+    <string name="badge_offline">🔒 오프라인 · 완전히 기기에서</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-pt/strings.xml
+++ b/android-llmservice/app/src/main/res/values-pt/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">Limpar</string>
     <string name="toast_log_copied">Registo copiado</string>
     <string name="toast_log_saved">Registo guardado</string>
+    <!-- Chat actions -->
+    <string name="action_stop">Parar</string>
+    <string name="action_copy">Copiar</string>
+    <string name="action_regenerate">Regenerar</string>
+    <string name="action_clear">Limpar</string>
+    <string name="action_cancel">Cancelar</string>
+    <string name="cd_clear">Limpar conversa</string>
+    <string name="toast_copied">Copiado</string>
+    <string name="clear_confirm_title">Limpar conversa?</string>
+    <string name="clear_confirm_message">Isto remove todas as mensagens da conversa atual.</string>
+    <string name="badge_offline">🔒 Offline · totalmente no dispositivo</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ru/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ru/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">Очистить</string>
     <string name="toast_log_copied">Журнал скопирован</string>
     <string name="toast_log_saved">Журнал сохранён</string>
+    <!-- Chat actions -->
+    <string name="action_stop">Стоп</string>
+    <string name="action_copy">Копировать</string>
+    <string name="action_regenerate">Перегенерировать</string>
+    <string name="action_clear">Очистить</string>
+    <string name="action_cancel">Отмена</string>
+    <string name="cd_clear">Очистить чат</string>
+    <string name="toast_copied">Скопировано</string>
+    <string name="clear_confirm_title">Очистить чат?</string>
+    <string name="clear_confirm_message">Это удалит все сообщения в текущем разговоре.</string>
+    <string name="badge_offline">🔒 Офлайн · полностью на устройстве</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-tr/strings.xml
+++ b/android-llmservice/app/src/main/res/values-tr/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">Temizle</string>
     <string name="toast_log_copied">Günlük kopyalandı</string>
     <string name="toast_log_saved">Günlük kaydedildi</string>
+    <!-- Chat actions -->
+    <string name="action_stop">Durdur</string>
+    <string name="action_copy">Kopyala</string>
+    <string name="action_regenerate">Yeniden oluştur</string>
+    <string name="action_clear">Temizle</string>
+    <string name="action_cancel">İptal</string>
+    <string name="cd_clear">Sohbeti temizle</string>
+    <string name="toast_copied">Kopyalandı</string>
+    <string name="clear_confirm_title">Sohbet temizlensin mi?</string>
+    <string name="clear_confirm_message">Bu, mevcut sohbetteki tüm mesajları kaldırır.</string>
+    <string name="badge_offline">🔒 Çevrimdışı · tamamen cihazda</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android-llmservice/app/src/main/res/values-zh-rCN/strings.xml
@@ -42,4 +42,15 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">清除</string>
     <string name="toast_log_copied">日志已复制</string>
     <string name="toast_log_saved">日志已保存</string>
+    <!-- Chat actions -->
+    <string name="action_stop">停止</string>
+    <string name="action_copy">复制</string>
+    <string name="action_regenerate">重新生成</string>
+    <string name="action_clear">清除</string>
+    <string name="action_cancel">取消</string>
+    <string name="cd_clear">清除对话</string>
+    <string name="toast_copied">已复制</string>
+    <string name="clear_confirm_title">清除对话？</string>
+    <string name="clear_confirm_message">这将删除当前对话中的所有消息。</string>
+    <string name="badge_offline">🔒 离线 · 完全在设备上</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values/strings.xml
+++ b/android-llmservice/app/src/main/res/values/strings.xml
@@ -46,4 +46,16 @@ SPDX-License-Identifier: MIT
     <string name="log_clear">Clear</string>
     <string name="toast_log_copied">Log copied</string>
     <string name="toast_log_saved">Log saved</string>
+
+    <!-- Chat actions -->
+    <string name="action_stop">Stop</string>
+    <string name="action_copy">Copy</string>
+    <string name="action_regenerate">Regenerate</string>
+    <string name="action_clear">Clear</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="cd_clear">Clear chat</string>
+    <string name="toast_copied">Copied</string>
+    <string name="clear_confirm_title">Clear chat?</string>
+    <string name="clear_confirm_message">This removes all messages in the current conversation.</string>
+    <string name="badge_offline">🔒 Offline · fully on-device</string>
 </resources>


### PR DESCRIPTION
## Summary

Small chat-quality quick wins from `android-llmservice/TODO.md` (all XS–S, no new dependency, no network, no foundational work):

- **Stop generation** — a Stop button replaces Send while a reply streams; it cancels the streaming coroutine (the `generateChatFlow` source closes on cancellation), keeps the partial reply, and shows **no** error (`CancellationException` is rethrown rather than turned into a generation error). Lets a runaway/repetitive reply be cut off.
- **Copy + Regenerate** — an actions row under the last assistant reply: Copy puts the reply on the clipboard (toast); Regenerate drops the trailing reply and re-runs the last user turn (handy after tuning the sampling settings). `send()` and `regenerate()` now share one `startGeneration()` path.
- **Clear chat** — 🗑 in the top bar (enabled only with messages present and not generating) + a confirm dialog.
- **Offline/privacy badge** — a `🔒 Offline · fully on-device` chip on the model-picker screen, reinforcing the zero-network posture.
- **i18n** — new UI strings added to the default resources and translated across all **13** shipped languages.
- Docs: `TODO.md` rows (`Copy/regenerate/stop/clear`, `Offline badge`, `Clear chat history`) flipped to ✅; `README.md` layout note updated.

The instrumented UI test is unaffected: it clicks `sendButton` while idle (present) and asserts via `uiState`; the Stop/Copy/Regenerate/Clear affordances are additive and carry their own test tags (`stopButton`/`copyButton`/`regenerateButton`/`clearButton`).

## Test plan

- [x] CI is green on this branch — `build-android-llmservice` compiles the app + runs the on-device Compose test on the emulator
- [x] Docs updated — `TODO.md` + `README.md`

## Related issues / PRs

Follow-up to the `android-llmservice` app (PRs #310–#314). No related issue number.

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m)_