### PR TITLE
chore(release): move main on to 5.2.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ To use the latest snapshot, add the repository and dependency to your `pom.xml`:
 <dependency>
     <groupId>net.ladenthin</groupId>
     <artifactId>llama</artifactId>
-    <version>5.0.7-SNAPSHOT</version>
+    <version>5.2.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/llama-kotlin/pom.xml
+++ b/llama-kotlin/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.1.0</version>
+		<version>5.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.1.0</version>
+		<version>5.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
 	<parent>
 		<groupId>net.ladenthin</groupId>
 		<artifactId>llama-parent</artifactId>
-		<version>5.1.0</version>
+		<version>5.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -93,7 +93,7 @@ SPDX-License-Identifier: MIT
 		<spotless.version>3.10.1</spotless.version>
 		<palantir-java-format.version>2.97.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.outputTimestamp>2026-08-29T16:06:02Z</project.build.outputTimestamp>
+		<project.build.outputTimestamp>2026-09-01T07:57:45Z</project.build.outputTimestamp>
 	</properties>
 
 	<!--

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
 	-->
 	<groupId>net.ladenthin</groupId>
 	<artifactId>llama-parent</artifactId>
-	<version>5.1.0</version>
+	<version>5.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary

`main` was still carrying **5.1.0**, a version published on Central since 2026-08-29 — verified, not assumed: `llama-parent`, `llama`, `llama-langchain4j` and `llama-kotlin` all return HTTP 200 at 5.1.0. Leaving `main` there is exactly what the forward bump exists to prevent: a snapshot deploy collides with a released coordinate, and anyone building from `main` produces artifacts indistinguishable from the release.

- `mvn versions:set -DnewVersion=5.2.0-SNAPSHOT -DgenerateBackupPoms=false` — the four poms (root, `llama`, `llama-langchain4j`, `llama-kotlin`). `llama-android` needs no edit: its Gradle build parses the version out of the poms at configure time, which is the whole reason it was built that way.
- **One doc change, and it was already stale before this bump.** The "Snapshot builds" section advertised `5.0.7-SNAPSHOT` as the snapshot channel — a version that never shipped, since 5.1.0 superseded it. That line tells a reader where to get the current development build, so it moves to `5.2.0-SNAPSHOT`.

Every other version literal in the docs stays at 5.1.0 on purpose — they are consumer-facing dependency snippets (`README.md`, `llama-langchain4j/README.md`, `llama-android/README.md`, `llama-kotlin/README.md`), and what a consumer should depend on is the release.

## Test plan

- [x] All four poms carry `5.2.0-SNAPSHOT` as project version **and** parent pointer; `git grep "5\.1\.0" -- '*.xml'` returns nothing tracked
- [ ] CI is green on this branch

No native rebuild is involved — this touches poms and one README line.

## Related issues / PRs

Relevant beyond housekeeping: srcmorph's `flashAttn` knob is currently *refused* because `ModelParameters.enableFlashAttn()` cannot express the mandatory `[on|off|auto]` value llama.cpp has required since b10273. The fix is a value-taking `setFlashAttn` here, and **5.2.0 is the version that TODO names** — so this bump puts `main` on the version that work will ship in.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_