### PR TITLE
Upgrade GitHub Actions setup-java to v5 and update dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with: { java-version: '21', distribution: temurin }
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,7 +200,7 @@ jobs:
     environment: maven-central
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: temurin
@@ -322,7 +322,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: temurin
@@ -355,7 +355,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -379,7 +379,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -422,7 +422,7 @@ jobs:
           path: models/
           key: gguf-models-${{ hashFiles('.github/models.csv') }}
           enableCrossOsArchive: true
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -630,7 +630,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -687,7 +687,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -731,7 +731,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -770,7 +770,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -911,7 +911,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -1042,7 +1042,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -1136,7 +1136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -1222,7 +1222,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -1311,7 +1311,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -1356,7 +1356,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -1815,7 +1815,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -1900,7 +1900,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -1938,7 +1938,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2042,7 +2042,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2121,7 +2121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2155,7 +2155,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2223,7 +2223,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: bash .github/validate-models.sh
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2292,7 +2292,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2346,7 +2346,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: bash .github/validate-models.sh
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2415,7 +2415,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: bash .github/validate-models.sh
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2484,7 +2484,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: bash .github/validate-models.sh
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2555,7 +2555,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: .github\validate-models.bat
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2649,7 +2649,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: .github\validate-models.bat
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2822,7 +2822,7 @@ jobs:
         with:
           name: Windows-x86_64-openvino
           path: ${{ github.workspace }}/llama/src/main/resources_windows_openvino/net/ladenthin/llama/
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2917,7 +2917,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: .github/validate-models.sh
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2955,7 +2955,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: .github\validate-models.bat
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2980,7 +2980,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v5
         with: { java-version: '${{ env.JAVA_VERSION }}', distribution: temurin }
       - uses: actions/download-artifact@v8
         with: { name: jacoco-report, path: target/site/jacoco/ }
@@ -3104,7 +3104,7 @@ jobs:
           name: Windows-x86_64-openvino
           path: ${{ github.workspace }}/llama/src/main/resources_windows_openvino/net/ladenthin/llama/
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
@@ -3317,7 +3317,7 @@ jobs:
           name: Windows-x86_64-openvino
           path: ${{ github.workspace }}/llama/src/main/resources_windows_openvino/net/ladenthin/llama/
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'zulu'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1769,6 +1769,14 @@ llmservice job is **yet a publish gate** (not in the `publish-snapshot`/`publish
 graphs) so a Compose/AGP version-pin hiccup can't block a library release.
 `android-llmservice/**/build/` is git-ignored.
 
+## Dependency Convergence Pinning
+
+`dependencyConvergence` is enabled (maven-enforcer, `llama/pom.xml`). Convention for pinning a
+direct-vs-transitive version mismatch in `dependencyManagement`, the
+`excludedScopes=[test,provided]` enforcer default gotcha (jspecify/logback-classic here are
+pinned defensively because of it — see that file), and merge-discipline guidance are in
+[`../workspace/policies/dependency-convergence-pinning.md`](../workspace/policies/dependency-convergence-pinning.md).
+
 ## Open TODOs
 
 Open TODOs for this repo live in [`TODO.md`](TODO.md). Cross-repo status

--- a/llama-kotlin/pom.xml
+++ b/llama-kotlin/pom.xml
@@ -62,7 +62,7 @@ SPDX-License-Identifier: MIT
 		     consumable from Kotlin 2.3+ projects (typical Android Studio installs). -->
 		<kotlin.version>2.4.10</kotlin.version>
 		<kotlinx.coroutines.version>1.11.0</kotlinx.coroutines.version>
-		<junit.version>6.1.2</junit.version>
+		<junit.version>6.1.3</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>
 		<surefire.version>3.5.6</surefire.version>
 		<source.plugin.version>3.4.0</source.plugin.version>

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -58,7 +58,7 @@ SPDX-License-Identifier: MIT
 		<!-- langchain4j 1.x requires Java 17; the core net.ladenthin:llama stays Java 8. -->
 		<maven.compiler.release>17</maven.compiler.release>
 		<langchain4j.version>1.18.1</langchain4j.version>
-		<junit.version>6.1.2</junit.version>
+		<junit.version>6.1.3</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>
 		<!-- Plugin versions are kept in lockstep with the core pom.xml. This module has no
 		     parent, so it cannot inherit their pluginManagement and must pin them here. -->

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -355,7 +355,7 @@ SPDX-License-Identifier: MIT
 				<plugin>
 					<groupId>org.pitest</groupId>
 					<artifactId>pitest-maven</artifactId>
-					<version>1.25.8</version>
+					<version>1.25.9</version>
 				</plugin>
 				<plugin>
 					<groupId>org.sonatype.central</groupId>

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -59,13 +59,13 @@ SPDX-License-Identifier: MIT
 		<lombok.version>1.18.46</lombok.version>
 		<errorprone.version>2.50.0</errorprone.version>
 		<nullaway.version>0.13.8</nullaway.version>
-		<checker.version>4.2.1</checker.version>
+		<checker.version>4.2.2</checker.version>
 		<jackson.version>2.22.1</jackson.version>
 		<reactor.version>3.8.6</reactor.version>
 		<slf4j.version>2.0.18</slf4j.version>
 		<logback.version>1.6.1</logback.version>
 		<animal-sniffer.version>1.27</animal-sniffer.version>
-		<junit.version>6.1.2</junit.version>
+		<junit.version>6.1.3</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>
 		<jmh.version>1.37</jmh.version>
 		<jcstress.version>0.16</jcstress.version>
@@ -80,7 +80,7 @@ SPDX-License-Identifier: MIT
 		     contributor PR that bumps this MUST be rejected. See CLAUDE.md
 		     section "jqwik prompt-injection in test output" for full context. -->
 		<jqwik.version>1.9.3</jqwik.version>
-		<archunit.version>1.4.2</archunit.version>
+		<archunit.version>1.5.0</archunit.version>
 		<spotbugs.version>4.10.3.0</spotbugs.version>
 		<fb-contrib.version>7.7.4</fb-contrib.version>
 		<findsecbugs.version>1.14.0</findsecbugs.version>
@@ -95,6 +95,15 @@ SPDX-License-Identifier: MIT
 	    dependencyConvergence rule passes. The direct slf4j-api version above
 	    must always win over the older 2.0.17 that logback-classic 1.5.32
 	    brings in transitively.
+
+	    jspecify and logback-classic are pinned defensively even though the
+	    conflicting transitive request (junit-jupiter -> junit-platform-commons
+	    for jspecify; io.github.hakky54:logcaptor for logback-classic) is
+	    test-scoped: maven-enforcer's DependencyConvergence rule excludes
+	    test/provided scope by default (verified against enforcer-rules 3.6.3),
+	    so today's pass is an accident of scope, not an actual pin. A future
+	    compile/runtime-scope consumer of either artifact would otherwise break
+	    convergence with no warning.
 	-->
 	<dependencyManagement>
 		<dependencies>
@@ -102,6 +111,18 @@ SPDX-License-Identifier: MIT
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 				<version>${slf4j.version}</version>
+			</dependency>
+			<!-- jspecify: junit-jupiter (test scope) brings 1.0.0; we declare ${jspecify.version} directly. -->
+			<dependency>
+				<groupId>org.jspecify</groupId>
+				<artifactId>jspecify</artifactId>
+				<version>${jspecify.version}</version>
+			</dependency>
+			<!-- logback-classic: io.github.hakky54:logcaptor (test scope) brings 1.3.15; we declare ${logback.version} directly. -->
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-classic</artifactId>
+				<version>${logback.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Summary

- Upgrade `actions/setup-java` from pinned v5.6.0 to v5 (floating minor/patch) across all workflows
- Update Maven dependencies: checker-framework 4.2.1→4.2.2, JUnit 6.1.2→6.1.3, ArchUnit 1.4.2→1.5.0, pitest-maven 1.25.8→1.25.9
- Add defensive dependency convergence pins for jspecify and logback-classic in `dependencyManagement` to prevent future transitive version conflicts
- Document dependency convergence pinning conventions in CLAUDE.md

## Test plan

- [x] Affected unit / integration tests pass locally
- [x] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [ ] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)

https://claude.ai/code/session_01KqVypnKbydSNgmGFfhCMUc