### PR TITLE
Upgrade actions/setup-java to v6 and pin log4j to 2.26.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with: { java-version: '21', distribution: temurin }
       - uses: github/codeql-action/init@v4
         with: { languages: java, queries: +security-and-quality }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,7 +203,7 @@ jobs:
     environment: maven-central
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: temurin
@@ -325,7 +325,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: '21'
           distribution: temurin
@@ -358,7 +358,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -382,7 +382,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -425,7 +425,7 @@ jobs:
           path: models/
           key: gguf-models-${{ hashFiles('.github/models.csv') }}
           enableCrossOsArchive: true
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -633,7 +633,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -690,7 +690,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -734,7 +734,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -773,7 +773,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -914,7 +914,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -1045,7 +1045,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -1139,7 +1139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -1225,7 +1225,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -1314,7 +1314,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -1359,7 +1359,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -1818,7 +1818,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -1903,7 +1903,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -1941,7 +1941,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2045,7 +2045,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2124,7 +2124,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2158,7 +2158,7 @@ jobs:
         with:
           name: webui-generated
           path: ${{ github.workspace }}/llama/webui-generated/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2226,7 +2226,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: bash .github/validate-models.sh
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2295,7 +2295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2349,7 +2349,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: bash .github/validate-models.sh
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2418,7 +2418,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: bash .github/validate-models.sh
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2487,7 +2487,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: bash .github/validate-models.sh
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2558,7 +2558,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: .github\validate-models.bat
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2652,7 +2652,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: .github\validate-models.bat
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2844,7 +2844,7 @@ jobs:
         with:
           name: Windows-x86_64-openvino
           path: ${{ github.workspace }}/llama/src/main/resources_windows_openvino/net/ladenthin/llama/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2939,7 +2939,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: .github/validate-models.sh
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -2977,7 +2977,7 @@ jobs:
           enableCrossOsArchive: true
       - name: Validate model files
         run: .github\validate-models.bat
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -3021,7 +3021,7 @@ jobs:
         with:
           name: llama-jars
           path: jars/
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -3036,7 +3036,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with: { java-version: '${{ env.JAVA_VERSION }}', distribution: temurin }
       - uses: actions/download-artifact@v8
         with: { name: jacoco-report, path: target/site/jacoco/ }
@@ -3179,7 +3179,7 @@ jobs:
           name: Windows-x86_64-openvino
           path: ${{ github.workspace }}/llama/src/main/resources_windows_openvino/net/ladenthin/llama/
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
@@ -3411,7 +3411,7 @@ jobs:
           name: Windows-x86_64-openvino
           path: ${{ github.workspace }}/llama/src/main/resources_windows_openvino/net/ladenthin/llama/
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: 21
           distribution: 'zulu'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ from version 5.0.0 onward. Pre-fork releases (`1.x`–`4.2.0`) were authored by
 - CI actions bumped to latest: `actions/setup-java` v5 → v6.
 - Upgraded llama.cpp from **b9894 to b9917** (all eight local patches re-verified across the range).
 
+### Fixed
+- **CVE-2026-49844** (GHSA-qv9r-c865-cp47, moderate): `org.apache.logging.log4j:log4j-api`
+  2.25.3 arrives as a **test-scope** transitive of `io.github.hakky54:logcaptor` 2.12.6, and
+  Dependabot could not update it on its own. Pinned `log4j-api` **and** `log4j-to-slf4j` to
+  **2.26.1** in `dependencyManagement` — both together, since `log4j-to-slf4j` requires a
+  matching `log4j-api` and the two must not skew. Neither reaches a published artifact.
+
 ## [5.0.6] - 2026-07-07
 
 Feature release. Headline additions are the Android AAR + Kotlin coroutines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ from version 5.0.0 onward. Pre-fork releases (`1.x`–`4.2.0`) were authored by
 - `QuantizationType.Q2_0` — maps the new upstream `LLAMA_FTYPE_MOSTLY_Q2_0` (llama.cpp b9916) for `LlamaQuantizer`.
 
 ### Changed
+- `ch.qos.logback:logback-classic` bumped 1.6.2 → 1.6.3 (test/runtime binding only).
+- CI actions bumped to latest: `actions/setup-java` v5 → v6.
 - Upgraded llama.cpp from **b9894 to b9917** (all eight local patches re-verified across the range).
 
 ## [5.0.6] - 2026-07-07

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -71,6 +71,12 @@ SPDX-License-Identifier: MIT
 		<jcstress.version>0.16</jcstress.version>
 		<lincheck.version>3.7</lincheck.version>
 		<logcaptor.version>2.12.6</logcaptor.version>
+		<!-- log4j-api / log4j-to-slf4j arrive ONLY as test-scope transitives of
+		     io.github.hakky54:logcaptor, which requests 2.25.3. That version is affected by
+		     CVE-2026-49844 (GHSA-qv9r-c865-cp47, moderate): MapMessage.asJson() emits bare
+		     NaN/Infinity tokens for non-finite floats, producing non-RFC-8259 JSON. Pinned to the
+		     newest patched stable so the alert clears; see the dependencyManagement entries. -->
+		<log4j.version>2.26.1</log4j.version>
 		<vmlens.version>1.2.28</vmlens.version>
 		<!-- DO NOT UPGRADE jqwik past 1.9.3. jqwik 1.10.0 added a deliberate
 		     anti-AI prompt-injection string to test stdout; the 1.10.1 user
@@ -123,6 +129,20 @@ SPDX-License-Identifier: MIT
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
 				<version>${logback.version}</version>
+			</dependency>
+			<!-- log4j-api + log4j-to-slf4j: io.github.hakky54:logcaptor (test scope) brings 2.25.3,
+			     which is affected by CVE-2026-49844; we declare ${log4j.version} directly. Both are
+			     pinned together because log4j-to-slf4j depends on log4j-api of the same version and
+			     the two must not skew. Test-scope only — neither reaches a published artifact. -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>${log4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-to-slf4j</artifactId>
+				<version>${log4j.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -63,7 +63,7 @@ SPDX-License-Identifier: MIT
 		<jackson.version>2.22.2</jackson.version>
 		<reactor.version>3.8.7</reactor.version>
 		<slf4j.version>2.0.18</slf4j.version>
-		<logback.version>1.6.2</logback.version>
+		<logback.version>1.6.3</logback.version>
 		<animal-sniffer.version>1.27</animal-sniffer.version>
 		<junit.version>6.1.3</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
## Summary

- Upgraded `actions/setup-java` from v5 to v6 across all CI workflows (publish, codeql, sonarqube).
- Bumped `ch.qos.logback:logback-classic` from 1.6.2 to 1.6.3.
- Pinned `org.apache.logging.log4j:log4j-api` and `log4j-to-slf4j` to 2.26.1 in `dependencyManagement` to address CVE-2026-49844 (GHSA-qv9r-c865-cp47, moderate severity).

## Details

The log4j CVE fix addresses a vulnerability in version 2.25.3, which arrives as a test-scope transitive dependency of `io.github.hakky54:logcaptor` 2.12.6. Dependabot could not update it independently, so both `log4j-api` and `log4j-to-slf4j` are now explicitly pinned together to 2.26.1 in `dependencyManagement`. Neither dependency reaches published artifacts (test-scope only).

## Test plan

- [x] CI is green on this branch
- [x] Docs / CHANGELOG updated

## Related issues / PRs

Addresses CVE-2026-49844 (GHSA-qv9r-c865-cp47)

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes (CVE fix is a standard dependency update)

https://claude.ai/code/session_015736Ef93fk9VcaxpBs8C9J