### PR TITLE
Upgrade gradle/actions/setup-gradle to v6 and pitest-maven to 1.25.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,7 +204,7 @@ jobs:
         with:
           java-version: '21'
           distribution: temurin
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.14.3"
       - name: Sign a throwaway artifact via useInMemoryPgpKeys (BouncyCastle)
@@ -915,7 +915,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.14.3"
       - name: Build core jar (byte-identical classes payload for the AAR)
@@ -1045,7 +1045,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.14.3"
       - name: Enable KVM group permissions (GitHub-hosted runner)
@@ -1138,7 +1138,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           # Kotlin 2.4's Gradle plugin deprecates Gradle < 8.14.4; the app uses the Kotlin
           # Android plugin, so bump this job to 8.14.4 (also carries two security fixes). The
@@ -1224,7 +1224,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.14.4"
       - name: Enable KVM group permissions (GitHub-hosted runner)
@@ -3140,7 +3140,7 @@ jobs:
       # the plain-Gradle build in llama-android/ — Maven cannot deploy
       # <packaging>aar</packaging>. Natives are already on disk from the artifact
       # downloads above; the core jar was just built by the reactor deploy.
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.14.3"
       - name: Publish Android AAR snapshots (llama-android + llama-android-opencl)
@@ -3329,7 +3329,7 @@ jobs:
       # the deployment publishes as soon as portal validation passes). Natives are
       # already on disk from the artifact downloads above; the core jar was just
       # built by the reactor deploy.
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.14.3"
       - name: Publish Android AAR release bundle to Central Portal

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -335,7 +335,7 @@ SPDX-License-Identifier: MIT
 				<plugin>
 					<groupId>org.pitest</groupId>
 					<artifactId>pitest-maven</artifactId>
-					<version>1.25.6</version>
+					<version>1.25.7</version>
 				</plugin>
 				<plugin>
 					<groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
## Summary

- Upgrade `gradle/actions/setup-gradle` from v4 to v6 across all GitHub Actions workflows
- Upgrade `pitest-maven` plugin from 1.25.6 to 1.25.7 in `llama/pom.xml`

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01EDGkPGwehc22JjeKFUfgyk