### PR TITLE
build(deps): bump build plugins and analysis tooling to current

### DIFF
--- a/llama-kotlin/pom.xml
+++ b/llama-kotlin/pom.xml
@@ -64,7 +64,7 @@ SPDX-License-Identifier: MIT
 		<kotlinx.coroutines.version>1.11.0</kotlinx.coroutines.version>
 		<junit.version>6.1.3</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>
-		<surefire.version>3.5.6</surefire.version>
+		<surefire.version>3.6.0</surefire.version>
 		<source.plugin.version>3.4.0</source.plugin.version>
 		<jar.plugin.version>3.5.1</jar.plugin.version>
 	</properties>

--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -62,8 +62,8 @@ SPDX-License-Identifier: MIT
 		<hamcrest.version>3.0</hamcrest.version>
 		<!-- Plugin versions are kept in lockstep with the core pom.xml. This module has no
 		     parent, so it cannot inherit their pluginManagement and must pin them here. -->
-		<compiler.plugin.version>3.15.0</compiler.plugin.version>
-		<surefire.version>3.5.6</surefire.version>
+		<compiler.plugin.version>3.16.0</compiler.plugin.version>
+		<surefire.version>3.6.0</surefire.version>
 		<source.plugin.version>3.4.0</source.plugin.version>
 		<javadoc.plugin.version>3.12.0</javadoc.plugin.version>
 	</properties>

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -56,16 +56,16 @@ SPDX-License-Identifier: MIT
 	<properties>
 		<sonar.organization>bernardladenthin</sonar.organization>
 		<jspecify.version>1.0.1</jspecify.version>
-		<lombok.version>1.18.46</lombok.version>
+		<lombok.version>1.18.48</lombok.version>
 		<errorprone.version>2.50.0</errorprone.version>
-		<nullaway.version>0.14.0</nullaway.version>
+		<nullaway.version>0.14.1</nullaway.version>
 		<!-- Checker Framework: the processor AND the checker-qual qualifiers it resolves.
 		     Both run on the build JDK and neither ships (checker-qual is provided scope), so
 		     this tracks the newest release. -->
-		<checker.version>4.2.2</checker.version>
+		<checker.version>4.2.3</checker.version>
 		<jackson.version>2.22.2</jackson.version>
 		<reactor.version>3.8.7</reactor.version>
-		<slf4j.version>2.0.18</slf4j.version>
+		<slf4j.version>2.0.19</slf4j.version>
 		<logback.version>1.6.3</logback.version>
 		<animal-sniffer.version>1.27</animal-sniffer.version>
 		<junit.version>6.1.3</junit.version>
@@ -90,10 +90,10 @@ SPDX-License-Identifier: MIT
 		     section "jqwik prompt-injection in test output" for full context. -->
 		<jqwik.version>1.9.3</jqwik.version>
 		<archunit.version>1.5.0</archunit.version>
-		<spotbugs.version>4.10.4.0</spotbugs.version>
+		<spotbugs.version>4.10.4.1</spotbugs.version>
 		<fb-contrib.version>7.7.4</fb-contrib.version>
 		<findsecbugs.version>1.14.0</findsecbugs.version>
-		<spotless.version>3.10.1</spotless.version>
+		<spotless.version>3.10.2</spotless.version>
 		<palantir-java-format.version>2.97.0</palantir-java-format.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.outputTimestamp>2026-09-01T07:57:45Z</project.build.outputTimestamp>
@@ -199,7 +199,7 @@ SPDX-License-Identifier: MIT
 		     org.checkerframework.framework.qual.DoesNotUnrefineReceiver". Processor and
 		     qualifiers must share a major version.
 
-		     provided scope resolves both constraints at once: 4.2.2 is on the compile
+		     provided scope resolves both constraints at once: 4.2.3 is on the compile
 		     classpath where the checker needs it, and provided is excluded from consumers'
 		     transitive graph AND from the fat jar (jar-with-dependencies takes scope
 		     runtime), so no checker-qual class of any version reaches a consumer's JVM.
@@ -349,7 +349,7 @@ SPDX-License-Identifier: MIT
 				<plugin>
 					<groupId>io.github.git-commit-id</groupId>
 					<artifactId>git-commit-id-maven-plugin</artifactId>
-					<version>10.0.0</version>
+					<version>10.0.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -359,7 +359,7 @@ SPDX-License-Identifier: MIT
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.15.0</version>
+					<version>3.16.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -389,7 +389,7 @@ SPDX-License-Identifier: MIT
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.5.6</version>
+					<version>3.6.0</version>
 					<configuration>
 						<!--
 							Tests in the `vmlens` package are meaningful only when run


### PR DESCRIPTION
## Summary

Pure version maintenance, no behaviour change in the library. One of four coordinated PRs (jllama / srcmorph / BAF / streambuffer).

**Cross-repo drift, closed.** The four sibling repos deliberately run the same toolchain versions; BitcoinAddressFinder pulled ahead when its Dependabot PRs were merged.

| | before | after |
|---|---|---|
| `maven-compiler-plugin` | 3.15.0 | **3.16.0** |
| `maven-surefire-plugin` | 3.5.6 | **3.6.0** |
| `nullaway` | 0.14.0 | **0.14.1** |

**Behind current upstream in all four repos.**

| | before | after |
|---|---|---|
| `git-commit-id-maven-plugin` | 10.0.0 | **10.0.1** |
| `spotless-maven-plugin` | 3.10.1 | **3.10.2** |
| `spotbugs-maven-plugin` | 4.10.4.0 | **4.10.4.1** |
| `checker` / `checker-qual` | 4.2.2 | **4.2.3** |
| `lombok` | 1.18.46 | **1.18.48** |
| `slf4j-api` / `slf4j-simple` | 2.0.18 | **2.0.19** |

The compiler and surefire versions also live under **different property names** in `llama-langchain4j` (`compiler.plugin.version`, `surefire.version`) and `llama-kotlin` (`surefire.version`) — a name-based scan misses those. They are bumped too, so the reactor is internally consistent rather than only the core module.

The **checker bump moves one property that feeds both the annotation processor and the qualifiers**, and that coupling is the point: the Nullness Checker resolves its own qualifiers through javac's symbol table, so the two must share a major version. That is the lesson from the 3.55.1 pin reverted in #412; the prose in the `checker-qual` comment is updated to match.

**Deliberately NOT bumped: `jqwik` stays at 1.9.3.** Releases from 1.10.0 on print a prompt-injection string aimed at AI coding agents, and the [workspace policy](https://github.com/bernardladenthin/workspace/blob/main/policies/jqwik-prompt-injection.md) requires rejecting any PR that moves it. Dependabot will keep proposing it.

### A worthwhile side effect of surefire 3.6.0

Verified by diffing the per-class reports before and after: a class whose `@BeforeAll` assumption aborts the whole class is now reported as **SKIPPED** instead of `tests=0, skipped=0`. That is exactly the blind spot `CLAUDE.md` documents under "CI model policy" — the shape that let every model-gated class silently contribute nothing while the job stayed green. Locally, model-free, it turns **25 classes and 256 tests** from invisible into visibly skipped (1486/17 → 1742/273). CI has the models, so those classes still run there; what changes is that a run which *fails* to provide them can no longer look like a full pass.

## Test plan

- [x] `mvn clean verify` green
- [x] `ctest` **520/520**
- [x] PIT **319/319 mutations killed (100%)**
- [x] Class-file gate clean over `llama/target`, including a real `-P assembly` fat jar: **1904 classes, 0 above major 52**
- [x] `slf4j-simple 2.0.19` checked **entry by entry**, not in aggregate: its only major-53 entry is `META-INF/versions/9/module-info.class`, which a classpath JVM never loads and the gate skips by design — identical to 2.0.18. The fat jar carries the 7 slf4j-simple entries and **0** checkerframework classes, as intended.
- [ ] CI is green on this branch — **macOS 15 is expected to stay red** for the unrelated b10797 regression tracked in #414/#415
- [x] No source or test change; poms only

## Related PRs

Same change in [srcmorph](https://github.com/bernardladenthin/srcmorph/pull/205), [streambuffer](https://github.com/bernardladenthin/streambuffer/pull/155) and BitcoinAddressFinder (category 2 only — BAF already carries category 1).

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_