### PR TITLE
fix(android-llmservice): keep the log strip above the system navigation bar

### DIFF
--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
@@ -11,6 +11,7 @@ import android.provider.OpenableColumns
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -25,6 +26,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -84,6 +86,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Edge-to-edge is forced on Android 15 (targetSdk 35); enable it explicitly on every version
+        // so window-inset handling is consistent. The bottom log strip then pads itself above the
+        // system navigation bar (see LogStrip) instead of being drawn behind it.
+        enableEdgeToEdge()
 
         // Test / automation hook: preload a model straight from an absolute path, bypassing the
         // interactive SAF picker (a separate system process the UI test can't drive). The shipping
@@ -233,8 +239,11 @@ private fun LogStrip(viewModel: ChatViewModel, onOpen: () -> Unit) {
     val log by viewModel.log.collectAsStateWithLifecycle()
     val last = log.lastOrNull() ?: stringResource(R.string.log_empty)
     Surface(tonalElevation = 2.dp) {
+        // navigationBarsPadding keeps the strip's content above the system nav bar (back / home /
+        // recents) under edge-to-edge; the Surface background still fills to the screen edge behind it.
         Row(
             modifier = Modifier.fillMaxWidth().clickable(onClick = onOpen).testTag("logStrip")
+                .navigationBarsPadding()
                 .padding(horizontal = 12.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/android-llmservice/requirements.md
+++ b/android-llmservice/requirements.md
@@ -94,7 +94,7 @@ by hand only (no automated test); `build` = enforced at build/resource-compile t
 
 | ID | Requirement | Source | Verified by |
 |---|---|---|---|
-| R7.1 | An **always-visible one-line log strip** sits at the very bottom (🧾, small font, may wrap to 2 display lines) showing the newest log line, or an empty-state string. | `MainActivity.LogStrip` | manual |
+| R7.1 | An **always-visible one-line log strip** sits at the very bottom (🧾, small font, may wrap to 2 display lines) showing the newest log line, or an empty-state string. Under edge-to-edge (`enableEdgeToEdge`) its content is padded **above the system navigation bar** (`navigationBarsPadding`) so it is never covered by the back/home/recents bar. | `MainActivity.onCreate`; `MainActivity.LogStrip` | manual |
 | R7.2 | Tapping the strip opens a **full-screen log viewer** with **Copy all**, **Save as…** (writes a `.txt` via SAF `CreateDocument`), and **Clear**; ✕ (top-right) closes it. | `MainActivity.LogDialog` | manual |
 | R7.3 | The log is a **rolling buffer capped at 500 lines**, each entry prefixed with a local wall-clock time. | `ChatViewModel.log` (`MAX_LOG_LINES`) | manual |
 | R7.4 | Logged events include: model loading/ready/load-failure, generation start (with the effective sampling knobs), reply-complete (char count), generation-stopped, generation-failure, regenerate, chat-cleared, settings-reset, and session save/load. | `ChatViewModel` (`log(...)` call sites) | manual |


### PR DESCRIPTION
## Summary

The bottom **log strip** was hidden behind the Android **system navigation bar** (back / home / recents). Cause: on Android 15 (`targetSdk 35`) apps are **edge-to-edge by default**, so the window draws behind the nav bar and the strip — the lowest app element — landed underneath it.

Fix (the "put the app content above the nav bar" approach the user asked for):
- Call `enableEdgeToEdge()` in `onCreate` so inset handling is **consistent on every Android version** (avoids the version-specific double-gap you'd get by only padding).
- Pad the log strip's content with **`navigationBarsPadding()`** so the 🧾 icon + text sit **above** the nav bar. The `Surface` background still fills to the screen edge behind it (so it looks like a full-width bar), but the content is never covered.

The `TopAppBar` already handles the status-bar inset (Material3 default) and the `Scaffold` content is inset via its `innerPadding`, so only the custom bottom bar needed the manual inset. `requirements.md` R7.1 updated to record the behavior.

No API/behavior change beyond layout; the instrumented UI test (which drives `promptInput`/`sendButton` in the content area) is unaffected.

## Test plan

- [x] `enableEdgeToEdge()` from `androidx.activity` (present in activity 1.9.3, via activity-compose) + `navigationBarsPadding()` from compose-foundation (BOM)
- [x] CI `build-android-llmservice` compiles + runs the on-device Compose test (API 30 emulator)
- [x] Docs synced — `requirements.md` R7.1

## Related issues / PRs

Follow-up to the `android-llmservice` app (PRs #310–#317). Reported: the bottom log strip is covered by the Android navigation bar.

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m)_