### PR TITLE
ci(android-llmservice): always build the APK; split off the emulator test as an optional non-gating check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1084,6 +1084,16 @@ jobs:
           path: models/
           key: gguf-models-${{ hashFiles('.github/models.csv') }}
           enableCrossOsArchive: true
+      - name: Free disk space for the emulator (only the draft model is needed on-device)
+        # Same guard as build-android-llmservice: the AVD userdata partition needs ~7.4 GB; drop the
+        # rest of the restored ~10 GB GGUF cache (this job adb-pushes only the tiny draft model) plus
+        # large preinstalled toolchains so the emulator can create userdata and boot.
+        run: |
+          echo "Disk before cleanup:"; df -h / | tail -1
+          find models -type f ! -name "${DRAFT_MODEL_NAME}" -delete 2>/dev/null || true
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/powershell /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+          docker image prune -af 2>/dev/null || true
+          echo "Disk after cleanup:"; df -h / | tail -1
       - name: Run on-emulator instrumentation (connectedDebugAndroidTest)
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -1199,6 +1209,18 @@ jobs:
           path: models/
           key: gguf-models-${{ hashFiles('.github/models.csv') }}
           enableCrossOsArchive: true
+      - name: Free disk space for the emulator (only the draft model is needed on-device)
+        # The AVD userdata partition needs ~7.4 GB; the release R8 build + the full ~10 GB GGUF
+        # cache restore left too little free, so the emulator FATALs ("Not enough space to create
+        # userdata partition") and the boot poll loops until timeout. This job only adb-pushes the
+        # tiny draft model, so drop the rest of the restored cache plus large preinstalled
+        # toolchains this Android job never uses.
+        run: |
+          echo "Disk before cleanup:"; df -h / | tail -1
+          find models -type f ! -name "${DRAFT_MODEL_NAME}" -delete 2>/dev/null || true
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/powershell /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+          docker image prune -af 2>/dev/null || true
+          echo "Disk after cleanup:"; df -h / | tail -1
       - name: Run LLM Service UI test on emulator (connectedDebugAndroidTest)
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
## Summary

Two related CI fixes for the LLM Service Android app so a flaky/slow emulator never blocks getting the installable APK.

**1. Free disk space before the emulator.** The emulator FATALed with `Not enough space to create userdata partition. Available: 3892 MB, need 7372 MB` → never booted → the boot-poll loop ran to timeout (looked like a hang). Root cause: the full **~10 GB** GGUF cache restore left too little free, but only the **tiny draft model** is pushed to the device. Added a cleanup step (both emulator jobs) that deletes every restored model except `DRAFT_MODEL_NAME` (generic `find … ! -name`) + large unused preinstalled toolchains + docker images → frees ~15 GB. **Verified in the last run:** "Disk space requirements … are met", emulator booted, `connectedDebugAndroidTest` started.

**2. Split build ⟂ emulator test.** Previously one job built the AAB/APK **and** ran the emulator test, with the artifact-upload steps **after** the test — so a red emulator meant **no APK**. Now split into two jobs:
- **`build-android-llmservice`** — builds the release AAB + installable APK and uploads them. **No emulator, no model cache.** A flaky emulator can never block the APK. (Also dropped `verify-model-cache` from its `needs` and `assembleDebug` from the build.)
- **`test-android-llmservice`** *(new)* — a **separate, non-gating** check that boots the emulator and runs `connectedDebugAndroidTest`. It can go **red on its own** without stopping the build/artifacts. Keep it **non-required** in branch protection to make the emulator test optional (visible-but-non-blocking) — exactly the "sim test more optional but still can be red" ask.

CLAUDE.md's CI-wiring section updated to describe the split.

Split out of #320 (already merged); this is CI-only, on top of current `main`.

## Test plan

- [x] YAML validated (`yaml.safe_load`); both jobs parse with correct `needs`
- [x] Disk fix already proven in the prior run (emulator boots)
- [x] Build job no longer depends on the emulator → APK/AAB always uploaded

## Checklist

- [x] Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m