### PR TITLE
feat(android-llmservice): device card, per-message copy, thread/context settings, prompt chips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1671,9 +1671,12 @@ Structure (mirrors the consumer-test's plumbing):
   (`onCreate`) — a privacy guarantee independent of the OS calling `onDestroy`; `MainActivity` also
   wipes best-effort on finish. Only the **opt-in saved session** persists. **`MainActivity.kt`** —
   Compose UI with a **two-row app bar** (row 1 = horizontally-scrollable model name on its own line,
-  row 2 = all action icons) + SAF picker + flag menu + Save/Load + the ⚙️ Settings sheet + the 🧾 log
-  strip/viewer + Stop/Copy/Regenerate/Clear chat actions + the offline badge; reads optional
-  `MODEL_PATH` / `CHAT_TEMPLATE` intent extras as a **test hook** (the shipping UI never sets them).
+  row 2 = all action icons) + SAF picker + flag menu + Save/Load + the ⚙️ Settings sheet
+  (sampling knobs + a **Model** section: CPU threads / context length applied via **Reload model**) +
+  the 🧾 log strip/viewer + Stop/Copy/Regenerate/Clear chat actions (+ **long-press any bubble to
+  copy**) + **prompt shortcut chips** + a **device-readiness card** (free RAM / storage / battery via
+  `DeviceInfo`) on the picker + the offline badge; reads optional `MODEL_PATH` / `CHAT_TEMPLATE`
+  intent extras as a **test hook** (the shipping UI never sets them).
 - **`app/src/androidTest/kotlin/.../ChatFlowInstrumentedTest.kt`** — the real end-to-end test:
   launches the activity with a preloaded model (bypassing the system SAF dialog, which only
   UiAutomator could drive), types a prompt, taps Send, asserts a non-empty streamed reply.

--- a/android-llmservice/README.md
+++ b/android-llmservice/README.md
@@ -209,9 +209,10 @@ android-llmservice/
         ├── main/res/values/{strings,themes}.xml + values-*/strings.xml (13 languages)
         ├── main/res/xml/locales_config.xml
         ├── main/kotlin/net/ladenthin/android/llmservice/
-        │   ├── MainActivity.kt      # Compose UI (two-row app bar) + SAF picker + flag menu + save/load + settings + log + chat actions (stop/copy/regenerate/clear)
+        │   ├── MainActivity.kt      # Compose UI (two-row app bar) + SAF picker + flag menu + save/load + settings + log + chat actions + prompt chips + device card
         │   ├── LlmServiceApp.kt     # Application: wipes transient working data (model copy + cache) on cold start (privacy)
-        │   ├── ChatViewModel.kt     # model load + streaming chat (stop/regenerate) + sampling settings + in-app log + session (the logic)
+        │   ├── ChatViewModel.kt     # model load + streaming chat (stop/regenerate) + sampling & model settings + in-app log + session (the logic)
+        │   ├── DeviceInfo.kt        # device-readiness snapshot (free RAM / storage / battery) for the picker card
         │   ├── Languages.kt         # the flag/language list
         │   └── SessionStore.kt      # private local JSON persistence (filesDir)
         └── androidTest/kotlin/net/ladenthin/android/llmservice/

--- a/android-llmservice/TODO.md
+++ b/android-llmservice/TODO.md
@@ -66,10 +66,10 @@ Everything else in the brief is feasible with standard AndroidX + the existing b
 | Feature | Purpose | Effort | Status | Notes |
 |---|---|---|---|---|
 | 3-card onboarding (Private by Design / Choose model / Chat or Serve) | First-run trust + orientation | S–M | ⬜ | one-time, persisted flag |
-| Device readiness check | Set expectations before a model fails | M | ⬜ | see rows below; single screen after onboarding |
-| Free RAM | Recommend model size | S | ⬜ | `ActivityManager.MemoryInfo` (`availMem`/`totalMem`) |
-| Free storage | Can the model be stored? | XS | ⬜ | `StatFs` on `filesDir` |
-| Battery level / charging | Warn on heavy inference | XS | ⬜ | `BatteryManager` |
+| Device readiness check | Set expectations before a model fails | M | 🔧 | RAM/storage/battery shipped as a card on the model-picker screen; a dedicated onboarding readiness screen + GPU/heuristic rows still todo |
+| Free RAM | Recommend model size | S | ✅ | `ActivityManager.MemoryInfo` (`availMem`/`totalMem`) — shown in the device card (`DeviceInfo`/`DeviceCard`) |
+| Free storage | Can the model be stored? | XS | ✅ | `StatFs` on `filesDir` — device card |
+| Battery level / charging | Warn on heavy inference | XS | ✅ | `BatteryManager` — device card (level + charging) |
 | GPU acceleration available? | Show if Adreno/OpenCL usable | M | ⬜ | only the OpenCL/Adreno AAR path (see §7); detect ICD presence |
 | Recommended model size heuristic | Approachable guidance | S | ⬜ | derive from free RAM + quant table |
 | Offline-mode status badge | Reinforce privacy | XS | ✅ | "🔒 Offline · fully on-device" chip on the model-picker screen |
@@ -81,8 +81,8 @@ Everything else in the brief is feasible with standard AndroidX + the existing b
 | Streaming responses + bubbles | Core chat | S | ✅ | polish to pastel user bubbles / larger AI cards |
 | Top bar: model chip · "Local" · RAM indicator · offline badge · switch | Context + control | M | 🔧 | model name shown (now horizontally draggable so long names are fully readable); RAM/switch/offline todo |
 | Markdown rendering (code, lists, tables, headings) | Readable answers | M | ⬜ | add a Compose Markdown renderer (e.g. compose-markdown) |
-| Copy / regenerate / stop / clear-chat actions | Standard chat UX | M | ✅ | **stop** cancels the streaming coroutine (façade closes the source); **copy**/**regenerate** act on the last reply; **clear** in the top bar with a confirm. Per-message copy (any bubble) is a possible follow-up |
-| Prompt shortcut chips (Summarize / Explain code / Translate / …) | Fast starts | S | ⬜ | localized prompt templates |
+| Copy / regenerate / stop / clear-chat actions | Standard chat UX | M | ✅ | **stop** cancels the streaming coroutine (façade closes the source); **copy**/**regenerate** act on the last reply; **long-press any bubble** copies that message; **clear** in the top bar with a confirm |
+| Prompt shortcut chips (Summarize / Explain code / Translate / …) | Fast starts | S | ✅ | localized `SuggestionChip`s above the input (fill the draft); 3 chips × 13 languages |
 | Attachment button → image input (vision) | Multimodal chat | L | ⬜ | `ContentPart.imageFile(...)` + a **vision GGUF + mmproj**; SAF image picker |
 | Audio input (speech) | Multimodal chat | L | ⬜ | `ContentPart.audioFile(...)` + an audio-capable model + mmproj |
 | Explicit states: loading / generating / stopped / unavailable / "too large for RAM" | Transparency | S | 🔧 | basic states exist; add the rest + messages |
@@ -132,8 +132,8 @@ See decision #1. All rows below assume a new in-app Ktor/NanoHTTPD HTTP layer wr
 
 | Feature | Purpose | Effort | Status | Notes |
 |---|---|---|---|---|
-| CPU threads | Tune speed | S | ⬜ | `ModelParameters.setThreads` / `setThreadsBatch` |
-| Context length | Memory vs. history | S | ⬜ | `setCtxSize` |
+| CPU threads | Tune speed | S | ✅ | `ModelParameters.setThreads` — in the ⚙️ Settings "Model" section; applies on **Reload model** |
+| Context length | Memory vs. history | S | ✅ | `setCtxSize` — Settings "Model" section; applies on **Reload model** |
 | Temperature / Max tokens / Top-K / Top-P / Min-P / **repeat penalty** + range | Sampling control | S | ✅ | shipped in the ⚙️ Generation settings sheet (live sliders + reset); `withTemperature`/`withNPredict`/`withTopK`/`withTopP`/`withMinP`/`withRepeatPenalty`/`withRepeatLastN`. The repeat-penalty default is what stops the small-model repetition loop |
 | GPU acceleration toggle | Speed on Adreno | M | 🔧 | `setGpuLayers`; **Adreno/OpenCL AAR only** (see §7) |
 | Battery saver mode | Protect battery | M | ⬜ | throttle threads / ngl on low battery |

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/ChatViewModel.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/ChatViewModel.kt
@@ -81,6 +81,26 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Model **load-time** parameters (unlike [GenerationSettings], which apply per request). Changing
+     * these only takes effect when the model is (re)loaded — see [reloadModel].
+     */
+    data class ModelConfig(
+        val threads: Int = DEFAULT_THREADS,
+        val contextSize: Int = DEFAULT_CONTEXT_SIZE,
+    ) {
+        companion object {
+            /** A portable CPU-thread default; users tune it in Settings. */
+            const val DEFAULT_THREADS = 4
+
+            /** Default context window (tokens). */
+            const val DEFAULT_CONTEXT_SIZE = 2048
+
+            /** The shipped defaults. */
+            val DEFAULT = ModelConfig()
+        }
+    }
+
     /** Immutable snapshot the Compose UI renders. */
     data class UiState(
         val modelState: ModelState = ModelState.NONE,
@@ -90,6 +110,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         val error: ErrorInfo? = null,
         val notice: Notice? = null,
         val settings: GenerationSettings = GenerationSettings.DEFAULT,
+        val modelConfig: ModelConfig = ModelConfig.DEFAULT,
     )
 
     private val _uiState = MutableStateFlow(UiState())
@@ -115,8 +136,27 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     private var chatTemplate: String? = null
 
     private companion object {
-        const val CONTEXT_SIZE = 2048
         const val MAX_LOG_LINES = 500
+    }
+
+    /** Replaces the model load-time config (threads / context). Applies on the next [reloadModel]. */
+    fun updateModelConfig(config: ModelConfig) {
+        _uiState.update { it.copy(modelConfig = config) }
+    }
+
+    /**
+     * Reopens the currently loaded model with the current [ModelConfig] (threads / context), so a
+     * changed thread count or context size takes effect. No-op if no model is loaded or busy.
+     */
+    fun reloadModel() {
+        val path = modelPath
+        if (path == null || _uiState.value.generating || _uiState.value.modelState == ModelState.LOADING) {
+            return
+        }
+        val name = _uiState.value.modelName ?: File(path).name
+        val template = chatTemplate
+        _uiState.update { it.copy(modelState = ModelState.LOADING, error = null) }
+        viewModelScope.launch { openModel(path, name, template) }
     }
 
     /** Appends one timestamped line to the rolling [log] (trimmed to [MAX_LOG_LINES]). */
@@ -171,13 +211,15 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private suspend fun openModel(path: String, displayName: String, template: String?) {
+        val config = _uiState.value.modelConfig
         log("Loading model: $displayName")
         try {
             val loaded = withContext(Dispatchers.IO) {
                 LlamaModel(
                     ModelParameters()
                         .setModel(path)
-                        .setCtxSize(CONTEXT_SIZE)
+                        .setCtxSize(config.contextSize)
+                        .setThreads(config.threads)
                         .setGpuLayers(0), // CPU-only: portable across every device
                 )
             }
@@ -188,7 +230,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             _uiState.update {
                 it.copy(modelState = ModelState.READY, modelName = displayName, error = null)
             }
-            log("Model ready: $displayName (ctx=$CONTEXT_SIZE, CPU)")
+            log("Model ready: $displayName (ctx=${config.contextSize}, threads=${config.threads}, CPU)")
         } catch (t: Throwable) {
             log("Load failed: ${t.message ?: "load failed"}")
             _uiState.update {

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/DeviceInfo.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/DeviceInfo.kt
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Bernard Ladenthin <bernard.ladenthin@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+package net.ladenthin.android.llmservice
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.BatteryManager
+import android.os.StatFs
+import java.util.Locale
+
+/**
+ * A one-shot snapshot of the device's readiness for on-device inference — shown on the model-picker
+ * screen so the user can gauge whether a model will fit before loading it. Read via [read]; all
+ * values come from standard Android system services (no permission needed).
+ *
+ * @property availMemBytes currently available RAM
+ * @property totalMemBytes total RAM
+ * @property availStorageBytes free space on the app's data partition
+ * @property batteryPercent battery level 0–100, or -1 if unknown
+ * @property charging whether the device is charging
+ */
+data class DeviceInfo(
+    val availMemBytes: Long,
+    val totalMemBytes: Long,
+    val availStorageBytes: Long,
+    val batteryPercent: Int,
+    val charging: Boolean,
+) {
+    companion object {
+        /** Reads the current device readiness snapshot. */
+        fun read(context: Context): DeviceInfo {
+            val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            val mi = ActivityManager.MemoryInfo()
+            am.getMemoryInfo(mi)
+            val stat = StatFs(context.filesDir.absolutePath)
+            val bm = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
+            val pct = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+            return DeviceInfo(
+                availMemBytes = mi.availMem,
+                totalMemBytes = mi.totalMem,
+                availStorageBytes = stat.availableBytes,
+                batteryPercent = if (pct in 0..100) pct else -1,
+                charging = bm.isCharging,
+            )
+        }
+    }
+}
+
+/** Formats a byte count as a compact human string (e.g. "3.2 GB"), locale-independent. */
+fun formatBytes(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val units = arrayOf("KB", "MB", "GB", "TB")
+    var value = bytes.toDouble() / 1024.0
+    var i = 0
+    while (value >= 1024.0 && i < units.size - 1) {
+        value /= 1024.0
+        i++
+    }
+    return String.format(Locale.US, "%.1f %s", value, units[i])
+}

--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
@@ -16,8 +16,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -49,6 +51,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -243,8 +246,12 @@ private fun ChatScreen(viewModel: ChatViewModel) {
     if (showSettings) {
         SettingsDialog(
             settings = state.settings,
+            modelConfig = state.modelConfig,
+            modelLoaded = state.modelState == ChatViewModel.ModelState.READY,
             onChange = viewModel::updateSettings,
+            onModelConfigChange = viewModel::updateModelConfig,
             onReset = viewModel::resetSettings,
+            onReload = viewModel::reloadModel,
             onClose = { showSettings = false },
         )
     }
@@ -339,12 +346,19 @@ private fun LogDialog(viewModel: ChatViewModel, onClose: () -> Unit) {
     }
 }
 
-/** Sampling-knobs sheet. Changes apply live; "Reset defaults" restores the shipped values. */
+/**
+ * Settings sheet. The **sampling** knobs apply live (per request); the **model** knobs
+ * (threads / context) are load-time and take effect via **Reload model**.
+ */
 @Composable
 private fun SettingsDialog(
     settings: ChatViewModel.GenerationSettings,
+    modelConfig: ChatViewModel.ModelConfig,
+    modelLoaded: Boolean,
     onChange: (ChatViewModel.GenerationSettings) -> Unit,
+    onModelConfigChange: (ChatViewModel.ModelConfig) -> Unit,
     onReset: () -> Unit,
+    onReload: () -> Unit,
     onClose: () -> Unit,
 ) {
     Dialog(onDismissRequest = onClose) {
@@ -367,8 +381,23 @@ private fun SettingsDialog(
                 IntSetting(R.string.settings_max_tokens, settings.maxTokens, 16..1024) {
                     onChange(settings.copy(maxTokens = it))
                 }
+
+                // Load-time model knobs: only take effect on (re)load, so they carry an explicit
+                // Reload button (enabled when a model is loaded).
+                Spacer(Modifier.height(12.dp))
+                Text(stringResource(R.string.settings_model_section), style = MaterialTheme.typography.titleMedium)
+                IntSetting(R.string.settings_threads, modelConfig.threads, 1..16) {
+                    onModelConfigChange(modelConfig.copy(threads = it))
+                }
+                IntSetting(R.string.settings_context, modelConfig.contextSize, 512..8192) {
+                    onModelConfigChange(modelConfig.copy(contextSize = it))
+                }
+
                 Spacer(Modifier.height(8.dp))
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = onReload, enabled = modelLoaded) {
+                        Text(stringResource(R.string.settings_reload))
+                    }
                     TextButton(onClick = onReset) { Text(stringResource(R.string.settings_reset)) }
                     TextButton(onClick = onClose) { Text(stringResource(R.string.action_close)) }
                 }
@@ -454,8 +483,51 @@ private fun ChooseModelView(error: String?, onChoose: () -> Unit) {
         ) {
             Text(stringResource(R.string.action_choose_model))
         }
+        DeviceCard(modifier = Modifier.padding(top = 24.dp))
         if (error != null) {
             Text(text = error, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(top = 16.dp))
+        }
+    }
+}
+
+/** A small readiness card: free RAM / storage / battery — so the user can gauge if a model fits. */
+@Composable
+private fun DeviceCard(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    // One-shot read at composition; the picker screen is short-lived, so live updates aren't needed.
+    val device = remember { DeviceInfo.read(context) }
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+        modifier = modifier,
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(stringResource(R.string.cd_device), style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "${stringResource(R.string.device_ram)}: " +
+                    stringResource(
+                        R.string.device_free_of,
+                        formatBytes(device.availMemBytes),
+                        formatBytes(device.totalMemBytes),
+                    ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                "${stringResource(R.string.device_storage)}: ${formatBytes(device.availStorageBytes)}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            val battery =
+                if (device.batteryPercent >= 0) {
+                    val charging = if (device.charging) " (${stringResource(R.string.device_charging)})" else ""
+                    "${device.batteryPercent}%$charging"
+                } else {
+                    "—"
+                }
+            Text(
+                "${stringResource(R.string.device_battery)}: $battery",
+                style = MaterialTheme.typography.bodyMedium,
+            )
         }
     }
 }
@@ -528,6 +600,26 @@ private fun Conversation(
 
         val ready = state.modelState == ChatViewModel.ModelState.READY
         var draft by remember { mutableStateOf("") }
+
+        // Prompt shortcut chips: quick starters that fill the input (localized). Shown only when
+        // ready, idle, and the input is still empty, so they don't clutter an in-progress message.
+        if (ready && !state.generating && draft.isBlank()) {
+            Row(
+                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                for (chip in intArrayOf(R.string.chip_summarize, R.string.chip_explain, R.string.chip_ideas)) {
+                    val label = stringResource(chip)
+                    SuggestionChip(
+                        onClick = { draft = "$label " },
+                        label = { Text(label) },
+                        modifier = Modifier.testTag("promptChip"),
+                    )
+                }
+            }
+        }
+
         Row(
             modifier = Modifier.fillMaxWidth().padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -598,11 +690,15 @@ private fun NotReadyBanner(modelState: ChatViewModel.ModelState, onChoose: () ->
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun MessageBubble(message: ChatViewModel.Message) {
     val isUser = message.role == "user"
     val bubbleColor =
         if (isUser) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val copiedMsg = stringResource(R.string.toast_copied)
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
@@ -610,7 +706,18 @@ private fun MessageBubble(message: ChatViewModel.Message) {
         Surface(
             color = bubbleColor,
             shape = MaterialTheme.shapes.medium,
-            modifier = Modifier.testTag(if (isUser) "userMessage" else "assistantMessage"),
+            modifier = Modifier
+                .testTag(if (isUser) "userMessage" else "assistantMessage")
+                // Long-press any bubble to copy its text (complements the last-reply Copy button).
+                .combinedClickable(
+                    onClick = {},
+                    onLongClick = {
+                        if (message.text.isNotBlank()) {
+                            clipboard.setText(AnnotatedString(message.text))
+                            Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+                        }
+                    },
+                ),
         ) {
             Text(text = message.text.ifEmpty { "…" }, modifier = Modifier.padding(12.dp))
         }

--- a/android-llmservice/app/src/main/res/values-ar/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ar/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">مسح المحادثة؟</string>
     <string name="clear_confirm_message">يؤدي هذا إلى إزالة جميع الرسائل في المحادثة الحالية.</string>
     <string name="badge_offline">🔒 دون اتصال · بالكامل على الجهاز</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">الجهاز</string>
+    <string name="device_ram">الذاكرة</string>
+    <string name="device_storage">التخزين</string>
+    <string name="device_battery">البطارية</string>
+    <string name="device_free_of">%1$s متاح من %2$s</string>
+    <string name="device_charging">قيد الشحن</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">لخّص هذا</string>
+    <string name="chip_explain">اشرح خطوة بخطوة</string>
+    <string name="chip_ideas">أعطني أفكارًا</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">النموذج (أعد التحميل للتطبيق)</string>
+    <string name="settings_threads">خيوط المعالج</string>
+    <string name="settings_context">طول السياق</string>
+    <string name="settings_reload">إعادة تحميل النموذج</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-de/strings.xml
+++ b/android-llmservice/app/src/main/res/values-de/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">Chat löschen?</string>
     <string name="clear_confirm_message">Dies entfernt alle Nachrichten in der aktuellen Unterhaltung.</string>
     <string name="badge_offline">🔒 Offline · vollständig auf dem Gerät</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">Gerät</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">Speicher</string>
+    <string name="device_battery">Akku</string>
+    <string name="device_free_of">%1$s frei von %2$s</string>
+    <string name="device_charging">lädt</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">Das zusammenfassen</string>
+    <string name="chip_explain">Schritt für Schritt erklären</string>
+    <string name="chip_ideas">Gib mir Ideen</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">Modell (neu laden zum Übernehmen)</string>
+    <string name="settings_threads">CPU-Threads</string>
+    <string name="settings_context">Kontextlänge</string>
+    <string name="settings_reload">Modell neu laden</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-es/strings.xml
+++ b/android-llmservice/app/src/main/res/values-es/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">¿Borrar chat?</string>
     <string name="clear_confirm_message">Esto elimina todos los mensajes de la conversación actual.</string>
     <string name="badge_offline">🔒 Sin conexión · totalmente en el dispositivo</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">Dispositivo</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">Almacenamiento</string>
+    <string name="device_battery">Batería</string>
+    <string name="device_free_of">%1$s libres de %2$s</string>
+    <string name="device_charging">cargando</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">Resume esto</string>
+    <string name="chip_explain">Explica paso a paso</string>
+    <string name="chip_ideas">Dame ideas</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">Modelo (recargar para aplicar)</string>
+    <string name="settings_threads">Hilos de CPU</string>
+    <string name="settings_context">Longitud de contexto</string>
+    <string name="settings_reload">Recargar modelo</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-fr/strings.xml
+++ b/android-llmservice/app/src/main/res/values-fr/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">Effacer la conversation ?</string>
     <string name="clear_confirm_message">Cela supprime tous les messages de la conversation actuelle.</string>
     <string name="badge_offline">🔒 Hors ligne · entièrement sur l\'appareil</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">Appareil</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">Stockage</string>
+    <string name="device_battery">Batterie</string>
+    <string name="device_free_of">%1$s libres sur %2$s</string>
+    <string name="device_charging">en charge</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">Résume ceci</string>
+    <string name="chip_explain">Explique étape par étape</string>
+    <string name="chip_ideas">Donne-moi des idées</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">Modèle (recharger pour appliquer)</string>
+    <string name="settings_threads">Threads CPU</string>
+    <string name="settings_context">Longueur de contexte</string>
+    <string name="settings_reload">Recharger le modèle</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-hi/strings.xml
+++ b/android-llmservice/app/src/main/res/values-hi/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">चैट साफ़ करें?</string>
     <string name="clear_confirm_message">यह वर्तमान बातचीत के सभी संदेश हटा देता है।</string>
     <string name="badge_offline">🔒 ऑफ़लाइन · पूरी तरह डिवाइस पर</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">डिवाइस</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">संग्रहण</string>
+    <string name="device_battery">बैटरी</string>
+    <string name="device_free_of">%2$s में से %1$s खाली</string>
+    <string name="device_charging">चार्ज हो रहा</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">इसका सारांश दें</string>
+    <string name="chip_explain">चरण दर चरण समझाएँ</string>
+    <string name="chip_ideas">मुझे विचार दें</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">मॉडल (लागू करने हेतु पुनः लोड करें)</string>
+    <string name="settings_threads">CPU थ्रेड्स</string>
+    <string name="settings_context">संदर्भ लंबाई</string>
+    <string name="settings_reload">मॉडल पुनः लोड करें</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-it/strings.xml
+++ b/android-llmservice/app/src/main/res/values-it/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">Cancellare la chat?</string>
     <string name="clear_confirm_message">Rimuove tutti i messaggi della conversazione attuale.</string>
     <string name="badge_offline">🔒 Offline · completamente sul dispositivo</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">Dispositivo</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">Archiviazione</string>
+    <string name="device_battery">Batteria</string>
+    <string name="device_free_of">%1$s liberi su %2$s</string>
+    <string name="device_charging">in carica</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">Riassumi questo</string>
+    <string name="chip_explain">Spiega passo passo</string>
+    <string name="chip_ideas">Dammi delle idee</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">Modello (ricarica per applicare)</string>
+    <string name="settings_threads">Thread CPU</string>
+    <string name="settings_context">Lunghezza contesto</string>
+    <string name="settings_reload">Ricarica modello</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ja/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ja/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">チャットをクリアしますか？</string>
     <string name="clear_confirm_message">現在の会話のすべてのメッセージを削除します。</string>
     <string name="badge_offline">🔒 オフライン · 完全にデバイス上</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">デバイス</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">ストレージ</string>
+    <string name="device_battery">バッテリー</string>
+    <string name="device_free_of">%2$s 中 %1$s 空き</string>
+    <string name="device_charging">充電中</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">これを要約</string>
+    <string name="chip_explain">手順ごとに説明</string>
+    <string name="chip_ideas">アイデアをください</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">モデル（適用するには再読み込み）</string>
+    <string name="settings_threads">CPU スレッド</string>
+    <string name="settings_context">コンテキスト長</string>
+    <string name="settings_reload">モデルを再読み込み</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ko/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ko/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">채팅을 지우시겠어요?</string>
     <string name="clear_confirm_message">현재 대화의 모든 메시지가 삭제됩니다.</string>
     <string name="badge_offline">🔒 오프라인 · 완전히 기기에서</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">기기</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">저장공간</string>
+    <string name="device_battery">배터리</string>
+    <string name="device_free_of">%2$s 중 %1$s 사용 가능</string>
+    <string name="device_charging">충전 중</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">이것을 요약</string>
+    <string name="chip_explain">단계별로 설명</string>
+    <string name="chip_ideas">아이디어를 줘</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">모델 (적용하려면 다시 로드)</string>
+    <string name="settings_threads">CPU 스레드</string>
+    <string name="settings_context">컨텍스트 길이</string>
+    <string name="settings_reload">모델 다시 로드</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-pt/strings.xml
+++ b/android-llmservice/app/src/main/res/values-pt/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">Limpar conversa?</string>
     <string name="clear_confirm_message">Isto remove todas as mensagens da conversa atual.</string>
     <string name="badge_offline">🔒 Offline · totalmente no dispositivo</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">Dispositivo</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">Armazenamento</string>
+    <string name="device_battery">Bateria</string>
+    <string name="device_free_of">%1$s livres de %2$s</string>
+    <string name="device_charging">a carregar</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">Resume isto</string>
+    <string name="chip_explain">Explica passo a passo</string>
+    <string name="chip_ideas">Dá-me ideias</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">Modelo (recarregar para aplicar)</string>
+    <string name="settings_threads">Threads da CPU</string>
+    <string name="settings_context">Comprimento do contexto</string>
+    <string name="settings_reload">Recarregar modelo</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ru/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ru/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">Очистить чат?</string>
     <string name="clear_confirm_message">Это удалит все сообщения в текущем разговоре.</string>
     <string name="badge_offline">🔒 Офлайн · полностью на устройстве</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">Устройство</string>
+    <string name="device_ram">ОЗУ</string>
+    <string name="device_storage">Хранилище</string>
+    <string name="device_battery">Батарея</string>
+    <string name="device_free_of">%1$s свободно из %2$s</string>
+    <string name="device_charging">заряжается</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">Кратко изложи это</string>
+    <string name="chip_explain">Объясни пошагово</string>
+    <string name="chip_ideas">Дай мне идеи</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">Модель (перезагрузить для применения)</string>
+    <string name="settings_threads">Потоки ЦП</string>
+    <string name="settings_context">Длина контекста</string>
+    <string name="settings_reload">Перезагрузить модель</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-tr/strings.xml
+++ b/android-llmservice/app/src/main/res/values-tr/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">Sohbet temizlensin mi?</string>
     <string name="clear_confirm_message">Bu, mevcut sohbetteki tüm mesajları kaldırır.</string>
     <string name="badge_offline">🔒 Çevrimdışı · tamamen cihazda</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">Cihaz</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">Depolama</string>
+    <string name="device_battery">Pil</string>
+    <string name="device_free_of">%2$s içinden %1$s boş</string>
+    <string name="device_charging">şarj oluyor</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">Bunu özetle</string>
+    <string name="chip_explain">Adım adım açıkla</string>
+    <string name="chip_ideas">Bana fikir ver</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">Model (uygulamak için yeniden yükle)</string>
+    <string name="settings_threads">CPU iş parçacıkları</string>
+    <string name="settings_context">Bağlam uzunluğu</string>
+    <string name="settings_reload">Modeli yeniden yükle</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android-llmservice/app/src/main/res/values-zh-rCN/strings.xml
@@ -53,4 +53,22 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">清除对话？</string>
     <string name="clear_confirm_message">这将删除当前对话中的所有消息。</string>
     <string name="badge_offline">🔒 离线 · 完全在设备上</string>
+    <!-- Device readiness card -->
+    <string name="cd_device">设备</string>
+    <string name="device_ram">内存</string>
+    <string name="device_storage">存储</string>
+    <string name="device_battery">电池</string>
+    <string name="device_free_of">%2$s 中可用 %1$s</string>
+    <string name="device_charging">充电中</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">总结这段内容</string>
+    <string name="chip_explain">逐步解释</string>
+    <string name="chip_ideas">给我一些想法</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">模型（重新加载以应用）</string>
+    <string name="settings_threads">CPU 线程</string>
+    <string name="settings_context">上下文长度</string>
+    <string name="settings_reload">重新加载模型</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values/strings.xml
+++ b/android-llmservice/app/src/main/res/values/strings.xml
@@ -58,4 +58,23 @@ SPDX-License-Identifier: MIT
     <string name="clear_confirm_title">Clear chat?</string>
     <string name="clear_confirm_message">This removes all messages in the current conversation.</string>
     <string name="badge_offline">🔒 Offline · fully on-device</string>
+
+    <!-- Device readiness card (model-picker screen) -->
+    <string name="cd_device">Device</string>
+    <string name="device_ram">RAM</string>
+    <string name="device_storage">Storage</string>
+    <string name="device_battery">Battery</string>
+    <string name="device_free_of">%1$s free of %2$s</string>
+    <string name="device_charging">charging</string>
+
+    <!-- Prompt shortcut chips -->
+    <string name="chip_summarize">Summarize this</string>
+    <string name="chip_explain">Explain step by step</string>
+    <string name="chip_ideas">Give me ideas</string>
+
+    <!-- Model (load-time) settings -->
+    <string name="settings_model_section">Model (reload to apply)</string>
+    <string name="settings_threads">CPU threads</string>
+    <string name="settings_context">Context length</string>
+    <string name="settings_reload">Reload model</string>
 </resources>

--- a/android-llmservice/requirements.md
+++ b/android-llmservice/requirements.md
@@ -59,6 +59,7 @@ by hand only (no automated test); `build` = enforced at build/resource-compile t
 | R3.4 | While loading, a **LOADING** state is shown (spinner + "Loading model…"); on failure a localized load error is shown and state returns to NONE. | `ChatViewModel.ModelState`; `error_load_model` | manual |
 | R3.5 | Loading a new model **closes** the previously loaded one (native memory is not GC-managed). | `ChatViewModel.openModel` | manual |
 | R3.6 | Recommended real model for coherent replies: an instruct GGUF (default **Gemma 3 4B Instruct**); base/completion models still run. | `README.md` | manual |
+| R3.7 | The model-picker screen shows a **device-readiness card**: free/total **RAM** (`ActivityManager.MemoryInfo`), free **storage** (`StatFs`), and **battery** level + charging (`BatteryManager`) — so the user can gauge whether a model fits before loading. Read once at composition. | `DeviceInfo`; `MainActivity.DeviceCard` | manual |
 
 ## R4 — Chat & streaming
 
@@ -70,6 +71,7 @@ by hand only (no automated test); `build` = enforced at build/resource-compile t
 | R4.4 | `send` is a **no-op** when the input is blank, no model is loaded, or a generation is already in flight. | `ChatViewModel.send` | manual |
 | R4.5 | An optional **chat-template override** (e.g. `chatml`) is supported for template-less GGUFs (used by the test hook; real instruct models carry their own template). | `ChatViewModel.chatTemplate` | instrumented |
 | R4.6 | A generation error keeps the partial reply and surfaces a localized generation error. | `ChatViewModel.startGeneration`; `error_generation` | manual |
+| R4.7 | **Prompt shortcut chips** (localized `SuggestionChip`s) appear above the input when ready/idle and the input is empty; tapping one fills the draft with a quick-start prompt. | `MainActivity.Conversation` (`promptChip`); `chip_*` | manual |
 
 ## R5 — Generation settings (sampling)
 
@@ -80,6 +82,7 @@ by hand only (no automated test); `build` = enforced at build/resource-compile t
 | R5.3 | All seven knobs are forwarded verbatim to `InferenceParameters` on every generation. | `ChatViewModel.startGeneration` | manual |
 | R5.4 | The **repeat penalty > 1 with a non-zero repeat range is required** — it is what prevents the degenerate repetition loop small on-device models fall into with a bare decode. | `ChatViewModel.startGeneration` (comment) | manual |
 | R5.5 | Slider ranges: temperature `0–2`, Top-K `0–100`, Top-P/Min-P `0–1`, repeat penalty `1–2`, repeat range `0–256`, max tokens `16–1024`. | `MainActivity.SettingsDialog` | manual |
+| R5.6 | The Settings sheet also has a **"Model" section** for the **load-time** params **CPU threads** (`1–16`, default 4) and **Context length** (`512–8192`, default 2048). These are **not** live — a **Reload model** button (enabled only when a model is loaded) reopens the current model with the new values. | `MainActivity.SettingsDialog`; `ChatViewModel.ModelConfig` / `reloadModel` | manual |
 
 ## R6 — Chat actions
 
@@ -90,6 +93,7 @@ by hand only (no automated test); `build` = enforced at build/resource-compile t
 | R6.3 | **Regenerate:** re-runs the last user turn — drops the trailing assistant reply and regenerates from the conversation up to that user turn (using the current sampling settings). | `MainActivity` (`regenerateButton`); `ChatViewModel.regenerate` | manual |
 | R6.4 | Copy/Regenerate appear only when idle and the last message is a **non-empty assistant reply**. | `MainActivity.Conversation` | manual |
 | R6.5 | **Clear chat:** 🗑 in the top bar (enabled only with messages present and not generating) clears the conversation after a **confirm dialog**. | `MainActivity` (`clearButton`); `ChatViewModel.clearChat` | manual |
+| R6.6 | **Long-press any message bubble** copies that message's text to the clipboard (with a "Copied" toast) — complements the last-reply Copy button (R6.2). | `MainActivity.MessageBubble` (`combinedClickable`) | manual |
 
 ## R7 — In-app log
 


### PR DESCRIPTION
## Summary

Four small TODO quick-wins (all XS–S, no new dependency, no network):

1. **Device-readiness card** (§2) — the model-picker screen now shows **free/total RAM** (`ActivityManager.MemoryInfo`), **free storage** (`StatFs`), and **battery** level + charging (`BatteryManager`) via a new `DeviceInfo` + `DeviceCard`, so the user can gauge whether a model fits before loading. One-shot read, no permission, no reload.
2. **Per-message copy** (§3) — **long-press any chat bubble** copies its text to the clipboard (`combinedClickable` + toast), complementing the existing last-reply Copy button.
3. **CPU threads + context length** (§6) — a new **"Model" section** in the ⚙️ Settings sheet (threads `1–16`, context `512–8192`). These are **load-time** `ModelParameters`, so they take effect via a new **Reload model** button (enabled only when a model is loaded). `ChatViewModel` gains `ModelConfig` + `reloadModel`; `openModel` now uses the config's threads/ctx (was a hardcoded constant).
4. **Prompt shortcut chips** (§3) — localized `SuggestionChip`s above the input (shown when ready/idle and the input is empty) that fill the draft with a quick-start prompt.

New UI strings translated across all **13** languages. Docs synced per the `requirements.md` rule: **R3.7 / R4.7 / R5.6 / R6.6**, TODO rows flipped, README layout (+ `DeviceInfo.kt`), CLAUDE.md android section.

The instrumented UI test is unaffected: it preloads a model (→ Conversation, not the picker) and drives `promptInput`/`sendButton`; chips hide once the draft is non-empty; the device card only renders on the picker.

## Test plan

- [x] Standard AndroidX APIs (`ActivityManager`/`StatFs`/`BatteryManager`), `SuggestionChip` (stable M3), `combinedClickable` (`@OptIn(ExperimentalFoundationApi)`)
- [x] CI `build-android-llmservice` compiles + runs the on-device Compose test (API 30 emulator)
- [x] Docs synced — `requirements.md`, `TODO.md`, `README.md`, `CLAUDE.md`

## Related issues / PRs

Follow-up to the `android-llmservice` app (PRs #310–#319). Implements the four "next easy" TODO items.

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m)_