### PR TITLE
fix(build): keep the OCP suppression list in step with the renamed setters

### DIFF
--- a/llama/spotbugs-exclude.xml
+++ b/llama/spotbugs-exclude.xml
@@ -59,8 +59,8 @@ SPDX-License-Identifier: MIT
 
     <!--
         ModelParameters intentionally types each enum-valued fluent setter
-        to its specific enum (CacheType, MiroStat, NumaStrategy,
-        ReasoningFormat, RopeScalingType, GpuSplitMode, TensorReadLazyMode)
+        to its specific enum (CacheType, FlashAttn, LazyMode, MiroStat,
+        NumaStrategy, ReasoningFormat, RopeScalingType, GpuSplitMode)
         rather than the shared CliArg interface that those enums all
         implement. The narrow type is the API contract:
 
@@ -80,12 +80,13 @@ SPDX-License-Identifier: MIT
         <Or>
             <Method name="setCacheTypeK"/>
             <Method name="setCacheTypeV"/>
+            <Method name="setFlashAttn"/>
+            <Method name="setLazyMode"/>
             <Method name="setMirostat"/>
             <Method name="setNuma"/>
             <Method name="setReasoningFormat"/>
             <Method name="setRopeScaling"/>
             <Method name="setSplitMode"/>
-            <Method name="setTensorReadLazy"/>
         </Or>
     </Match>
 


### PR DESCRIPTION
## Summary

- **`main` is red.** The Publish run on `2d29615` fails its SpotBugs gate with two `OCP_OVERLY_CONCRETE_PARAMETER` findings, both introduced by #408:
  ```
  setFlashAttn(FlashAttn): 1st parameter 'mode' could be declared as CliArg
  setLazyMode(LazyMode):   1st parameter 'mode' could be declared as CliArg
  ```
- **The finding is right about the mechanics and wrong about the design**, which is why the fix belongs in `spotbugs-exclude.xml` and not in the code. Widening either parameter to `CliArg` is exactly what the comment already sitting above that block forbids: `setFlashAttn(CacheType.Q8_0)` would then compile and emit a nonsense CLI value that the native layer rejects at runtime. The narrow enum type *is* the API contract.
- **The block lists methods by name, so a rename makes it silently wrong.** #408 renamed `setTensorReadLazy` to `setLazyMode`; that entry has matched nothing since, while the new `setLazyMode` and `setFlashAttn` were never covered. Both are added, the dead entry dropped, and the block's own comment updated to name the current enum set.

## Why it reached `main`

`spotbugs:check` binds to `verify`, so neither `mvn test` nor `mvn package` runs it — #408 was validated with both and still shipped this. Worth noting because it is the second time this exact gap has bitten in this line of work (the equivalent miss happened in srcmorph and was diagnosed as a Spotless failure at first). The gate itself did its job; only the local pre-push loop was blind.

## Test plan

- [x] Verified with **the exact command the failing CI job runs**, not an approximation:
      `mvn -B --no-transfer-progress -f llama/pom.xml -DskipTests -Denforcer.skip=true compile spotbugs:check`
      &rarr; `BugInstance size is 0`, `BUILD SUCCESS` (was `Total bugs: 2` before the change)
- [x] Confirmed the dropped entry is genuinely dead: the only remaining occurrence of `setTensorReadLazy` in the tree is a javadoc line documenting the rename
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable — n/a, the suppression comment is the documentation and it is updated here

## Related issues / PRs

Fixes the SpotBugs failure introduced by #408. Unblocks the 5.2.0 snapshot/release, which `bernardladenthin/srcmorph` `main` is currently waiting on (it pins `net.ladenthin:llama:5.2.0`).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_