### PR TITLE
build(deps): Kotlin 2.4.20 and dependency-submission action v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3356,7 +3356,7 @@ jobs:
       - uses: actions/download-artifact@v8
         with: { name: jacoco-report, path: target/site/jacoco/ }
         continue-on-error: true
-      - uses: advanced-security/maven-dependency-submission-action@v5
+      - uses: advanced-security/maven-dependency-submission-action@v6
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/llama-kotlin/pom.xml
+++ b/llama-kotlin/pom.xml
@@ -60,7 +60,7 @@ SPDX-License-Identifier: MIT
 		<!-- Kotlin consumers can read metadata at most one minor version ahead of
 		     their own compiler, so compiling with Kotlin 2.4 keeps this artifact
 		     consumable from Kotlin 2.3+ projects (typical Android Studio installs). -->
-		<kotlin.version>2.4.10</kotlin.version>
+		<kotlin.version>2.4.20</kotlin.version>
 		<kotlinx.coroutines.version>1.11.0</kotlinx.coroutines.version>
 		<junit.version>6.1.3</junit.version>
 		<hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
Two independent version bumps from a cross-repo sweep on 2026-09-09, both to the newest **stable**.

## Kotlin 2.4.10 → 2.4.20 (`llama-kotlin/pom.xml`)

`workspace/crossrepostatus.md` rejected this one with *"newer is an RC only"*. That was true when it was written — but Central now carries the plain `2.4.20` release after `-Beta1`, `-Beta2`, `-RC`, `-RC2` and `-RC3`, so the rationale **expired** rather than being overruled. One `<kotlin.version>` property moves; it drives both `kotlin-stdlib` and `kotlin-maven-plugin`.

**Deliberately not touched:** `android-llmservice/settings.gradle.kts` keeps the Compose compiler plugin at `2.4.10`. That is a different pin against a different Kotlin — AGP 9.x supplies its own built-in Kotlin (2.2.10+) for that Gradle build, which never reads `llama-kotlin`'s property — so the two are not required to move together, and bumping it would be an untested AGP/Compose change riding along with a library bump.

## `advanced-security/maven-dependency-submission-action` v5 → v6

Closing cross-repo drift, not chasing a release. Dependabot opened this bump in **streambuffer only** (bernardladenthin/streambuffer#156, merged), leaving the other three sibling repos on v5 until their own staggered weekly run. `v6.0.0` moves the action runtime from Node 20 to Node 24.

It was **not** adopted on faith: streambuffer's `Report` job — the job that actually runs the action, with no `continue-on-error` on that step — went green on it first. Companion PRs bring BAF and srcmorph up in the same sweep.

## Verification

```
mvn -pl llama-kotlin -am -DskipTests install     # BUILD SUCCESS
mvn -pl llama-kotlin test                        # Tests run: 6, Failures: 0, Errors: 0
```

and the compiler that actually ran was confirmed rather than assumed — the build log shows `--- kotlin:2.4.20:compile (compile) @ llama-kotlin ---`, so this is not a silent fallback to the previously resolved version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_