### PR TITLE
Upgrade spotbugs, palantir-java-format, and Kotlin dependencies

### DIFF
--- a/llama-kotlin/pom.xml
+++ b/llama-kotlin/pom.xml
@@ -61,7 +61,7 @@ SPDX-License-Identifier: MIT
 		     read metadata at most one minor version ahead of their own compiler, so
 		     compiling with 2.2.x keeps this artifact consumable from Kotlin 2.1+
 		     projects (typical Android Studio installs) instead of forcing 2.2+. -->
-		<kotlin.version>2.4.0</kotlin.version>
+		<kotlin.version>2.4.10</kotlin.version>
 		<kotlinx.coroutines.version>1.11.0</kotlinx.coroutines.version>
 		<junit.version>6.1.2</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -82,11 +82,11 @@ SPDX-License-Identifier: MIT
 		     section "jqwik prompt-injection in test output" for full context. -->
 		<jqwik.version>1.9.3</jqwik.version>
 		<archunit.version>1.4.2</archunit.version>
-		<spotbugs.version>4.10.2.0</spotbugs.version>
+		<spotbugs.version>4.10.3.0</spotbugs.version>
 		<fb-contrib.version>7.7.4</fb-contrib.version>
 		<findsecbugs.version>1.14.0</findsecbugs.version>
 		<spotless.version>3.8.0</spotless.version>
-		<palantir-java-format.version>2.94.0</palantir-java-format.version>
+		<palantir-java-format.version>2.96.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.outputTimestamp>2026-07-07T07:32:17Z</project.build.outputTimestamp>
 	</properties>


### PR DESCRIPTION
## Summary

- Upgrade spotbugs from 4.10.2.0 to 4.10.3.0
- Upgrade palantir-java-format from 2.94.0 to 2.96.0
- Upgrade Kotlin from 2.4.0 to 2.4.10

These are minor version updates to development and build tooling dependencies with no breaking changes expected.

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01RzKLo5MC4n1PJsq5zeW7dP