### PR TITLE
feat(android-llmservice): two-row app bar + ephemeral working data (privacy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1666,10 +1666,14 @@ Structure (mirrors the consumer-test's plumbing):
   the partial reply, not an error) and **regenerate** (drop the trailing reply, re-run the last user turn,
   shared `startGeneration` path); keeps a capped rolling in-app **log**. **`SessionStore.kt`** — private
   local save/load: the conversation + model path as JSON in `filesDir/session.json` (`org.json`, no dep
-  added), readable only by the app. **`MainActivity.kt`** — Compose UI + SAF picker + flag menu +
-  Save/Load + the ⚙️ Settings sheet + the 🧾 log strip/viewer + Stop/Copy/Regenerate/Clear chat actions +
-  the offline badge + the horizontally-scrollable model-name title; reads optional `MODEL_PATH` /
-  `CHAT_TEMPLATE` intent extras as a **test hook** (the shipping UI never sets them).
+  added), readable only by the app. **`LlmServiceApp.kt`** — `Application` that **wipes the transient
+  working data** (the copied model `current-model.gguf` + cache) on every **cold start**
+  (`onCreate`) — a privacy guarantee independent of the OS calling `onDestroy`; `MainActivity` also
+  wipes best-effort on finish. Only the **opt-in saved session** persists. **`MainActivity.kt`** —
+  Compose UI with a **two-row app bar** (row 1 = horizontally-scrollable model name on its own line,
+  row 2 = all action icons) + SAF picker + flag menu + Save/Load + the ⚙️ Settings sheet + the 🧾 log
+  strip/viewer + Stop/Copy/Regenerate/Clear chat actions + the offline badge; reads optional
+  `MODEL_PATH` / `CHAT_TEMPLATE` intent extras as a **test hook** (the shipping UI never sets them).
 - **`app/src/androidTest/kotlin/.../ChatFlowInstrumentedTest.kt`** — the real end-to-end test:
   launches the activity with a preloaded model (bypassing the system SAF dialog, which only
   UiAutomator could drive), types a prompt, taps Send, asserts a non-empty streamed reply.

--- a/android-llmservice/README.md
+++ b/android-llmservice/README.md
@@ -50,6 +50,16 @@ on-device path — to a single JSON file in the app's **private internal storage
 (nothing autosaves) and fully local, keeping the "nothing leaves the device" promise.
 Loading restores the messages and re-opens the model if its file is still present.
 
+## Ephemeral by default (privacy)
+
+Nothing lingers between sessions. The copied model (`current-model.gguf`, which can be several
+GB) and the app cache are **wiped on every cold start** (`LlmServiceApp.onCreate`) — a guarantee
+that holds no matter how the app was last closed (swipe-away, low-memory kill, crash) — and are
+also cleared best-effort when the app is finished (`MainActivity.onDestroy`). So after you fully
+close the app you re-pick the model on next launch, and no large data sits around. The **only**
+thing that persists is the session you **explicitly Save** (see below) — everything else is
+transient. (A language switch recreates the activity but does *not* wipe the in-use model.)
+
 ## Why a `content://` URI is copied to a real path
 
 llama.cpp memory-maps the model from a **real filesystem path**, but the file picker
@@ -199,7 +209,8 @@ android-llmservice/
         ├── main/res/values/{strings,themes}.xml + values-*/strings.xml (13 languages)
         ├── main/res/xml/locales_config.xml
         ├── main/kotlin/net/ladenthin/android/llmservice/
-        │   ├── MainActivity.kt      # Compose UI + SAF picker + flag menu + save/load + settings + log + chat actions (stop/copy/regenerate/clear)
+        │   ├── MainActivity.kt      # Compose UI (two-row app bar) + SAF picker + flag menu + save/load + settings + log + chat actions (stop/copy/regenerate/clear)
+        │   ├── LlmServiceApp.kt     # Application: wipes transient working data (model copy + cache) on cold start (privacy)
         │   ├── ChatViewModel.kt     # model load + streaming chat (stop/regenerate) + sampling settings + in-app log + session (the logic)
         │   ├── Languages.kt         # the flag/language list
         │   └── SessionStore.kt      # private local JSON persistence (filesDir)

--- a/android-llmservice/app/src/main/AndroidManifest.xml
+++ b/android-llmservice/app/src/main/AndroidManifest.xml
@@ -18,7 +18,13 @@ SPDX-License-Identifier: MIT
       disabling backup keeps them out of adb backup and cloud auto-backup so nothing leaves the
       device that way. Also resolves the CodeQL "Application backup allowed" alert.
     -->
+    <!--
+      android:name=".LlmServiceApp" wipes transient working data (the copied model + cache) on every
+      cold start so nothing lingers between sessions (privacy). Only the user's explicitly saved
+      session survives.
+    -->
     <application
+        android:name=".LlmServiceApp"
         android:allowBackup="false"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/ChatViewModel.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/ChatViewModel.kt
@@ -28,6 +28,12 @@ import net.ladenthin.llama.parameters.ModelParameters
 import net.ladenthin.llama.value.Pair
 
 /**
+ * File name of the SAF-picked model copied into `filesDir`. Transient working data — wiped on cold
+ * start (and best-effort on close) by [LlmServiceApp] so nothing lingers between sessions.
+ */
+const val MODEL_COPY_NAME: String = "current-model.gguf"
+
+/**
  * Holds the loaded [LlamaModel] and drives streaming chat over the llama-kotlin
  * [generateChatFlow] facade. All native work runs on [Dispatchers.IO]; the UI observes
  * [uiState]. This is the whole "brain" of the app — the Compose layer is pure rendering.
@@ -340,7 +346,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun copyToInternal(uri: Uri): String {
         val resolver = getApplication<Application>().contentResolver
-        val target = File(getApplication<Application>().filesDir, "current-model.gguf")
+        val target = File(getApplication<Application>().filesDir, MODEL_COPY_NAME)
         resolver.openInputStream(uri).use { input ->
             requireNotNull(input) { "content resolver returned no stream for $uri" }
             target.outputStream().use { output -> input.copyTo(output, bufferSize = 1 shl 20) }

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/LlmServiceApp.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/LlmServiceApp.kt
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+package net.ladenthin.android.llmservice
+
+import android.app.Application
+import android.content.Context
+import java.io.File
+
+/**
+ * Application entry point whose only job is a **privacy guarantee**: wipe the app's transient
+ * working data on every **cold start**, so the app always begins fresh regardless of how it was last
+ * killed (swipe-away, low-memory kill, crash — none of which reliably call `onDestroy`).
+ *
+ * "Working data" = the copied model ([MODEL_COPY_NAME], which can be gigabytes) and the cache dir.
+ * The **only** thing that intentionally survives is the user's explicitly saved session
+ * ([SessionStore]) — it exists precisely so the user can opt in to keeping a chat; everything else is
+ * ephemeral. `MainActivity` additionally calls [clearWorkingData] on finish for prompt cleanup, but
+ * this cold-start wipe is the reliable guarantee.
+ */
+class LlmServiceApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        clearWorkingData(this)
+    }
+
+    companion object {
+        /**
+         * Deletes the copied model and everything under the cache dir. Safe to call on process start
+         * (nothing is loaded yet) and best-effort on exit (deleting the still-mmapped model file is
+         * fine — the mapping stays valid until the model is closed). Does **not** touch the opt-in
+         * saved session (`session.json`).
+         *
+         * @param context any context (used for `filesDir` / `cacheDir`)
+         */
+        fun clearWorkingData(context: Context) {
+            File(context.filesDir, MODEL_COPY_NAME).delete()
+            context.cacheDir?.listFiles()?.forEach { it.deleteRecursively() }
+        }
+    }
+}

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -51,7 +52,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -107,6 +107,17 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        // Prompt privacy cleanup when the app is actually closing (not on a config-change / locale
+        // recreation). The cold-start wipe in LlmServiceApp is the reliable guarantee; this just
+        // removes the copied model sooner. isFinishing is false on config changes, so the in-use
+        // model survives a language switch.
+        if (isFinishing) {
+            LlmServiceApp.clearWorkingData(this)
+        }
+    }
+
     companion object {
         /** Absolute on-device GGUF path to preload (test hook). */
         const val EXTRA_MODEL_PATH = "net.ladenthin.android.llmservice.MODEL_PATH"
@@ -146,39 +157,48 @@ private fun ChatScreen(viewModel: ChatViewModel) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    // Horizontally scrollable so a long model name can be dragged into view in full,
-                    // without an auto-scrolling marquee that would "wobble" constantly.
+            // Two-row app bar: the model name gets its own full-width line (so a long name is
+            // readable / draggable), and all the action icons sit on a second line below it.
+            Surface(shadowElevation = 3.dp) {
+                Column(modifier = Modifier.fillMaxWidth().statusBarsPadding()) {
+                    // Row 1: model name, horizontally scrollable (drag a long name into view; no
+                    // auto-marquee wobble).
                     Text(
                         text = state.modelName ?: stringResource(R.string.app_name),
+                        style = MaterialTheme.typography.titleLarge,
                         maxLines = 1,
                         softWrap = false,
-                        modifier = Modifier.horizontalScroll(rememberScrollState()),
+                        modifier = Modifier.fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(horizontal = 16.dp, vertical = 10.dp),
                     )
-                },
-                actions = {
-                    IconButton(
-                        onClick = { viewModel.saveSession() },
-                        enabled = state.messages.isNotEmpty(),
+                    // Row 2: all action icons on their own line.
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text("💾", modifier = Modifier.testTag("saveButton"))
+                        IconButton(
+                            onClick = { viewModel.saveSession() },
+                            enabled = state.messages.isNotEmpty(),
+                        ) {
+                            Text("💾", modifier = Modifier.testTag("saveButton"))
+                        }
+                        IconButton(onClick = { viewModel.loadSession() }) {
+                            Text("📂", modifier = Modifier.testTag("loadButton"))
+                        }
+                        IconButton(
+                            onClick = { showClearConfirm = true },
+                            enabled = state.messages.isNotEmpty() && !state.generating,
+                        ) {
+                            Text("🗑", modifier = Modifier.testTag("clearButton"))
+                        }
+                        IconButton(onClick = { showSettings = true }) {
+                            Text("⚙️", modifier = Modifier.testTag("settingsButton"))
+                        }
+                        LanguageMenu()
                     }
-                    IconButton(onClick = { viewModel.loadSession() }) {
-                        Text("📂", modifier = Modifier.testTag("loadButton"))
-                    }
-                    IconButton(
-                        onClick = { showClearConfirm = true },
-                        enabled = state.messages.isNotEmpty() && !state.generating,
-                    ) {
-                        Text("🗑", modifier = Modifier.testTag("clearButton"))
-                    }
-                    IconButton(onClick = { showSettings = true }) {
-                        Text("⚙️", modifier = Modifier.testTag("settingsButton"))
-                    }
-                    LanguageMenu()
-                },
-            )
+                }
+            }
         },
         bottomBar = { LogStrip(viewModel = viewModel, onOpen = { showLog = true }) },
         snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/android-llmservice/requirements.md
+++ b/android-llmservice/requirements.md
@@ -47,13 +47,14 @@ by hand only (no automated test); `build` = enforced at build/resource-compile t
 | R2.2 | `allowBackup=false` — conversation data is not included in system backups. | `AndroidManifest.xml` | build |
 | R2.3 | All inference runs **on-device** (CPU); no request is ever made to a remote server by the app. | `ChatViewModel` (no network calls) | manual |
 | R2.4 | A **"🔒 Offline · fully on-device"** badge is shown on the model-picker screen. | `MainActivity.OfflineBadge`; `badge_offline` | manual |
+| R2.5 | **Transient working data is ephemeral:** the copied model (`current-model.gguf`) and the cache dir are **wiped on every cold start** (`LlmServiceApp.onCreate`) — guaranteeing a fresh start regardless of how the app was last killed — and best-effort on finish (`MainActivity.onDestroy` when `isFinishing`). The **only** data that persists is the user's **explicitly saved** session (`session.json`, opt-in). | `LlmServiceApp`; `MainActivity.onDestroy` | manual |
 
 ## R3 — Model selection & loading
 
 | ID | Requirement | Source | Verified by |
 |---|---|---|---|
 | R3.1 | The user picks a GGUF via the **Storage Access Framework** (`ACTION_OPEN_DOCUMENT`, `*/*`) — no storage permission. | `MainActivity` picker | manual |
-| R3.2 | A picked `content://` model is **copied into app-private `filesDir`** (`current-model.gguf`) and loaded **by real path** (llama.cpp mmaps a real path, not a `content://` URI). | `ChatViewModel.copyToInternal` | manual |
+| R3.2 | A picked `content://` model is **copied into app-private `filesDir`** (`current-model.gguf` = `MODEL_COPY_NAME`) and loaded **by real path** (llama.cpp mmaps a real path, not a `content://` URI). The copy is **ephemeral** (wiped on cold start / close — see R2.5), so a model is re-picked after the app is fully closed. | `ChatViewModel.copyToInternal` | manual |
 | R3.3 | The model loads **CPU-only** (`setGpuLayers(0)`) with context size **2048**, portable across every device. | `ChatViewModel.openModel` (`CONTEXT_SIZE`) | manual |
 | R3.4 | While loading, a **LOADING** state is shown (spinner + "Loading model…"); on failure a localized load error is shown and state returns to NONE. | `ChatViewModel.ModelState`; `error_load_model` | manual |
 | R3.5 | Loading a new model **closes** the previously loaded one (native memory is not GC-managed). | `ChatViewModel.openModel` | manual |
@@ -122,7 +123,7 @@ by hand only (no automated test); `build` = enforced at build/resource-compile t
 
 | ID | Requirement | Source | Verified by |
 |---|---|---|---|
-| R10.1 | The top-bar **model-name title is horizontally scrollable** (draggable), so a long name can be read in full — single line, no auto-marquee. | `MainActivity` top bar | manual |
+| R10.1 | The app bar is **two rows**: row 1 is the **model-name title on its own full-width line**, **horizontally scrollable** (draggable) so a long name can be read in full (single line, no auto-marquee); row 2 holds **all action icons** (save / load / clear / settings / language) on their own line below it. | `MainActivity` top bar | manual |
 | R10.2 | The release `signingConfig` reads an **upload keystore** from env vars / `-P` props, and **falls back to debug signing** when none is set (so forks/PRs/local builds stay green). **Upgrade caveat:** the debug fallback uses an ephemeral per-runner key, so debug-signed CI APKs are **not** mutually upgradeable (a signer change is rejected → uninstall required); stable in-place upgrades need the upload-key secrets. | `app/build.gradle.kts` | build |
 | R10.3 | The build produces a release **`.aab`** (for Play) and an installable release **`.apk`** (sideload); the Maven Central GPG key cannot sign these — Android needs a Java keystore upload key. | `app/build.gradle.kts`; `README.md` | build |
 | R10.4 | `versionCode` is **monotonic** (derived from `GITHUB_RUN_NUMBER` in CI, strictly increasing per run; `-PappVersionCode` overrides; local hand builds use `1`), so successive release APKs advertise a higher version and Android accepts the in-place upgrade (given a stable signer, R10.2). | `app/build.gradle.kts` | build |


### PR DESCRIPTION
## Summary

Two on-device requests:

**1) Two-row app bar.** The model name now has its **own full-width line** (horizontally scrollable, so a long name is readable/draggable), and **all action icons** (💾 save / 📂 load / 🗑 clear / ⚙️ settings / 🌐 language) move to a **second line below it**. Replaces the single-row `TopAppBar` with a custom `Surface` + `Column` (with `statusBarsPadding` for the status-bar inset under edge-to-edge).

**2) Ephemeral working data (privacy).** The app left a large **copied model** (`current-model.gguf`, can be several GB) in `filesDir` between runs. Now:
- A new **`LlmServiceApp` (`Application`)** wipes the copied model **+ the cache dir on every cold start** (`onCreate`) — a guarantee that holds regardless of how the app was last killed (swipe-away, low-memory kill, crash — none of which reliably call `onDestroy`).
- `MainActivity.onDestroy` also wipes **best-effort on finish** (`isFinishing`), so a **locale-switch recreation does *not*** drop the in-use model (only a real close does).
- The **only** data that persists is the user's **explicitly saved session** (`session.json`, opt-in) — everything else is transient. Trade-off: after fully closing the app you re-pick the model on next launch (intended, for privacy).
- The model filename is now the shared `MODEL_COPY_NAME` constant.

Docs synced (per the `requirements.md` rule): **R2.5** (ephemeral working data), **R3.2** (copy is ephemeral), **R10.1** (two-row bar); README ("Ephemeral by default" + layout + `LlmServiceApp.kt`); CLAUDE.md android section.

The instrumented UI test is unaffected: it loads the model from an absolute adb-pushed path (not the copy), and the cold-start/finish wipes only touch `current-model.gguf` (absent in the test) + cache.

## Test plan

- [x] `enableEdgeToEdge` (already on main) + `statusBarsPadding` handle the top inset for the custom bar
- [x] CI `build-android-llmservice` compiles + runs the on-device Compose test (API 30 emulator)
- [x] Docs synced — `requirements.md`, `README.md`, `CLAUDE.md`

## Related issues / PRs

Follow-up to the `android-llmservice` app (PRs #310–#318). Reported: app leaves a lot of data after close; wants the icons on their own row under the model name.

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m)_