### PR TITLE
Remove org.jetbrains.kotlin.android plugin for AGP 9 built-in Kotlin support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1652,11 +1652,16 @@ compiles/loads the API); this one has a UI and is driven end-to-end. The name is
 domain is the only string that must be globally unique.
 
 Structure (mirrors the consumer-test's plumbing):
-- **`settings.gradle.kts`** — `rootProject.name = "android-llmservice"`; pins AGP `9.2.0` + Kotlin
-  `2.4.0` + the Compose plugin; `mavenLocal()` first so the freshly-built AAR + façade resolve there
-  in CI (Maven Central for real users). AGP 9.x requires Gradle >= 9.4.1 and JDK 17+; CI already
-  runs JDK 21 everywhere (`env.JAVA_VERSION`), so only the `gradle-version` pin on the jobs that
-  build this project (and the `.github/android-consumer-test` fixture) needed bumping.
+- **`settings.gradle.kts`** — `rootProject.name = "android-llmservice"`; pins AGP `9.2.0` + the
+  Compose compiler plugin (`2.4.0`); `mavenLocal()` first so the freshly-built AAR + façade
+  resolve there in CI (Maven Central for real users). AGP 9.x requires Gradle >= 9.4.1 and
+  JDK 17+; CI already runs JDK 21 everywhere (`env.JAVA_VERSION`), so only the `gradle-version`
+  pin on the jobs that build this project (and the `.github/android-consumer-test` fixture)
+  needed bumping. AGP 9.0+ has **built-in Kotlin support** (a runtime dependency on Kotlin
+  Gradle plugin 2.2.10+), so the standalone `org.jetbrains.kotlin.android` plugin is no longer
+  applied — applying it now fails the build with "no longer required for Kotlin support since
+  AGP 9.0" (`app/build.gradle.kts` line 7). The Compose compiler plugin still applies
+  separately and its 2.4.0 pin exceeds AGP's 2.2.10 floor, so no other version changed.
 - **`app/build.gradle.kts`** — `namespace`/`applicationId` `net.ladenthin.android.llmservice`,
   `minSdk 28` (AAR floor), `compileSdk/targetSdk 35`, Jetpack Compose, `androidx.appcompat` (only for
   the per-app language API), ABIs `arm64-v8a` + `x86_64`. Depends on `net.ladenthin:llama-android` +

--- a/android-llmservice/app/build.gradle.kts
+++ b/android-llmservice/app/build.gradle.kts
@@ -6,7 +6,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
+    // AGP 9.0+ built-in Kotlin support replaces the standalone kotlin-android plugin —
+    // see the note in settings.gradle.kts.
     id("org.jetbrains.kotlin.plugin.compose")
 }
 

--- a/android-llmservice/settings.gradle.kts
+++ b/android-llmservice/settings.gradle.kts
@@ -14,11 +14,14 @@ pluginManagement {
         gradlePluginPortal()
     }
     // Versions pinned here (KISS: no version catalog). AGP matches the consumer-test
-    // fixture; Kotlin matches llama-kotlin (2.4.0). AGP 9.x requires Gradle >= 9.4.1 —
-    // see the gradle-version pins on the CI jobs that build this project in publish.yml.
+    // fixture. AGP 9.x requires Gradle >= 9.4.1 — see the gradle-version pins on the CI
+    // jobs that build this project in publish.yml. AGP 9.0+ has built-in Kotlin support
+    // (runtime dependency on Kotlin Gradle plugin 2.2.10+), so the standalone
+    // org.jetbrains.kotlin.android plugin is no longer applied/needed — see
+    // https://developer.android.com/build/migrate-to-built-in-kotlin. The Compose
+    // compiler plugin (2.4.0) still applies separately and exceeds AGP's 2.2.10 floor.
     plugins {
         id("com.android.application") version "9.2.0"
-        id("org.jetbrains.kotlin.android") version "2.4.0"
         id("org.jetbrains.kotlin.plugin.compose") version "2.4.0"
     }
 }


### PR DESCRIPTION
## Summary

- `android-llmservice` failed to build on CI with: *"The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0."* — a fallout from the AGP 8.7.3 → 9.2.0 bump in #331.
- AGP 9.0+ bundles Kotlin support directly (a runtime dependency on Kotlin Gradle plugin 2.2.10+), so applying the standalone `org.jetbrains.kotlin.android` plugin alongside it is now a hard error.
- Removes `id("org.jetbrains.kotlin.android")` from `android-llmservice/settings.gradle.kts` (`pluginManagement.plugins`) and `android-llmservice/app/build.gradle.kts` (`plugins {}`). `org.jetbrains.kotlin.plugin.compose` (2.4.0) still applies separately for Compose — its version already exceeds AGP's 2.2.10 floor, so nothing else needed changing.
- Updates the matching `CLAUDE.md` note.

## Test plan

- [ ] CI green on this branch — specifically `build-android-llmservice` and `test-android-llmservice`, the jobs that actually build this Gradle project
- [x] Could not build-verify locally (no Android SDK in this sandbox); fix is based on the official migration guide ([developer.android.com/build/migrate-to-built-in-kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin))

## Related issues / PRs

Follow-up to #331 (AGP 8.7.3 → 9.2.0 bump).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_015qu2VUdHXRhp6ndxJGkxri

---
_Generated by [Claude Code](https://claude.ai/code/session_015qu2VUdHXRhp6ndxJGkxri)_