### PR TITLE
Upgrade logback from 1.6.0 to 1.6.1

### DIFF
--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -63,7 +63,7 @@ SPDX-License-Identifier: MIT
 		<jackson.version>2.22.1</jackson.version>
 		<reactor.version>3.8.6</reactor.version>
 		<slf4j.version>2.0.18</slf4j.version>
-		<logback.version>1.6.0</logback.version>
+		<logback.version>1.6.1</logback.version>
 		<animal-sniffer.version>1.27</animal-sniffer.version>
 		<junit.version>6.1.2</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
## Summary

- Bump logback dependency from version 1.6.0 to 1.6.1 in `pom.xml`
- This is a patch-level update that includes bug fixes and improvements from the logback project

## Test plan

- [x] CI is green on this branch
- No code changes required; dependency update only

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

https://claude.ai/code/session_01MbWyxYs1TCQN6Hb7HynF19