### PR TITLE
ci: stop three macOS arm64 dylibs from colliding in the `*-libraries` merge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1340,7 +1340,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: macos-15-libraries
+          name: macos-15-no-metal
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
 
   build-macos-arm64-metal:
@@ -1385,7 +1385,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: macos-14-libraries
+          name: macos-14-metal
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
 
   build-windows-x86_64-msvc:
@@ -2184,7 +2184,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: macos-15-metal-libraries
+          name: macos-15-metal
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
 
   # ---------------------------------------------------------------------------
@@ -2330,7 +2330,7 @@ jobs:
           system_profiler SPHardwareDataType
       - uses: actions/download-artifact@v8
         with:
-          name: macos-14-libraries
+          name: macos-14-metal
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
       # GGUF models are downloaded + cached ONCE by the upstream `download-models` job
       # (this job `needs:` it), so here we only RESTORE the shared cache — no per-job
@@ -2399,7 +2399,7 @@ jobs:
           system_profiler SPHardwareDataType
       - uses: actions/download-artifact@v8
         with:
-          name: macos-15-libraries
+          name: macos-15-no-metal
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
       # GGUF models are downloaded + cached ONCE by the upstream `download-models` job
       # (this job `needs:` it), so here we only RESTORE the shared cache — no per-job
@@ -2468,7 +2468,7 @@ jobs:
           system_profiler SPHardwareDataType
       - uses: actions/download-artifact@v8
         with:
-          name: macos-15-metal-libraries
+          name: macos-15-metal
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
       # GGUF models are downloaded + cached ONCE by the upstream `download-models` job
       # (this job `needs:` it), so here we only RESTORE the shared cache — no per-job
@@ -2751,6 +2751,15 @@ jobs:
         with:
           pattern: "*-libraries"
           merge-multiple: true
+          path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
+      # All three macOS arm64 build jobs emit the same path Mac/aarch64/libjllama.dylib, so their
+      # artifact names are kept outside the "*-libraries" glob above — merging them would drop
+      # three different dylibs onto one file. The variant that ships is selected explicitly:
+      # macos-15-metal is the only one built with both Metal and GGML_NATIVE=OFF (portable across
+      # CPU generations); macos-14-metal and macos-15-no-metal remain test-only.
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-15-metal
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
       - uses: actions/download-artifact@v8
         with:
@@ -3038,6 +3047,15 @@ jobs:
           pattern: "*-libraries"
           merge-multiple: true
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
+      # All three macOS arm64 build jobs emit the same path Mac/aarch64/libjllama.dylib, so their
+      # artifact names are kept outside the "*-libraries" glob above — merging them would drop
+      # three different dylibs onto one file. The variant that ships is selected explicitly:
+      # macos-15-metal is the only one built with both Metal and GGML_NATIVE=OFF (portable across
+      # CPU generations); macos-14-metal and macos-15-no-metal remain test-only.
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-15-metal
+          path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
       - uses: actions/download-artifact@v8
         with:
           name: linux-libraries-cuda
@@ -3250,6 +3268,15 @@ jobs:
         with:
           pattern: "*-libraries"
           merge-multiple: true
+          path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
+      # All three macOS arm64 build jobs emit the same path Mac/aarch64/libjllama.dylib, so their
+      # artifact names are kept outside the "*-libraries" glob above — merging them would drop
+      # three different dylibs onto one file. The variant that ships is selected explicitly:
+      # macos-15-metal is the only one built with both Metal and GGML_NATIVE=OFF (portable across
+      # CPU generations); macos-14-metal and macos-15-no-metal remain test-only.
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-15-metal
           path: ${{ github.workspace }}/llama/src/main/resources/net/ladenthin/llama/
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
All three macOS arm64 build jobs write net/ladenthin/llama/Mac/aarch64/libjllama.dylib (none passes -DOS_NAME/-DOS_ARCH, so CMakeLists auto-detects the same subdir), and all three uploaded under a name ending in `-libraries`. The package, publish-snapshot and publish-release jobs then download `pattern: "*-libraries"` with `merge-multiple: true` into one directory, so three different dylibs land on one path.

The published dylib is consequently a hybrid: its ad-hoc linker signature no longer matches its own __TEXT pages, and macOS SIGKILLs any process that loads it. Verified on 5.0.6, 5.0.7-20260810.011118-18 and 5.0.7-20260811.201306-19 (66/4078 and 1141/4097 code pages fail their stored hashes); 5.0.7-20260801.013705-16 loads only because its foreign bytes happen to fall outside the signed range.

macOS arm64 is the only <os>/<arch> with more than one artifact in the glob, which is why it is the only broken platform. Windows already avoids this by naming its MSVC variants outside the glob; this applies the same treatment to macOS:

  macos-15-libraries       -> macos-15-no-metal   (test-only)
  macos-14-libraries       -> macos-14-metal      (test-only)
  macos-15-metal-libraries -> macos-15-metal      (shipped, selected explicitly)

The variant that ships is now chosen by an explicit download step rather than by which artifact name happens to match a glob. macos-15-metal is the only build with both Metal and GGML_NATIVE=OFF, and it is what the current (corrupt) jars already report in their Mach-O header (minos 15.0 / sdk 15.5), so shipping it keeps the intended behaviour.

## Summary

<!-- 1-3 bullets describing what changed and why. -->

## Test plan

- [x] Affected unit / integration tests pass locally
- [x] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable

## Related issues / PRs

<!-- e.g. Closes #123, Refs #456 -->

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (if there are, I have notified the maintainer privately per `SECURITY.md`)
