### PR TITLE
ci(dockcross): bump cross-compile images to 20260712-79e54f9

### DIFF
--- a/.github/dockcross/dockcross-android-arm
+++ b/.github/dockcross/dockcross-android-arm
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm:20260515-5fd14ac
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm:20260712-79e54f9
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/.github/dockcross/dockcross-android-arm64
+++ b/.github/dockcross/dockcross-android-arm64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm64:20260515-5fd14ac
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm64:20260712-79e54f9
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/.github/dockcross/dockcross-android-x86_64
+++ b/.github/dockcross/dockcross-android-x86_64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86_64:20260515-5fd14ac
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86_64:20260712-79e54f9
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/.github/dockcross/dockcross-linux-arm64-lts
+++ b/.github/dockcross/dockcross-linux-arm64-lts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-arm64-lts:20260515-5fd14ac
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-arm64-lts:20260712-79e54f9
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/.github/dockcross/dockcross-manylinux2014-x64
+++ b/.github/dockcross/dockcross-manylinux2014-x64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2014-x64:20260515-5fd14ac
+DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2014-x64:20260712-79e54f9
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/.github/dockcross/dockcross-manylinux_2_28-x64
+++ b/.github/dockcross/dockcross-manylinux_2_28-x64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux_2_28-x64:20260515-5fd14ac
+DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux_2_28-x64:20260712-79e54f9
 
 #------------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

- Refreshes all **six** dockcross wrapper image pins from `20260515-5fd14ac` (2026-05-15) to **`20260712-79e54f9`** (2026-07-12, the current dockcross release / `:latest`).
- dockcross ships every image under one synchronized `date-gitsha` tag, so all six `DEFAULT_DOCKCROSS_IMAGE` lines move together: `manylinux2014-x64`, `manylinux_2_28-x64`, `android-arm`, `android-arm64`, `android-x86_64`, `linux-arm64-lts`. Verified each image publishes the new tag on Docker Hub.

**This is a freshness bump, not a fix:**
- `manylinux2014` stays **glibc 2.17** by design, so patch `0009` (the `posix_spawn_file_actions_addchdir_np` guard) remains necessary regardless.
- The **Android** images may carry a newer NDK/clang — the toolchain-sensitive invariants (16 KB LOAD alignment, the `__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__` gate, `-static-libstdc++`, the `DT_NEEDED` whitelist) are all CI-gated by `package-android-aar` + `test-android-emulator`, so any regression surfaces there.
- `linux-arm64-lts` is **unused** by CI (Linux aarch64 builds natively on `ubuntu-24.04-arm`) — bumped for consistency only.

## Test plan

- [x] New tag `20260712-79e54f9` confirmed present on Docker Hub for all six images
- [x] Old tag `20260515-5fd14ac` no longer referenced anywhere in the repo (only the 6 pin lines changed; no `publish.yml`/docs references)
- [ ] CI green — the manylinux + Android cross-compile jobs are what actually exercise these images (nothing to verify locally; no Docker in the dev sandbox)

## Related issues / PRs

Independent maintenance follow-up (kept separate from the b10154 fixes in #365 so any Android-toolchain surprise is easy to bisect).

## Checklist

- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeheJtyQwUzJGLcYpyWURD)_