### PR TITLE
feat(android-llmservice): quit + clean up button (❌) on the main screen

### DIFF
--- a/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
+++ b/android-llmservice/app/src/main/kotlin/net/ladenthin/android/llmservice/MainActivity.kt
@@ -4,6 +4,7 @@
 
 package net.ladenthin.android.llmservice
 
+import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
@@ -157,6 +158,7 @@ private fun ChatScreen(viewModel: ChatViewModel) {
     var showSettings by remember { mutableStateOf(false) }
     var showLog by remember { mutableStateOf(false) }
     var showClearConfirm by remember { mutableStateOf(false) }
+    var showQuitConfirm by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -220,7 +222,11 @@ private fun ChatScreen(viewModel: ChatViewModel) {
                     LoadingView()
 
                 !hasConversation ->
-                    ChooseModelView(error = errorText(state.error), onChoose = onChoose)
+                    ChooseModelView(
+                        error = errorText(state.error),
+                        onChoose = onChoose,
+                        onRequestQuit = { showQuitConfirm = true },
+                    )
 
                 else ->
                     Conversation(
@@ -247,6 +253,26 @@ private fun ChatScreen(viewModel: ChatViewModel) {
             },
             dismissButton = {
                 TextButton(onClick = { showClearConfirm = false }) { Text(stringResource(R.string.action_cancel)) }
+            },
+        )
+    }
+    if (showQuitConfirm) {
+        AlertDialog(
+            onDismissRequest = { showQuitConfirm = false },
+            title = { Text(stringResource(R.string.quit_confirm_title)) },
+            text = { Text(stringResource(R.string.quit_confirm_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showQuitConfirm = false
+                    // Wipe the transient working data (model copy + cache) — the saved session
+                    // (session.json) is deliberately NOT touched — then close the app and drop it
+                    // from Recents.
+                    LlmServiceApp.clearWorkingData(context)
+                    (context as? Activity)?.finishAndRemoveTask()
+                }) { Text(stringResource(R.string.action_quit)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showQuitConfirm = false }) { Text(stringResource(R.string.action_cancel)) }
             },
         )
     }
@@ -476,23 +502,32 @@ private fun LoadingView() {
 }
 
 @Composable
-private fun ChooseModelView(error: String?, onChoose: () -> Unit) {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        OfflineBadge(modifier = Modifier.padding(bottom = 16.dp))
-        Text(text = stringResource(R.string.intro_pick_model), textAlign = TextAlign.Center)
-        Button(
-            onClick = onChoose,
-            modifier = Modifier.padding(top = 24.dp).testTag("chooseModelButton"),
+private fun ChooseModelView(error: String?, onChoose: () -> Unit, onRequestQuit: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
-            Text(stringResource(R.string.action_choose_model))
+            OfflineBadge(modifier = Modifier.padding(bottom = 16.dp))
+            Text(text = stringResource(R.string.intro_pick_model), textAlign = TextAlign.Center)
+            Button(
+                onClick = onChoose,
+                modifier = Modifier.padding(top = 24.dp).testTag("chooseModelButton"),
+            ) {
+                Text(stringResource(R.string.action_choose_model))
+            }
+            DeviceCard(modifier = Modifier.padding(top = 24.dp))
+            if (error != null) {
+                Text(text = error, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(top = 16.dp))
+            }
         }
-        DeviceCard(modifier = Modifier.padding(top = 24.dp))
-        if (error != null) {
-            Text(text = error, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(top = 16.dp))
+        // Quit + clean up (keeps saved chats) — a "close app" ❌ at the top-right of the main screen.
+        IconButton(
+            onClick = onRequestQuit,
+            modifier = Modifier.align(Alignment.TopEnd).testTag("quitButton"),
+        ) {
+            Text("❌")
         }
     }
 }

--- a/android-llmservice/app/src/main/res/values-ar/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ar/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">خيوط المعالج</string>
     <string name="settings_context">طول السياق</string>
     <string name="settings_reload">إعادة تحميل النموذج</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">خروج</string>
+    <string name="quit_confirm_title">الخروج والتنظيف؟</string>
+    <string name="quit_confirm_message">يغلق التطبيق ويحذف بيانات العمل (النموذج المنسوخ + ذاكرة التخزين المؤقت). تُحفظ المحادثات المخزنة.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-de/strings.xml
+++ b/android-llmservice/app/src/main/res/values-de/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">CPU-Threads</string>
     <string name="settings_context">Kontextlänge</string>
     <string name="settings_reload">Modell neu laden</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">Beenden</string>
+    <string name="quit_confirm_title">Beenden und aufräumen?</string>
+    <string name="quit_confirm_message">Schließt die App und löscht Arbeitsdaten (kopiertes Modell + Cache). Gespeicherte Chats bleiben erhalten.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-es/strings.xml
+++ b/android-llmservice/app/src/main/res/values-es/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">Hilos de CPU</string>
     <string name="settings_context">Longitud de contexto</string>
     <string name="settings_reload">Recargar modelo</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">Salir</string>
+    <string name="quit_confirm_title">¿Salir y limpiar?</string>
+    <string name="quit_confirm_message">Cierra la app y elimina los datos de trabajo (el modelo copiado + la caché). Los chats guardados se conservan.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-fr/strings.xml
+++ b/android-llmservice/app/src/main/res/values-fr/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">Threads CPU</string>
     <string name="settings_context">Longueur de contexte</string>
     <string name="settings_reload">Recharger le modèle</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">Quitter</string>
+    <string name="quit_confirm_title">Quitter et nettoyer ?</string>
+    <string name="quit_confirm_message">Ferme l\'application et supprime les données de travail (le modèle copié + le cache). Les conversations enregistrées sont conservées.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-hi/strings.xml
+++ b/android-llmservice/app/src/main/res/values-hi/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">CPU थ्रेड्स</string>
     <string name="settings_context">संदर्भ लंबाई</string>
     <string name="settings_reload">मॉडल पुनः लोड करें</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">बंद करें</string>
+    <string name="quit_confirm_title">बंद करें और साफ़ करें?</string>
+    <string name="quit_confirm_message">ऐप बंद करता है और कार्यशील डेटा (कॉपी किया गया मॉडल + कैश) हटाता है। सहेजी गई चैट बनी रहती हैं।</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-it/strings.xml
+++ b/android-llmservice/app/src/main/res/values-it/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">Thread CPU</string>
     <string name="settings_context">Lunghezza contesto</string>
     <string name="settings_reload">Ricarica modello</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">Esci</string>
+    <string name="quit_confirm_title">Uscire e ripulire?</string>
+    <string name="quit_confirm_message">Chiude l\'app ed elimina i dati di lavoro (il modello copiato + la cache). Le chat salvate vengono mantenute.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ja/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ja/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">CPU スレッド</string>
     <string name="settings_context">コンテキスト長</string>
     <string name="settings_reload">モデルを再読み込み</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">終了</string>
+    <string name="quit_confirm_title">終了してクリーンアップしますか？</string>
+    <string name="quit_confirm_message">アプリを閉じて作業データ（コピーしたモデル + キャッシュ）を削除します。保存済みのチャットは残ります。</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ko/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ko/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">CPU 스레드</string>
     <string name="settings_context">컨텍스트 길이</string>
     <string name="settings_reload">모델 다시 로드</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">종료</string>
+    <string name="quit_confirm_title">종료하고 정리할까요?</string>
+    <string name="quit_confirm_message">앱을 닫고 작업 데이터(복사된 모델 + 캐시)를 삭제합니다. 저장된 채팅은 유지됩니다.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-pt/strings.xml
+++ b/android-llmservice/app/src/main/res/values-pt/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">Threads da CPU</string>
     <string name="settings_context">Comprimento do contexto</string>
     <string name="settings_reload">Recarregar modelo</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">Sair</string>
+    <string name="quit_confirm_title">Sair e limpar?</string>
+    <string name="quit_confirm_message">Fecha a app e elimina os dados de trabalho (o modelo copiado + a cache). As conversas guardadas são mantidas.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-ru/strings.xml
+++ b/android-llmservice/app/src/main/res/values-ru/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">Потоки ЦП</string>
     <string name="settings_context">Длина контекста</string>
     <string name="settings_reload">Перезагрузить модель</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">Выйти</string>
+    <string name="quit_confirm_title">Выйти и очистить?</string>
+    <string name="quit_confirm_message">Закрывает приложение и удаляет рабочие данные (скопированную модель + кэш). Сохранённые чаты остаются.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-tr/strings.xml
+++ b/android-llmservice/app/src/main/res/values-tr/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">CPU iş parçacıkları</string>
     <string name="settings_context">Bağlam uzunluğu</string>
     <string name="settings_reload">Modeli yeniden yükle</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">Çık</string>
+    <string name="quit_confirm_title">Çıkılsın ve temizlensin mi?</string>
+    <string name="quit_confirm_message">Uygulamayı kapatır ve çalışma verilerini siler (kopyalanan model + önbellek). Kaydedilen sohbetler korunur.</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android-llmservice/app/src/main/res/values-zh-rCN/strings.xml
@@ -71,4 +71,8 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">CPU 线程</string>
     <string name="settings_context">上下文长度</string>
     <string name="settings_reload">重新加载模型</string>
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">退出</string>
+    <string name="quit_confirm_title">退出并清理？</string>
+    <string name="quit_confirm_message">关闭应用并删除工作数据（已复制的模型 + 缓存）。已保存的对话会保留。</string>
 </resources>

--- a/android-llmservice/app/src/main/res/values/strings.xml
+++ b/android-llmservice/app/src/main/res/values/strings.xml
@@ -77,4 +77,9 @@ SPDX-License-Identifier: MIT
     <string name="settings_threads">CPU threads</string>
     <string name="settings_context">Context length</string>
     <string name="settings_reload">Reload model</string>
+
+    <!-- Quit + clean up (from the main screen) -->
+    <string name="action_quit">Quit</string>
+    <string name="quit_confirm_title">Quit and clean up?</string>
+    <string name="quit_confirm_message">Closes the app and deletes working data (the copied model + cache). Saved chats are kept.</string>
 </resources>

--- a/android-llmservice/requirements.md
+++ b/android-llmservice/requirements.md
@@ -48,6 +48,7 @@ by hand only (no automated test); `build` = enforced at build/resource-compile t
 | R2.3 | All inference runs **on-device** (CPU); no request is ever made to a remote server by the app. | `ChatViewModel` (no network calls) | manual |
 | R2.4 | A **"🔒 Offline · fully on-device"** badge is shown on the model-picker screen. | `MainActivity.OfflineBadge`; `badge_offline` | manual |
 | R2.5 | **Transient working data is ephemeral:** the copied model (`current-model.gguf`) and the cache dir are **wiped on every cold start** (`LlmServiceApp.onCreate`) — guaranteeing a fresh start regardless of how the app was last killed — and best-effort on finish (`MainActivity.onDestroy` when `isFinishing`). The **only** data that persists is the user's **explicitly saved** session (`session.json`, opt-in). | `LlmServiceApp`; `MainActivity.onDestroy` | manual |
+| R2.6 | **Quit & clean up:** a ❌ button on the model-picker (main) screen opens a confirm dialog that, on confirm, **wipes the working data** (model copy + cache, keeping the saved session) and **closes the app** (`finishAndRemoveTask` — removed from Recents). | `MainActivity` (`quitButton`; `LlmServiceApp.clearWorkingData` + `finishAndRemoveTask`) | manual |
 
 ## R3 — Model selection & loading
 


### PR DESCRIPTION
## Summary

Adds a **❌ at the top-right of the model-picker (main) screen** to **safely quit the app and wipe working data — keeping saved chats** (the counterpart to the in-chat unload ❌).

On tap → a confirm dialog ("Quit and clean up? … Saved chats are kept."). On confirm:
- `LlmServiceApp.clearWorkingData(context)` — deletes the copied model (`current-model.gguf`) + cache. **`session.json` (saved chats) is deliberately NOT touched.**
- `finishAndRemoveTask()` — closes the app and removes it from Recents.

So "delete everything except saved chats" is exactly what happens, and the app closes cleanly. New UI strings translated across all **13** languages. `requirements.md` **R2.6** added.

Placed on `ChooseModelView` (not the top bar), so it doesn't collide with the in-chat unload ❌ from #323.

## Test plan

- [x] `finishAndRemoveTask` via `(LocalContext as? Activity)`; `clearWorkingData` reuses the existing cold-start wipe (keeps `session.json`)
- [x] Button only on the main/picker screen (`quitButton` tag); confirm dialog before acting
- [x] All 13 languages + English validated (well-formed XML)

## Related issues / PRs

Follow-up to the `android-llmservice` app; complements the unload-model ❌ (#323). Independent of the CI split (#322).

## Checklist

- [x] Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTS5FpMtBLJENTGoRUrp5m)_