### PR TITLE
Bump AGP 9.2.0 to 9.2.1 (R8 ClassNotFoundException fix)

### DIFF
--- a/.github/android-consumer-test/settings.gradle.kts
+++ b/.github/android-consumer-test/settings.gradle.kts
@@ -16,7 +16,11 @@ pluginManagement {
     plugins {
         // AGP 9.x requires Gradle >= 9.4.1 — see the gradle-version pins on the CI jobs
         // that build this fixture in publish.yml (package-android-aar, test-android-emulator).
-        id("com.android.application") version "9.2.0"
+        // 9.2.1 (not 9.2.0) is pinned: it fixes a real R8 regression
+        // (java.lang.ClassNotFoundException on com.android.tools.r8.RecordTag after
+        // upgrading Gradle to 9.x with AGP 9.2.0) that hits this fixture directly since
+        // buildTypes.release sets isMinifyEnabled = true.
+        id("com.android.application") version "9.2.1"
     }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1652,9 +1652,13 @@ compiles/loads the API); this one has a UI and is driven end-to-end. The name is
 domain is the only string that must be globally unique.
 
 Structure (mirrors the consumer-test's plumbing):
-- **`settings.gradle.kts`** — `rootProject.name = "android-llmservice"`; pins AGP `9.2.0` + the
+- **`settings.gradle.kts`** — `rootProject.name = "android-llmservice"`; pins AGP `9.2.1` + the
   Compose compiler plugin (`2.4.0`); `mavenLocal()` first so the freshly-built AAR + façade
-  resolve there in CI (Maven Central for real users). AGP 9.x requires Gradle >= 9.4.1 and
+  resolve there in CI (Maven Central for real users). `9.2.1` (not `9.2.0`) fixes a real R8
+  regression (`ClassNotFoundException` on `com.android.tools.r8.RecordTag` after upgrading
+  Gradle to 9.x with AGP 9.2.0) that hits this project directly since `buildTypes.release`
+  sets `isMinifyEnabled = true`; the `.github/android-consumer-test` fixture is pinned the
+  same way for the same reason. AGP 9.x requires Gradle >= 9.4.1 and
   JDK 17+; CI already runs JDK 21 everywhere (`env.JAVA_VERSION`), so only the `gradle-version`
   pin on the jobs that build this project (and the `.github/android-consumer-test` fixture)
   needed bumping. AGP 9.0+ has **built-in Kotlin support** (a runtime dependency on Kotlin

--- a/android-llmservice/README.md
+++ b/android-llmservice/README.md
@@ -197,7 +197,7 @@ gradle -p android-llmservice connectedDebugAndroidTest -PjllamaVersion="$VERSION
 
 ```
 android-llmservice/
-├── settings.gradle.kts          # AGP 9.2.0 + Kotlin 2.4.0 + Compose plugin, mavenLocal first
+├── settings.gradle.kts          # AGP 9.2.1 (built-in Kotlin) + Compose plugin 2.4.0, mavenLocal first
 ├── gradle.properties
 ├── requirements.md              # spec of record: every feature the app implements today (no unit tests)
 ├── TODO.md                      # roadmap: not-yet-built features

--- a/android-llmservice/settings.gradle.kts
+++ b/android-llmservice/settings.gradle.kts
@@ -15,13 +15,17 @@ pluginManagement {
     }
     // Versions pinned here (KISS: no version catalog). AGP matches the consumer-test
     // fixture. AGP 9.x requires Gradle >= 9.4.1 — see the gradle-version pins on the CI
-    // jobs that build this project in publish.yml. AGP 9.0+ has built-in Kotlin support
-    // (runtime dependency on Kotlin Gradle plugin 2.2.10+), so the standalone
-    // org.jetbrains.kotlin.android plugin is no longer applied/needed — see
-    // https://developer.android.com/build/migrate-to-built-in-kotlin. The Compose
-    // compiler plugin (2.4.0) still applies separately and exceeds AGP's 2.2.10 floor.
+    // jobs that build this project in publish.yml. 9.2.1 (not 9.2.0) is pinned: it fixes
+    // a real R8 regression (java.lang.ClassNotFoundException on
+    // com.android.tools.r8.RecordTag after upgrading Gradle to 9.x with AGP 9.2.0) that
+    // hits this project directly since buildTypes.release sets isMinifyEnabled = true.
+    // AGP 9.0+ has built-in Kotlin support (runtime dependency on Kotlin Gradle plugin
+    // 2.2.10+), so the standalone org.jetbrains.kotlin.android plugin is no longer
+    // applied/needed — see https://developer.android.com/build/migrate-to-built-in-kotlin.
+    // The Compose compiler plugin (2.4.0) still applies separately and exceeds AGP's
+    // 2.2.10 floor.
     plugins {
-        id("com.android.application") version "9.2.0"
+        id("com.android.application") version "9.2.1"
         id("org.jetbrains.kotlin.plugin.compose") version "2.4.0"
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `com.android.application` from `9.2.0` → `9.2.1` in both `android-llmservice/settings.gradle.kts` and `.github/android-consumer-test/settings.gradle.kts`.
- AGP 9.2.1 is a patch release fixing `java.lang.ClassNotFoundException: Didn't find class "com.android.tools.r8.RecordTag"` after upgrading Gradle to 9.x with AGP 9.2.0.
- This is directly relevant, not hypothetical: both `android-llmservice` and `.github/android-consumer-test` run R8 (`isMinifyEnabled = true`) in their release build type, and CI already runs Gradle 9.4.1 for these jobs (from #331/#333).
- Also fixes stale "Kotlin 2.4.0" wording in `android-llmservice/README.md` left over from the built-in-Kotlin migration in #333 (Kotlin is no longer a separately-applied/versioned plugin — only the Compose compiler plugin is).
- Verified every other Android dependency pin in this project (Compose BOM, activity-compose, lifecycle-compose, appcompat, androidx.test, kotlinx-coroutines-android, Kotlin 2.4.0) against the authoritative `developer.android.com` release-notes pages — all are already at the latest stable version.

## Test plan

- [ ] CI green on this branch — specifically the R8/`isMinifyEnabled` release-build steps in `package-android-aar` and `build-android-llmservice`
- [x] Could not build-verify locally (no Android SDK in this sandbox); based on the official AGP 9.2.1 release notes

## Related issues / PRs

Follow-up to #331 (AGP 8.7.3 → 9.2.0) and #333 (built-in Kotlin migration).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_015qu2VUdHXRhp6ndxJGkxri

---
_Generated by [Claude Code](https://claude.ai/code/session_015qu2VUdHXRhp6ndxJGkxri)_