### PR TITLE
chore: upgrade GitHub Actions and Maven dependencies

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - name: Install pinned clang-format

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -335,7 +335,7 @@ SPDX-License-Identifier: MIT
 				<plugin>
 					<groupId>org.pitest</groupId>
 					<artifactId>pitest-maven</artifactId>
-					<version>1.25.7</version>
+					<version>1.25.8</version>
 				</plugin>
 				<plugin>
 					<groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
## Summary

- Upgrade `actions/setup-python` from v6 to v7 in the clang-format workflow
- Upgrade `pitest-maven` plugin from 1.25.7 to 1.25.8 in `llama/pom.xml`

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_011LoFAQdknHucxVxWymQunV