### PR TITLE
Raise compileSdk to 37 to fix AAR-metadata check failure

### DIFF
--- a/.github/android-consumer-test/app/build.gradle.kts
+++ b/.github/android-consumer-test/app/build.gradle.kts
@@ -12,7 +12,11 @@ val jllamaVersion: String = providers.gradleProperty("jllamaVersion").get()
 
 android {
     namespace = "net.ladenthin.llama.consumertest"
-    compileSdk = 35
+    // 37 (not 35): kept in sync with android-llmservice's compileSdk bump (this fixture
+    // mirrors its plumbing, see .github/android-consumer-test's file header). Not
+    // independently required today — this fixture has no Compose dependency and so
+    // doesn't hit the AAR-metadata floor that forced android-llmservice's bump.
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "net.ladenthin.llama.consumertest"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1667,7 +1667,8 @@ Structure (mirrors the consumer-test's plumbing):
   AGP 9.0" (`app/build.gradle.kts` line 7). The Compose compiler plugin still applies
   separately and its 2.4.0 pin exceeds AGP's 2.2.10 floor, so no other version changed.
 - **`app/build.gradle.kts`** — `namespace`/`applicationId` `net.ladenthin.android.llmservice`,
-  `minSdk 28` (AAR floor), `compileSdk/targetSdk 35`, Jetpack Compose, `androidx.appcompat` (only for
+  `minSdk 28` (AAR floor), `compileSdk 37` (raised from 35 — Compose/lifecycle/activity AAR
+  metadata now requires it), `targetSdk 35`, Jetpack Compose, `androidx.appcompat` (only for
   the per-app language API), ABIs `arm64-v8a` + `x86_64`. Depends on `net.ladenthin:llama-android` +
   `net.ladenthin:llama-kotlin` at `-PjllamaVersion=<reactor version>` (defaults to the last release
   when built by hand). The release `signingConfig` reads an **upload keystore** (env vars

--- a/android-llmservice/app/build.gradle.kts
+++ b/android-llmservice/app/build.gradle.kts
@@ -32,7 +32,12 @@ val hasUploadKeystore: Boolean = !uploadStorePath.isNullOrBlank() && file(upload
 
 android {
     namespace = "net.ladenthin.android.llmservice"
-    compileSdk = 35
+    // 37 (not 35): the AAR-metadata check fails otherwise — activity-compose 1.13.0 /
+    // androidx.core 1.18.0 / navigationevent 1.0.0 require compileSdk >= 36, and
+    // lifecycle-{viewmodel,runtime}-compose 2.11.0 require compileSdk >= 37. targetSdk is
+    // left at 35 on purpose (compileSdk widens the compile-time API surface; targetSdk
+    // opts into new runtime behavior and is bumped independently).
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "net.ladenthin.android.llmservice"


### PR DESCRIPTION
## Summary

- `android-llmservice`'s `:app:checkReleaseAarMetadata` task failed in CI with 9 AAR-metadata issues: `activity-compose:1.13.0`, `androidx.core:1.18.0`, and `androidx.navigationevent:*:1.0.0` require `compileSdk >= 36`; `lifecycle-{viewmodel,runtime}-compose:2.11.0` require `compileSdk >= 37`. These versions were all pulled in by the dependency bumps in #331; the project was still on `compileSdk = 35`.
- Raises `compileSdk` from 35 to 37 in `android-llmservice/app/build.gradle.kts`. `targetSdk` is deliberately left at 35 — `compileSdk` only widens the compile-time API surface, `targetSdk` opts into new runtime behavior and can be bumped independently (per AGP's own recommendation in the error output).
- Also bumps `.github/android-consumer-test`'s `compileSdk` to stay in sync with the fixture it mirrors (not independently required there — that fixture has no Compose dependency).
- Updates the matching `CLAUDE.md` note.

## Test plan

- [ ] CI green on this branch — specifically `:app:checkReleaseAarMetadata` in `build-android-llmservice`
- [x] Could not build-verify locally (no Android SDK in this sandbox); fix follows AGP's own recommended action verbatim from the failure output

## Related issues / PRs

Follow-up to #331 (Compose/activity/lifecycle dependency bumps).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_015qu2VUdHXRhp6ndxJGkxri

---
_Generated by [Claude Code](https://claude.ai/code/session_015qu2VUdHXRhp6ndxJGkxri)_