### PR TITLE
Prepare 5.1.0 release: drop -SNAPSHOT, finalize CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ from version 5.0.0 onward. Pre-fork releases (`1.x`–`4.2.0`) were authored by
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-08-29
+
 > The entries below also cover the **b9917 → b10456** window (PRs #341–#394), which went unrecorded
 > here while it happened; they were reconstructed from the git history and from
 > [`docs/history/llama-cpp-breaking-changes.md`](docs/history/llama-cpp-breaking-changes.md), which
@@ -520,7 +522,8 @@ Releases `1.1.1` through `4.2.0` were authored by [@kherud](https://github.com/k
 
 For an architecture-level diff between the pre-fork baseline (`49be664`) and the first 5.0.0 candidate (`24918e4`), see [`docs/history/49be664_24918e4.md`](docs/history/49be664_24918e4.md). For the server-fork-deletion refactor that culminated in 5.0.0, see [`docs/history/REFACTORING.md`](docs/history/REFACTORING.md). For the chat-completion integration that landed in 5.0.0, see [`docs/history/CHAT_INTEGRATION_SUMMARY.md`](docs/history/CHAT_INTEGRATION_SUMMARY.md).
 
-[Unreleased]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.6...HEAD
+[Unreleased]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.1.0...HEAD
+[5.1.0]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.6...v5.1.0
 [5.0.6]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.5...v5.0.6
 [5.0.5]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.4...v5.0.5
 [5.0.4]: https://github.com/bernardladenthin/java-llama.cpp/compare/v5.0.3...v5.0.4

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Access this library via Maven (released versions on Maven Central):
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.6</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -218,7 +218,7 @@ there. Pick **at most one** classifier (they are mutually exclusive):
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.6</version>
+    <version>5.1.0</version>
 </dependency>
 
 <!-- GPU / accelerator or alternate-CPU build: add the <classifier> from the
@@ -226,7 +226,7 @@ there. Pick **at most one** classifier (they are mutually exclusive):
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.6</version>
+    <version>5.1.0</version>
     <classifier>cuda13-linux-x86-64</classifier>
 </dependency>
 ```
@@ -994,7 +994,7 @@ forcing that floor on every core consumer. It ships and versions in lockstep wit
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama-langchain4j</artifactId>
-    <version>5.0.6</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -1154,12 +1154,12 @@ One dependency line in Android Studio — no submodule, no NDK build, no manual 
 
 ```kotlin
 dependencies {
-    implementation("net.ladenthin:llama-android:5.0.6")
+    implementation("net.ladenthin:llama-android:5.1.0")
     // or, for Qualcomm Adreno GPUs (device must provide an OpenCL ICD):
-    // implementation("net.ladenthin:llama-android-opencl:5.0.6")
+    // implementation("net.ladenthin:llama-android-opencl:5.1.0")
 
     // optional Kotlin coroutines facade (Flow streaming + suspend wrappers):
-    implementation("net.ladenthin:llama-kotlin:5.0.6")
+    implementation("net.ladenthin:llama-kotlin:5.1.0")
 }
 ```
 

--- a/llama-android/README.md
+++ b/llama-android/README.md
@@ -13,9 +13,9 @@ ProGuard rules.
 ```kotlin
 // build.gradle.kts of your app — that's all.
 dependencies {
-    implementation("net.ladenthin:llama-android:5.0.6")
+    implementation("net.ladenthin:llama-android:5.1.0")
     // or, for Qualcomm Adreno GPUs (device must provide an OpenCL ICD):
-    // implementation("net.ladenthin:llama-android-opencl:5.0.6")
+    // implementation("net.ladenthin:llama-android-opencl:5.1.0")
 }
 ```
 

--- a/llama-kotlin/README.md
+++ b/llama-kotlin/README.md
@@ -11,11 +11,11 @@ Pure Kotlin/JVM — works on desktop JVMs **and** Android.
 
 ```kotlin
 dependencies {
-    implementation("net.ladenthin:llama-kotlin:5.0.6")
+    implementation("net.ladenthin:llama-kotlin:5.1.0")
     // ...plus the binding itself — the façade does NOT drag it in transitively
     // (provided scope), so YOU pick the right flavor:
-    implementation("net.ladenthin:llama:5.0.6")          // desktop JVM
-    // implementation("net.ladenthin:llama-android:5.0.6") // Android (AAR)
+    implementation("net.ladenthin:llama:5.1.0")          // desktop JVM
+    // implementation("net.ladenthin:llama-android:5.1.0") // Android (AAR)
 }
 ```
 

--- a/llama-kotlin/pom.xml
+++ b/llama-kotlin/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.7-SNAPSHOT</version>
+		<version>5.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama-langchain4j/README.md
+++ b/llama-langchain4j/README.md
@@ -62,7 +62,7 @@ ScoringModel reranker     = new JllamaScoringModel(rerankLlama);
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama-langchain4j</artifactId>
-    <version>5.0.6</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.7-SNAPSHOT</version>
+		<version>5.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.0.7-SNAPSHOT</version>
+		<version>5.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -93,7 +93,7 @@ SPDX-License-Identifier: MIT
 		<spotless.version>3.10.1</spotless.version>
 		<palantir-java-format.version>2.97.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.outputTimestamp>2026-07-07T07:32:17Z</project.build.outputTimestamp>
+		<project.build.outputTimestamp>2026-08-29T16:06:02Z</project.build.outputTimestamp>
 	</properties>
 
 	<!--

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
 	-->
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama-parent</artifactId>
-	<version>5.0.7-SNAPSHOT</version>
+	<version>5.1.0</version>
 	<packaging>pom</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary

Step 1 of the [canonical release procedure](../workspace/workflows/release-process.md). Merge this, then create the `v5.1.0` tag and run **Publish** with `publish_to_central=true`.

- **`5.0.7-SNAPSHOT` → `5.1.0`** across all four reactor poms via `versions:set`. Minor, not patch: the b10456 → b10682 range **added public API** — `setKvUnifiedPerSlot`, `setTensorReadLazy` + the new `TensorReadLazyMode` enum, `setCpuFfnLayers`, `setCpuMoeLayers`, `setMmprojDevice`, and the three `setVideo*` setters — with nothing removed. The `5.0.7` base is skipped.
- **Release dependency examples updated in all four READMEs** (13 occurrences): root `README.md`, `llama-langchain4j/`, `llama-android/`, `llama-kotlin/`.
- **CHANGELOG finalized**: `[Unreleased]` → `[5.1.0] - 2026-08-29`, fresh empty `[Unreleased]` above it, footer gains the `5.1.0` compare link and `[Unreleased]` re-points to `v5.1.0...HEAD`.

## Two things worth reading before merging

**The snapshot snippet in `README.md` still says `5.0.7-SNAPSHOT`, deliberately.** The canonical procedure moves the snapshot example in **Step 3**, after the release is live. Because this release skips the `5.0.7` base entirely, that line currently names a version that will never be published — it gets repointed to the next snapshot base in the post-release PR. Flagging it so it doesn't read as an oversight.

**This follows `docs/RELEASE.md`, not the previous release.** The supplement lists **four** READMEs carrying release versions; the `v5.0.6` prep (`b76fb69`) touched only two of them. All four are updated here and all now read `5.1.0` with no `5.0.6` left anywhere.

## Test plan

- [x] All four poms move in lockstep — verified by parsing each: root `own=5.1.0`, and `llama`/`llama-langchain4j`/`llama-kotlin` each `parent=5.1.0`. The children hardcode the parent version (there is no `${revision}`), so a missed one fails the reactor with `Could not find artifact net.ladenthin:llama-parent:pom:5.1.0`. No `-SNAPSHOT` remains in any pom.
- [x] No `5.0.6` remains in any README; the snapshot line is the only `-SNAPSHOT` left and is intentional.
- [x] **CHANGELOG consistency checked mechanically** — released headings, footer compare-links and `v*` tags are the same set. This is the check that catches the class of defect the sibling repos actually shipped (see below).
- [ ] CI green on this branch — pending on this PR. The content is unchanged from the merged b10682 PR (#404); this is a version/docs-only commit.

## An audit came out of this, landing in `workspace`

Preparing this release surfaced that **the CHANGELOG compare-link footer is the most-missed step**, because nothing builds, tests or renders it:

- **BitcoinAddressFinder `v1.7.0`** shipped with no `[1.7.0]` link at all and `[Unreleased]` still pointing at `v1.6.1` — repaired in its 1.8.0 prep.
- **srcmorph `v1.1.0`** is tagged and released but has **no CHANGELOG section at all**; the chain jumps `1.0.2 → 1.1.1`. Open, recorded in `crossrepostatus.md`.
- **java-llama.cpp and streambuffer are clean** — headings, links and tags agree in both.

The hardened checklist, the mechanical headings/links/tags check, and a per-repo table of the version sites that actually drift are now in `workspace/workflows/release-process.md`.

## Related issues / PRs

Follows #404 (llama.cpp b10682 + tooling). Cross-repo release-hygiene findings in the `workspace` PR of this sweep; `BitcoinAddressFinder` 1.8.0 is prepared in parallel.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_