### PR TITLE
ci: bump remaining Gradle pins 8.14.3 → 9.6.1 (signing selftest + publish jobs)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -192,7 +192,7 @@ jobs:
   # SECURITY: prints no secret material. Key/passphrase reach Gradle only via env
   # (read by System.getenv at runtime); `set -x` is never enabled; the passphrase
   # is `::add-mask::`ed; Gradle runs with `--stacktrace` only. Only the produced
-  # `.asc` (exit code) is asserted. Uses Gradle 8.14.3.
+  # `.asc` (exit code) is asserted. Uses Gradle 9.6.1.
   # ---------------------------------------------------------------------------
   verify-signing-key-gradle:
     name: Verify GPG signing key — Gradle/BouncyCastle path (no secrets printed)
@@ -206,7 +206,7 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.14.3"
+          gradle-version: "9.6.1"
       - name: Sign a throwaway artifact via useInMemoryPgpKeys (BouncyCastle)
         shell: bash
         env:
@@ -3145,7 +3145,7 @@ jobs:
       # downloads above; the core jar was just built by the reactor deploy.
       - uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.14.3"
+          gradle-version: "9.6.1"
       - name: Publish Android AAR snapshots (llama-android + llama-android-opencl)
         run: |
           mkdir -p llama-android/natives/cpu/arm64-v8a llama-android/natives/cpu/x86_64 llama-android/natives/opencl/arm64-v8a
@@ -3350,7 +3350,7 @@ jobs:
       # built by the reactor deploy.
       - uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.14.3"
+          gradle-version: "9.6.1"
       - name: Publish Android AAR release bundle to Central Portal
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- Bumps the three remaining `gradle-version: "8.14.3"` pins in `.github/workflows/publish.yml` to **9.6.1** — the **GPG-signing key selftest** (`verify-signing-key-gradle`) job and the **snapshot** + **release** publish jobs (which drive the plain-Gradle `llama-android` AAR publish), plus the one stale `# Uses Gradle 8.14.3` comment.
- Unifies **every** `gradle-version` pin in the workflow at 9.6.1: the AGP jobs already moved to 9.6.1 in #367, leaving these three deliberately on the 8.x line. 9.6.1 is the current Gradle stable and stays above the AGP-9.3.x floor (≥ 9.5.0).
- Workflow-only change; no source, dependency, or Maven change.

## Test plan

- [ ] Affected unit / integration tests pass locally — n/a (CI-workflow-only change)
- [ ] CI is green on this branch — **needs CI**: these jobs were deliberately on 8.x, so the plain-Gradle `llama-android` publish path needs revalidation on Gradle 9.6.1 (watch `verify-signing-key-gradle` and the publish jobs)
- [ ] Docs / CHANGELOG updated where applicable — n/a

## Related issues / PRs

- Follow-up to #367 (which moved the AGP jobs to 9.6.1); this completes the workflow-wide unification.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ap1143gp7CRatgo9TezNhQ)_