### PR TITLE
ci: never let the dependency-submission step withhold the GitHub assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3356,7 +3356,11 @@ jobs:
       - uses: actions/download-artifact@v8
         with: { name: jacoco-report, path: target/site/jacoco/ }
         continue-on-error: true
+      # Submits the dependency graph to GitHub. Informational: it says nothing about whether the
+      # artifacts are correct, but it sits in the `report` job, which the release path needs -- so
+      # without this flag a third-party action having a bad day can block a publish.
       - uses: advanced-security/maven-dependency-submission-action@v6
+        continue-on-error: true
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:


### PR DESCRIPTION
One line plus its rationale comment, closing a cross-repo parity gap — but the gap is not cosmetic, and it defeats a guarantee this pipeline was deliberately built to provide.

## The guarantee

`github-snapshot` / `github-release-signed` run even when the Central publish **fails**:

```yaml
if: ${{ !cancelled() && (needs.publish-snapshot.result == 'success' || needs.publish-snapshot.result == 'failure') && ... }}
# Also runs when publish-snapshot FAILED (not when skipped/cancelled): a Central
# publish-poll timeout reds that job after the artifacts were already uploaded —
# the GitHub pre-release assets must not be lost in that case.
```

Note the precise shape: it tolerates **`failure`**, not **`skipped`**.

## The hole

The dependency-submission step sits in the `report` job **unguarded**, and `report` gates the entire chain:

```
report FAILS  (third-party informational action)
  └─> check-snapshot        SKIPPED   ← failed need; its if: is a plain event/ref
                                        condition, no always()/!cancelled() escape
       └─> publish-snapshot SKIPPED   ← if: check-snapshot.result == 'success'
            └─> github-snapshot       if: publish-snapshot ∈ {success, failure}
                                      'skipped' matches NEITHER → does not run
```

So the action having a bad day doesn't merely delay a Central publish — it **silently loses the GitHub assets**, which is exactly the outcome the `if:` above exists to prevent. The action submits the dependency graph to GitHub; it says nothing about whether the artifacts are correct, so it has no business gating anything.

## Why it was missing here and not in srcmorph

srcmorph got this guard **in passing**, from `ee2ae49` *"ci: report unsigned assets without ever withholding them"*. That commit's actual feature was the unsigned-asset reporting, which **was** ported here — as `90dd21a`, a single clean `68 insertions(+)` change that reproduced the *feature* and did not touch the submission step. The drive-by line never travelled. So this is not a regression and not a design divergence; it is a port that copied the intent and missed an unrelated hardening bundled into the same upstream commit.

## Scope — what deliberately stays bare

The convention being restored is narrow: *informational third-party steps do not block*. Within `report`, the submission action was the only step violating it —

| step | before |
|---|---|
| `actions/download-artifact` | guarded |
| **`maven-dependency-submission-action`** | **bare** |
| Coveralls | guarded |
| Codecov | guarded |

`checkout` and `setup-java` stay bare because they are infrastructure, not reports.

## Verification

All four `publish.yml` files still parse; `report` still contains exactly one submission step; and the 5-line block (comment + `uses:` + flag) now hashes **identically in all four repos** — `5cbdaf64e4f4f303`.

Companion PRs do the same in BitcoinAddressFinder and streambuffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNYn8W1xuVxVJtyL34GyH)_