### PR TITLE
build(deps): langchain4j 1.20.0, and correct the log4j pin's rationale

### DIFF
--- a/llama-langchain4j/pom.xml
+++ b/llama-langchain4j/pom.xml
@@ -57,7 +57,7 @@ SPDX-License-Identifier: MIT
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- langchain4j 1.x requires Java 17; the core net.ladenthin:llama stays Java 8. -->
 		<maven.compiler.release>17</maven.compiler.release>
-		<langchain4j.version>1.19.0</langchain4j.version>
+		<langchain4j.version>1.20.0</langchain4j.version>
 		<junit.version>6.1.3</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>
 		<!-- Plugin versions are kept in lockstep with the core pom.xml. This module has no

--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -74,11 +74,18 @@ SPDX-License-Identifier: MIT
 		<jcstress.version>0.16</jcstress.version>
 		<lincheck.version>3.7</lincheck.version>
 		<logcaptor.version>2.12.7</logcaptor.version>
-		<!-- log4j-api / log4j-to-slf4j arrive ONLY as test-scope transitives of
-		     io.github.hakky54:logcaptor, which requests 2.25.3. That version is affected by
-		     CVE-2026-49844 (GHSA-qv9r-c865-cp47, moderate): MapMessage.asJson() emits bare
-		     NaN/Infinity tokens for non-finite floats, producing non-RFC-8259 JSON. Pinned to the
-		     newest patched stable so the alert clears; see the dependencyManagement entries. -->
+		<!-- FLOOR GUARD, no longer an active fix. log4j-api / log4j-to-slf4j arrive ONLY as
+		     test-scope transitives of io.github.hakky54:logcaptor. When this pin was added,
+		     logcaptor 2.12.6 requested log4j 2.25.3, affected by CVE-2026-49844
+		     (GHSA-qv9r-c865-cp47, moderate): MapMessage.asJson() emits bare NaN/Infinity
+		     tokens for non-finite floats, producing non-RFC-8259 JSON.
+		     logcaptor 2.12.7 declares <version.log4j>2.26.1</version.log4j> itself, i.e.
+		     exactly what this pin forces, so today it changes nothing about the resolved
+		     graph. It is kept as a lower bound: if logcaptor ever falls back to an affected
+		     line, the pin holds the version here instead of letting it regress silently.
+		     Unrelated to the Java 8 class-file floor, which is a different change entirely
+		     (slf4j-simple instead of logback, checker-qual at provided scope). Neither log4j
+		     artifact reaches a published artifact at all; both are test scope. -->
 		<log4j.version>2.26.1</log4j.version>
 		<vmlens.version>1.2.28</vmlens.version>
 		<!-- DO NOT UPGRADE jqwik past 1.9.3. jqwik 1.10.0 added a deliberate
@@ -133,10 +140,11 @@ SPDX-License-Identifier: MIT
 				<artifactId>logback-classic</artifactId>
 				<version>${logback.version}</version>
 			</dependency>
-			<!-- log4j-api + log4j-to-slf4j: io.github.hakky54:logcaptor (test scope) brings 2.25.3,
-			     which is affected by CVE-2026-49844; we declare ${log4j.version} directly. Both are
-			     pinned together because log4j-to-slf4j depends on log4j-api of the same version and
-			     the two must not skew. Test-scope only — neither reaches a published artifact. -->
+			<!-- log4j-api + log4j-to-slf4j, pinned as a lower bound rather than as a fix: the
+			     logcaptor version in use already requests ${log4j.version} itself. Rationale and
+			     the CVE history are on the property declaration above. Both are pinned together
+			     because log4j-to-slf4j depends on log4j-api of the same version and the two must
+			     not skew. Test-scope only — neither reaches a published artifact. -->
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-api</artifactId>


### PR DESCRIPTION
## Summary

Two independent maintenance items, one commit each.

**1. The log4j pin is a floor guard now, not an active CVE fix (comment text only).**
Both comments in `llama/pom.xml` still said logcaptor *"brings 2.25.3, which is affected by CVE-2026-49844"*. That stopped being true when this repo moved to **logcaptor 2.12.7**, whose own pom declares `<version.log4j>2.26.1</version.log4j>` — exactly what the pin forces. The `dependencyManagement` entries therefore change nothing about the resolved graph today.

The pin is **kept deliberately**, as a lower bound: a logcaptor release that fell back to an affected line could not regress the test classpath silently. But a comment describing it as *the fix* sends the next reader looking for a vulnerability that is no longer reachable.

The comment also now states what the pin is **not** related to, because the two changes landed in the same week and were conflated once already: this has nothing to do with the **Java 8 class-file floor**. That one is `slf4j-simple` instead of logback plus `checker-qual` at `provided` scope, and it concerns the *shipped* artifact — both log4j artifacts are test scope and reach no published artifact at all.

No version, scope or dependency changed. Kept byte-parallel with the same rewrite in BitcoinAddressFinder, which carries the identical pin.

**2. langchain4j 1.19.0 → 1.20.0.**
The only dependency across the four sibling repos genuinely behind a stable upstream. Confined to `llama-langchain4j`, which is `maven.compiler.release 17` because langchain4j 1.x requires Java 17; the core `net.ladenthin:llama` stays Java 8 and that split is untouched. Nothing about the old pin was deliberate — no rationale comment, not in the do-not-bump registry. It was a lag.

## Test plan

- [x] Affected unit / integration tests pass locally

  ```
  mvn -pl llama -am -DskipTests install    -> BUILD SUCCESS
  mvn -f llama-langchain4j/pom.xml verify  -> BUILD SUCCESS
      Tests run: 49, Failures: 0, Errors: 0, Skipped: 7
  ```

  Verified rather than assumed, because a langchain4j minor can move interface shapes and this module implements four of them. The module imports **44 types** across `agent.tool`, `data.message`, `model.chat.request(.json)`, `model.chat.response` and `model.output`; all still resolve, and the adapters compile unchanged against `ChatModel`, `StreamingChatModel`, `EmbeddingModel` and `ScoringModel`. The 7 skips are the model-gated integration tests (they self-skip without a GGUF); the 42 that ran are the mapping, schema-serializer and streaming-assembler suites — exactly the code touching the langchain4j API surface.

  `verify` rather than `test` on purpose: it also builds the javadoc jar, so a javadoc break from a changed signature fails now instead of at release time.

- [x] `xml.etree` parses both poms; no `--` inside any XML comment
- [ ] CI is green on this branch
- [x] Docs / CHANGELOG updated where applicable — comment-only change plus a dependency bump with no behaviour change; the cross-repo record lives in `workspace/crossrepostatus.md`

## Related issues / PRs

Pairs with the identical comment rewrite in BitcoinAddressFinder and with the registry-row decision in `bernardladenthin/workspace#39`.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] My commits follow Conventional Commits
- [x] No security-sensitive changes — the pin that *was* security-relevant is retained unchanged; only its comment is corrected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_