### PR TITLE
Upgrade AGP to 9.2.0 and Gradle to 9.4.1; update dependencies

### DIFF
--- a/.github/android-consumer-test/app/build.gradle.kts
+++ b/.github/android-consumer-test/app/build.gradle.kts
@@ -47,6 +47,6 @@ dependencies {
     implementation("net.ladenthin:llama-android:$jllamaVersion")
 
     // On-emulator instrumentation (test-android-emulator CI job).
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test:runner:1.7.0")
 }

--- a/.github/android-consumer-test/settings.gradle.kts
+++ b/.github/android-consumer-test/settings.gradle.kts
@@ -14,7 +14,9 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.7.3"
+        // AGP 9.x requires Gradle >= 9.4.1 — see the gradle-version pins on the CI jobs
+        // that build this fixture in publish.yml (package-android-aar, test-android-emulator).
+        id("com.android.application") version "9.2.0"
     }
 }
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -917,7 +917,8 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.14.3"
+          # AGP 9.2.0 (the .github/android-consumer-test fixture) requires Gradle >= 9.4.1.
+          gradle-version: "9.4.1"
       - name: Build core jar (byte-identical classes payload for the AAR)
         run: >
           mvn -B --no-transfer-progress -pl llama -am -DskipTests -Denforcer.skip=true
@@ -1047,7 +1048,8 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.14.3"
+          # AGP 9.2.0 (the .github/android-consumer-test fixture) requires Gradle >= 9.4.1.
+          gradle-version: "9.4.1"
       - name: Enable KVM group permissions (GitHub-hosted runner)
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -1140,10 +1142,10 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v6
         with:
-          # Kotlin 2.4's Gradle plugin deprecates Gradle < 8.14.4; the app uses the Kotlin
-          # Android plugin, so bump this job to 8.14.4 (also carries two security fixes). The
-          # AAR/lib jobs stay on the more-compatible 8.14.3 — they use no Kotlin Gradle plugin.
-          gradle-version: "8.14.4"
+          # AGP 9.2.0 (android-llmservice) requires Gradle >= 9.4.1; also satisfies Kotlin
+          # 2.4's Gradle-plugin floor. The AAR/lib-only jobs stay on an older Gradle since
+          # they build no AGP project.
+          gradle-version: "9.4.1"
       - name: Build core jar + install llama-kotlin facade to mavenLocal
         # install (not package) so the app's Gradle build resolves llama-kotlin +
         # the core POM from mavenLocal. llama-kotlin's core dep is provided-scope, so the
@@ -1226,7 +1228,8 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.14.4"
+          # AGP 9.2.0 (android-llmservice) requires Gradle >= 9.4.1.
+          gradle-version: "9.4.1"
       - name: Enable KVM group permissions (GitHub-hosted runner)
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1652,9 +1652,11 @@ compiles/loads the API); this one has a UI and is driven end-to-end. The name is
 domain is the only string that must be globally unique.
 
 Structure (mirrors the consumer-test's plumbing):
-- **`settings.gradle.kts`** — `rootProject.name = "android-llmservice"`; pins AGP `8.7.3` + Kotlin
+- **`settings.gradle.kts`** — `rootProject.name = "android-llmservice"`; pins AGP `9.2.0` + Kotlin
   `2.4.0` + the Compose plugin; `mavenLocal()` first so the freshly-built AAR + façade resolve there
-  in CI (Maven Central for real users).
+  in CI (Maven Central for real users). AGP 9.x requires Gradle >= 9.4.1 and JDK 17+; CI already
+  runs JDK 21 everywhere (`env.JAVA_VERSION`), so only the `gradle-version` pin on the jobs that
+  build this project (and the `.github/android-consumer-test` fixture) needed bumping.
 - **`app/build.gradle.kts`** — `namespace`/`applicationId` `net.ladenthin.android.llmservice`,
   `minSdk 28` (AAR floor), `compileSdk/targetSdk 35`, Jetpack Compose, `androidx.appcompat` (only for
   the per-app language API), ABIs `arm64-v8a` + `x86_64`. Depends on `net.ladenthin:llama-android` +

--- a/android-llmservice/README.md
+++ b/android-llmservice/README.md
@@ -197,7 +197,7 @@ gradle -p android-llmservice connectedDebugAndroidTest -PjllamaVersion="$VERSION
 
 ```
 android-llmservice/
-├── settings.gradle.kts          # AGP 8.7.3 + Kotlin 2.4.0 + Compose plugin, mavenLocal first
+├── settings.gradle.kts          # AGP 9.2.0 + Kotlin 2.4.0 + Compose plugin, mavenLocal first
 ├── gradle.properties
 ├── requirements.md              # spec of record: every feature the app implements today (no unit tests)
 ├── TODO.md                      # roadmap: not-yet-built features

--- a/android-llmservice/app/build.gradle.kts
+++ b/android-llmservice/app/build.gradle.kts
@@ -114,24 +114,24 @@ dependencies {
 
     // AppCompat: only for its per-app language API (AppCompatDelegate.setApplicationLocales),
     // which powers the in-app flag language picker and persists the choice across restarts.
-    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
 
     // Jetpack Compose UI (BOM pins the mutually consistent runtime versions).
-    val composeBom = platform("androidx.compose:compose-bom:2024.12.01")
+    val composeBom = platform("androidx.compose:compose-bom:2026.06.01")
     implementation(composeBom)
-    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.activity:activity-compose:1.13.0")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.11.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.11.0")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     // On-emulator instrumentation (build-android-llmservice CI job).
     androidTestImplementation(composeBom)
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test:core:1.6.1")
-    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test:core:1.7.0")
+    androidTestImplementation("androidx.test:runner:1.7.0")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/android-llmservice/settings.gradle.kts
+++ b/android-llmservice/settings.gradle.kts
@@ -14,9 +14,10 @@ pluginManagement {
         gradlePluginPortal()
     }
     // Versions pinned here (KISS: no version catalog). AGP matches the consumer-test
-    // fixture; Kotlin matches llama-kotlin (2.4.0).
+    // fixture; Kotlin matches llama-kotlin (2.4.0). AGP 9.x requires Gradle >= 9.4.1 —
+    // see the gradle-version pins on the CI jobs that build this project in publish.yml.
     plugins {
-        id("com.android.application") version "8.7.3"
+        id("com.android.application") version "9.2.0"
         id("org.jetbrains.kotlin.android") version "2.4.0"
         id("org.jetbrains.kotlin.plugin.compose") version "2.4.0"
     }

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -55,7 +55,7 @@ SPDX-License-Identifier: MIT
 
 	<properties>
 		<sonar.organization>bernardladenthin</sonar.organization>
-		<jna.version>5.19.0</jna.version>
+		<jna.version>5.19.1</jna.version>
 		<jspecify.version>1.0.0</jspecify.version>
 		<lombok.version>1.18.46</lombok.version>
 		<errorprone.version>2.50.0</errorprone.version>
@@ -64,7 +64,7 @@ SPDX-License-Identifier: MIT
 		<jackson.version>2.22.1</jackson.version>
 		<reactor.version>3.8.6</reactor.version>
 		<slf4j.version>2.0.18</slf4j.version>
-		<logback.version>1.5.37</logback.version>
+		<logback.version>1.5.38</logback.version>
 		<animal-sniffer.version>1.27</animal-sniffer.version>
 		<junit.version>6.1.1</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
## Summary

- Upgrade Android Gradle Plugin (AGP) from 8.7.3 to 9.2.0 in both `android-llmservice` and `.github/android-consumer-test` fixtures
- Bump Gradle from 8.14.3/8.14.4 to 9.4.1 across all CI jobs that build Android projects (AGP 9.x requires Gradle ≥ 9.4.1)
- Update Jetpack Compose and AndroidX dependencies to compatible versions (Compose BOM 2026.06.01, activity-compose 1.13.0, lifecycle 2.11.0, test libraries 1.3.0/1.7.0)
- Update AppCompat to 1.7.1, JNA to 5.19.1, and Logback to 1.5.38

## Test plan

- [x] CI is green on this branch (all Android builds and tests pass with AGP 9.2.0 and Gradle 9.4.1)
- [x] Existing unit / integration tests pass (no test code changes required)

## Related issues / PRs

N/A

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_015qu2VUdHXRhp6ndxJGkxri