### PR TITLE
Upgrade Gradle, clang-format, spotless, and remove unused JNA version

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,7 +12,7 @@ on:
 # reproducible between contributors and CI. Bump CLANG_FORMAT_VERSION here and in
 # CLAUDE.md (Code Formatting) together, then reformat the tree with the same version.
 env:
-  CLANG_FORMAT_VERSION: "22.1.5"
+  CLANG_FORMAT_VERSION: "22.1.8"
 
 jobs:
   clang-format:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -918,7 +918,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           # AGP 9.3.0 (the .github/android-consumer-test fixture) requires Gradle >= 9.5.0.
-          gradle-version: "9.5.0"
+          gradle-version: "9.6.1"
       - name: Build core jar (byte-identical classes payload for the AAR)
         run: >
           mvn -B --no-transfer-progress -pl llama -am -DskipTests -Denforcer.skip=true
@@ -1049,7 +1049,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           # AGP 9.3.0 (the .github/android-consumer-test fixture) requires Gradle >= 9.5.0.
-          gradle-version: "9.5.0"
+          gradle-version: "9.6.1"
       - name: Enable KVM group permissions (GitHub-hosted runner)
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -1145,7 +1145,7 @@ jobs:
           # AGP 9.3.0 (android-llmservice) requires Gradle >= 9.5.0; also satisfies Kotlin
           # 2.4's Gradle-plugin floor. The AAR/lib-only jobs stay on an older Gradle since
           # they build no AGP project.
-          gradle-version: "9.5.0"
+          gradle-version: "9.6.1"
       - name: Build core jar + install llama-kotlin facade to mavenLocal
         # install (not package) so the app's Gradle build resolves llama-kotlin +
         # the core POM from mavenLocal. llama-kotlin's core dep is provided-scope, so the
@@ -1229,7 +1229,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           # AGP 9.3.0 (android-llmservice) requires Gradle >= 9.5.0.
-          gradle-version: "9.5.0"
+          gradle-version: "9.6.1"
       - name: Enable KVM group permissions (GitHub-hosted runner)
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -948,12 +948,12 @@ not track the loader's own Java package). This is the same
 ### Code Formatting
 
 C++ formatting is **enforced in CI** (`.github/workflows/clang-format.yml`) with a **pinned**
-clang-format — currently **22.1.5**, installed via `pip install clang-format==22.1.5`. Format with
+clang-format — currently **22.1.8**, installed via `pip install clang-format==22.1.8`. Format with
 that exact version before committing; a different clang-format version reflows code differently and
 will fail the check.
 
 ```bash
-pip install "clang-format==22.1.5"
+pip install "clang-format==22.1.8"
 clang-format -i src/main/cpp/*.cpp src/main/cpp/*.hpp src/test/cpp/*.cpp   # Format C++ code
 ```
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -55,7 +55,6 @@ SPDX-License-Identifier: MIT
 
 	<properties>
 		<sonar.organization>bernardladenthin</sonar.organization>
-		<jna.version>5.19.1</jna.version>
 		<jspecify.version>1.0.0</jspecify.version>
 		<lombok.version>1.18.46</lombok.version>
 		<errorprone.version>2.50.0</errorprone.version>
@@ -85,7 +84,7 @@ SPDX-License-Identifier: MIT
 		<spotbugs.version>4.10.3.0</spotbugs.version>
 		<fb-contrib.version>7.7.4</fb-contrib.version>
 		<findsecbugs.version>1.14.0</findsecbugs.version>
-		<spotless.version>3.8.0</spotless.version>
+		<spotless.version>3.9.0</spotless.version>
 		<palantir-java-format.version>2.96.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.outputTimestamp>2026-07-07T07:32:17Z</project.build.outputTimestamp>


### PR DESCRIPTION
## Summary

- Upgrade Gradle from 9.5.0 to 9.6.1 across all CI workflows (4 jobs)
- Upgrade clang-format from 22.1.5 to 22.1.8 in CI and documentation
- Upgrade spotless from 3.8.0 to 3.9.0 in Maven configuration
- Remove unused `jna.version` property from `llama/pom.xml`

## Test plan

- [x] CI is green on this branch

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01Ap1143gp7CRatgo9TezNhQ